### PR TITLE
security: harden reverse proxy trust boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ JWT_SECRET=change-me-generate-with-openssl-rand-hex-32
 # Use .lionsquad.at so login cookies work on both lionsquad.at and www.lionsquad.at.
 AUTH_COOKIE_DOMAIN=.lionsquad.at
 TRUST_PROXY_HEADERS=true
+# Only these direct proxy sources may influence client IP/scheme. Narrow the
+# Docker range to the actual proxy/network shown by `docker network inspect`.
+TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128,172.16.0.0/12
+# Optional extra Host header names. FRONTEND_URL/CORS_ORIGINS are included automatically.
+TRUSTED_HOSTS=
 ADMIN_EMAIL=admin@lionsquad.at
 # First-install only. install.sh removes this after the one-time admin bootstrap.
 ADMIN_PASSWORD=change-me-to-a-long-random-password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
+      - name: Validate reverse-proxy deployment config
+        env:
+          CORS_ORIGINS: https://example.test
+          FRONTEND_URL: https://example.test
+          JWT_SECRET: ci-only-secret-value-with-at-least-32-characters
+          PUBLIC_BACKEND_URL: https://example.test
+        run: |
+          docker compose config -q
+          docker run --rm \
+            --add-host backend:127.0.0.1 \
+            --volume "$PWD/frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+            nginx:alpine nginx -t
       - uses: actions/setup-node@v6
         with:
           node-version: "20"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,9 +57,23 @@ Create two proxy hosts:
 2. `lionsquad.at/api/*` -> backend container / host port `8001`
 
 Enable HTTPS (Let's Encrypt) inside NPM.
+Enable HTTP-to-HTTPS redirection and preserve the public `Host`. NPM must set
+`X-Forwarded-For` and `X-Forwarded-Proto`; the application accepts these headers
+only from the IP networks configured in `TRUSTED_PROXY_CIDRS`.
 Set the proxy body size to at least 1700 MB when direct gallery video uploads are enabled,
 otherwise image/document/video uploads can fail with
 `413 Request Entity Too Large` before the app receives the request.
+
+For a proxy installed directly on the host, Loopback is sufficient:
+
+```env
+TRUST_PROXY_HEADERS=true
+TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
+```
+
+For a Docker-based proxy or when all traffic first reaches the frontend container,
+add and then narrow the corresponding Docker network shown by
+`docker network inspect`. Never configure `*`, `0.0.0.0/0`, or `::/0`.
 
 ## 5. First admin and login
 

--- a/README.md
+++ b/README.md
@@ -214,13 +214,21 @@ Vor Livegang oder nach groesseren Updates:
 
 ## Reverse Proxy
 
-Empfohlene Variante:
+TLS endet am aeusseren Reverse Proxy. Dieser muss `Host`, `X-Forwarded-For` und
+`X-Forwarded-Proto` sauber setzen. Zwei Topologien werden unterstuetzt:
 
-- `https://lionsquad.at` zeigt auf den Frontend-Container.
-- `/api/*` wird an den Backend-Container weitergeleitet.
+- `https://lionsquad.at` zeigt auf den Frontend-Container und `/api/*` direkt auf
+  den Backend-Container; oder
+- der gesamte Traffic geht zum Frontend-Container, dessen internes Nginx `/api/*`
+  an das Backend weiterleitet.
+
+In beiden Faellen:
+
 - Websocket-Sonderregeln sind aktuell nicht erforderlich.
 - HTTPS per Let's Encrypt aktivieren.
 - HTTP auf HTTPS weiterleiten.
+- Eingehende `X-Forwarded-*`-Header am aeusseren Proxy ersetzen bzw. korrekt
+  erweitern; niemals ungeprueft vom Internet uebernehmen.
 
 Wenn Nginx Proxy Manager auf dem Docker-Host laeuft:
 
@@ -240,7 +248,34 @@ Empfohlen fuer reine Reverse-Proxy-Setups auf demselben Host:
 FRONTEND_BIND=127.0.0.1
 BACKEND_BIND=127.0.0.1
 TRUST_PROXY_HEADERS=true
+TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
 ```
+
+`TRUSTED_PROXY_CIDRS` enthaelt ausschliesslich die direkten Proxy-Quellen. Laeuft
+der Proxy oder der interne Frontend-Nginx in Docker, muessen deren tatsaechliche
+IP-Netze ergaenzt werden. Das Netz laesst sich mit `docker network inspect`
+ermitteln. Bei der Topologie "alles zum Frontend" muessen sowohl das App-Netz des
+Frontend-Nginx als auch die Quelle des aeusseren Proxys vertrauenswuerdig sein,
+damit Uvicorn die Weiterleitungskette von rechts sicher aufloesen kann.
+
+Die Compose-Vorgabe akzeptiert fuer bestehende Docker-Installationen zunaechst
+Loopback und `172.16.0.0/12`. Fuer Produktion sollte dieser Docker-Bereich auf das
+konkret verwendete Proxy-/App-Netz verkleinert werden. `*`, `0.0.0.0/0` und
+`::/0` werden bewusst abgelehnt. Zusaetzliche legitime Hostnamen koennen ueber
+`TRUSTED_HOSTS` angegeben werden; `FRONTEND_URL` und `CORS_ORIGINS` werden
+automatisch uebernommen.
+
+Nach einer Aenderung pruefen:
+
+```bash
+docker compose config
+docker compose up -d --build
+curl -I https://lionsquad.at/api/health
+```
+
+Die API-Antwort muss ueber die oeffentliche URL erreichbar sein. Login, Logout,
+ein Upload und ein absichtlich wiederholter Request bis zur `429`-Antwort pruefen
+zusaetzlich Cookies, Client-IP und Rate-Limit hinter dem Proxy.
 
 ## Analytics
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,12 @@
 - Client error telemetry is disabled by default (`CLIENT_LOGGING_ENABLED=false`). If enabled
   deliberately, query strings, tokens, email addresses, and local paths are redacted and
   client-side deduplication/rate limits apply.
+- Published container ports bind to Loopback by default for operation behind a reverse proxy.
+- Forwarded client IP and HTTPS information is accepted only from `TRUSTED_PROXY_CIDRS`;
+  wildcard/default-route trust is rejected. Rate limits and session audit records use the
+  client address already validated by Uvicorn, never raw forwarding headers.
+- Public Host headers are restricted to `FRONTEND_URL`, `CORS_ORIGINS`, optional
+  `TRUSTED_HOSTS`, and the internal health-check names.
 
 ## First administrator
 

--- a/backend/docker-entrypoint.py
+++ b/backend/docker-entrypoint.py
@@ -5,6 +5,8 @@ import pathlib
 import pwd
 import stat
 
+from runtime_config import env_flag, trusted_proxy_cidrs
+
 
 APP_USER = os.environ.get("APP_USER", "appuser")
 UPLOAD_DIR = pathlib.Path(os.environ.get("UPLOAD_DIR", "/app/backend/uploads"))
@@ -77,6 +79,20 @@ def assert_upload_writable() -> None:
             raise RuntimeError(f"Upload path is not writable: {directory} ({exc})") from exc
 
 
+def build_uvicorn_args() -> list[str]:
+    port = os.environ.get("PORT", "8001")
+    args = ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", port]
+    if env_flag("TRUST_PROXY_HEADERS"):
+        args.extend([
+            "--proxy-headers",
+            "--forwarded-allow-ips",
+            ",".join(trusted_proxy_cidrs()),
+        ])
+    else:
+        args.append("--no-proxy-headers")
+    return args
+
+
 def main() -> None:
     try:
         user = pwd.getpwnam(APP_USER)
@@ -91,8 +107,7 @@ def main() -> None:
     assert_upload_writable()
     _log("upload volume writable; starting backend")
 
-    port = os.environ.get("PORT", "8001")
-    os.execvp("uvicorn", ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", port])
+    os.execvp("uvicorn", build_uvicorn_args())
 
 
 if __name__ == "__main__":

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -111,8 +111,7 @@ async def _issue_mobile_session(db, user: dict, request: Request) -> tuple[str, 
         "created_at": now_utc(),
         "expires_at": refresh_expires_at(),
         "user_agent": request.headers.get("user-agent"),
-        "ip": request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-              or (request.client.host if request.client else None),
+        "ip": get_client_ip(request),
         "client": "mobile",
     })
     return access, refresh

--- a/backend/routes/seo_render_routes.py
+++ b/backend/routes/seo_render_routes.py
@@ -734,9 +734,7 @@ def public_origin(request: Request, branding: dict) -> str:
     configured = (branding.get("domain") or os.environ.get("PUBLIC_URL") or os.environ.get("FRONTEND_URL") or "").strip().rstrip("/")
     if configured:
         return configured if configured.startswith(("http://", "https://")) else f"https://{configured}"
-    proto = request.headers.get("x-forwarded-proto") or request.url.scheme
-    host = request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc
-    return f"{proto}://{host}".rstrip("/")
+    return str(request.base_url).rstrip("/")
 
 
 def absolute_url(value: str | None, origin: str) -> str:

--- a/backend/runtime_config.py
+++ b/backend/runtime_config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from ipaddress import ip_network
+from urllib.parse import urlparse
 
 
 ENV_ALIASES = {
@@ -21,6 +23,7 @@ PLACEHOLDER_SECRET_MARKERS = {
     "replace-me",
 }
 TRUE_VALUES = {"1", "true", "yes", "on"}
+LOCAL_HTTP_HOSTS = ("localhost", "127.0.0.1", "[::1]", "backend")
 
 
 def env_flag(name: str, environ: Mapping[str, str] | None = None) -> bool:
@@ -47,6 +50,67 @@ def is_placeholder_secret(value: str) -> bool:
     return not normalized or any(marker in normalized for marker in PLACEHOLDER_SECRET_MARKERS)
 
 
+def trusted_proxy_cidrs(environ: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Return validated proxy IPs/networks accepted by Uvicorn."""
+    source = environ if environ is not None else os.environ
+    if not env_flag("TRUST_PROXY_HEADERS", source):
+        return ()
+
+    raw_values = str(source.get("TRUSTED_PROXY_CIDRS", "")).split(",")
+    values: list[str] = []
+    for raw in raw_values:
+        value = raw.strip()
+        if not value:
+            continue
+        if value == "*":
+            raise RuntimeError("TRUSTED_PROXY_CIDRS must never trust every source.")
+        try:
+            network = ip_network(value, strict=False)
+        except ValueError as exc:
+            raise RuntimeError(f"Invalid trusted proxy IP/network: {value!r}.") from exc
+        if network.prefixlen == 0:
+            raise RuntimeError("TRUSTED_PROXY_CIDRS must never include a default route.")
+        normalized = str(network)
+        if normalized not in values:
+            values.append(normalized)
+    if not values:
+        raise RuntimeError(
+            "TRUST_PROXY_HEADERS=true requires explicit TRUSTED_PROXY_CIDRS."
+        )
+    return tuple(values)
+
+
+def trusted_http_hosts(environ: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Build the public/internal Host allowlist without accepting wildcards in production."""
+    source = environ if environ is not None else os.environ
+    app_env = resolve_app_environment(source)
+    configured = [
+        value.strip().lower().rstrip(".")
+        for value in str(source.get("TRUSTED_HOSTS", "")).split(",")
+        if value.strip()
+    ]
+    if "*" in configured and app_env == "production":
+        raise RuntimeError("TRUSTED_HOSTS='*' is not allowed in production.")
+
+    hosts = list(configured)
+    for raw_url in (
+        str(source.get("FRONTEND_URL", "")),
+        *str(source.get("CORS_ORIGINS", "")).split(","),
+    ):
+        value = raw_url.strip()
+        if not value or value == "*":
+            continue
+        parsed = urlparse(value if "://" in value else f"https://{value}")
+        host = (parsed.hostname or "").lower().rstrip(".")
+        if host and host not in hosts:
+            hosts.append(host)
+
+    for host in LOCAL_HTTP_HOSTS:
+        if host not in hosts:
+            hosts.append(host)
+    return tuple(hosts)
+
+
 def validate_runtime_environment(environ: Mapping[str, str] | None = None) -> str:
     source = environ if environ is not None else os.environ
     app_env = resolve_app_environment(source)
@@ -55,6 +119,9 @@ def validate_runtime_environment(environ: Mapping[str, str] | None = None) -> st
         raise RuntimeError(
             "TLS_RESET is not supported by the API process. Use reset_data.py in an explicit non-production environment."
         )
+
+    trusted_proxy_cidrs(source)
+    trusted_http_hosts(source)
 
     if app_env != "production":
         return app_env

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, FileResponse, StreamingResponse
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 from contextlib import asynccontextmanager
 
 from database import get_db, init_indexes, close_client
@@ -56,7 +57,11 @@ from routes.extras_routes import (
     settings_router, season_router, widget_router, dsgvo_router, pdf_router, audit_router,
 )
 from services.change_events import change_event_stream, publish_api_change
-from runtime_config import resolve_app_environment, validate_runtime_environment
+from runtime_config import (
+    resolve_app_environment,
+    trusted_http_hosts,
+    validate_runtime_environment,
+)
 from storage import PUBLIC_UPLOAD_DIR, UPLOAD_DIR, ensure_storage_directories
 
 
@@ -108,6 +113,11 @@ app = FastAPI(
     docs_url=None if is_production else "/docs",
     redoc_url=None if is_production else "/redoc",
     openapi_url=None if is_production else "/openapi.json",
+)
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=list(trusted_http_hosts()),
+    www_redirect=False,
 )
 
 # CORS: credentials require explicit trusted origins. Open wildcard CORS can be
@@ -311,8 +321,7 @@ async def security_headers(request, call_next):
     response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
-    forwarded_proto = request.headers.get("x-forwarded-proto", "")
-    if request.url.scheme == "https" or forwarded_proto == "https":
+    if request.url.scheme == "https":
         response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     if request.url.path.startswith("/api/"):
         response.headers["Cache-Control"] = "no-store"

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -1,5 +1,4 @@
 """Small Mongo-backed rate limits for public or abuse-prone endpoints."""
-import os
 from datetime import datetime, timezone, timedelta
 
 from fastapi import HTTPException, Request
@@ -18,25 +17,8 @@ def _format_wait(seconds: int) -> str:
     return f"{minutes} Minuten {rest} Sekunden"
 
 
-def _truthy_env(name: str, default: str = "false") -> bool:
-    return os.environ.get(name, default).strip().lower() in {"1", "true", "yes", "on"}
-
-
 def get_client_ip(request: Request) -> str:
-    """Return the best client IP known to the app.
-
-    The production compose setup binds backend ports to localhost and routes API
-    traffic through nginx, so trusting proxy headers is appropriate there. If the
-    backend is ever exposed directly, set TRUST_PROXY_HEADERS=false.
-    """
-    if _truthy_env("TRUST_PROXY_HEADERS", "true"):
-        xff = request.headers.get("x-forwarded-for", "")
-        first = xff.split(",", 1)[0].strip() if xff else ""
-        if first:
-            return first[:120]
-        real_ip = request.headers.get("x-real-ip", "").strip()
-        if real_ip:
-            return real_ip[:120]
+    """Return Uvicorn's validated peer/client IP, never raw forwarding headers."""
     return (request.client.host if request.client else "unknown")[:120]
 
 

--- a/backend/services/scheduler.py
+++ b/backend/services/scheduler.py
@@ -96,7 +96,7 @@ async def _safe_birthday_greetings():
         from services.birthday_mailer import queue_birthday_greetings
         res = await queue_birthday_greetings()
         if res.get("queued") or res.get("deduped"):
-            logger.info("[scheduler] birthday_greetings queued=%s deduped=%s", res.get("queued") or 0, res.get("deduped") or 0)
+            logger.info("[scheduler] birthday_greetings completed")
     except Exception as exc:
         _log_task_failure("birthday_greetings", exc)
 

--- a/backend/tests/test_runtime_security_unit.py
+++ b/backend/tests/test_runtime_security_unit.py
@@ -3,9 +3,17 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 import seed
-from runtime_config import resolve_app_environment, validate_runtime_environment
+from runtime_config import (
+    resolve_app_environment,
+    trusted_http_hosts,
+    trusted_proxy_cidrs,
+    validate_runtime_environment,
+)
 
 
 def test_app_environment_must_be_explicit():
@@ -33,6 +41,57 @@ def test_production_rejects_demo_and_reset_flags():
 def test_development_still_rejects_api_reset_flag():
     with pytest.raises(RuntimeError, match="not supported by the API process"):
         validate_runtime_environment({"APP_ENV": "development", "TLS_RESET": "true"})
+
+
+def test_proxy_headers_require_explicit_narrow_trust_boundary():
+    with pytest.raises(RuntimeError, match="requires explicit"):
+        trusted_proxy_cidrs({"TRUST_PROXY_HEADERS": "true"})
+    with pytest.raises(RuntimeError, match="never trust every source"):
+        trusted_proxy_cidrs({"TRUST_PROXY_HEADERS": "true", "TRUSTED_PROXY_CIDRS": "*"})
+    with pytest.raises(RuntimeError, match="default route"):
+        trusted_proxy_cidrs({"TRUST_PROXY_HEADERS": "true", "TRUSTED_PROXY_CIDRS": "0.0.0.0/0"})
+
+    assert trusted_proxy_cidrs({
+        "TRUST_PROXY_HEADERS": "true",
+        "TRUSTED_PROXY_CIDRS": "127.0.0.1, 172.20.0.0/24,127.0.0.1/32",
+    }) == ("127.0.0.1/32", "172.20.0.0/24")
+
+
+def test_trusted_hosts_derive_from_public_urls_and_reject_production_wildcard():
+    environment = {
+        "APP_ENV": "production",
+        "FRONTEND_URL": "https://lionsquad.at",
+        "CORS_ORIGINS": "https://www.lionsquad.at,https://app.example.test",
+    }
+    hosts = trusted_http_hosts(environment)
+    assert "lionsquad.at" in hosts
+    assert "www.lionsquad.at" in hosts
+    assert "app.example.test" in hosts
+    assert "localhost" in hosts
+
+    with pytest.raises(RuntimeError, match="not allowed in production"):
+        trusted_http_hosts({**environment, "TRUSTED_HOSTS": "*"})
+
+
+def test_trusted_host_middleware_rejects_injected_public_host():
+    environment = {
+        "APP_ENV": "production",
+        "FRONTEND_URL": "https://lionsquad.at",
+    }
+    app = FastAPI()
+    app.add_middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=list(trusted_http_hosts(environment)),
+        www_redirect=False,
+    )
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    assert client.get("/health", headers={"host": "lionsquad.at"}).status_code == 200
+    assert client.get("/health", headers={"host": "attacker.example"}).status_code == 400
 
 
 def test_admin_bootstrap_never_changes_existing_superadmin(monkeypatch):

--- a/backend/tests/test_security_hardening_unit.py
+++ b/backend/tests/test_security_hardening_unit.py
@@ -1,4 +1,5 @@
-"""Focused regressions for Package 2 security hardening."""
+"""Focused regressions for repository security-hardening packages."""
+import asyncio
 import logging
 from pathlib import Path
 import runpy
@@ -6,6 +7,7 @@ import sys
 import types
 
 import pytest
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 
 def test_scheduler_failure_log_excludes_exception_payload(caplog):
@@ -44,3 +46,77 @@ def test_entrypoint_uses_owner_only_upload_permissions(monkeypatch):
 
     assert entrypoint["DIRECTORY_MODE"] == 0o700
     assert entrypoint["FILE_MODE"] == 0o600
+
+
+def test_entrypoint_limits_forwarded_headers_to_configured_proxy_networks(monkeypatch):
+    fake_pwd = types.SimpleNamespace(struct_passwd=object)
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+    monkeypatch.setenv("TRUST_PROXY_HEADERS", "true")
+    monkeypatch.setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32,172.20.0.0/24")
+    entrypoint = runpy.run_path(str(Path(__file__).resolve().parents[1] / "docker-entrypoint.py"))
+
+    args = entrypoint["build_uvicorn_args"]()
+    assert "--proxy-headers" in args
+    assert args[args.index("--forwarded-allow-ips") + 1] == "127.0.0.1/32,172.20.0.0/24"
+
+
+def test_rate_limit_identity_ignores_unvalidated_forwarding_headers():
+    from services.rate_limit import get_client_ip
+
+    request = types.SimpleNamespace(
+        headers={"x-forwarded-for": "198.51.100.99", "x-real-ip": "198.51.100.98"},
+        client=types.SimpleNamespace(host="203.0.113.7"),
+    )
+
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def _proxy_scope(client: str, forwarded_for: str, forwarded_proto: str = "https") -> dict:
+    captured: dict = {}
+
+    async def app(scope, receive, send):
+        captured.update(scope)
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        return None
+
+    middleware = ProxyHeadersMiddleware(
+        app,
+        trusted_hosts="127.0.0.1/32,10.0.0.0/8",
+    )
+    scope = {
+        "type": "http",
+        "client": (client, 12345),
+        "scheme": "http",
+        "headers": [
+            (b"x-forwarded-for", forwarded_for.encode("ascii")),
+            (b"x-forwarded-proto", forwarded_proto.encode("ascii")),
+        ],
+    }
+    asyncio.run(middleware(scope, receive, send))
+    return captured
+
+
+def test_proxy_chain_uses_rightmost_untrusted_client_and_ignores_spoofed_prefix():
+    scope = _proxy_scope("127.0.0.1", "192.0.2.250, 198.51.100.23, 10.20.0.4")
+
+    assert scope["client"][0] == "198.51.100.23"
+    assert scope["scheme"] == "https"
+
+
+def test_untrusted_direct_peer_cannot_override_client_or_scheme():
+    scope = _proxy_scope("203.0.113.7", "198.51.100.23")
+
+    assert scope["client"][0] == "203.0.113.7"
+    assert scope["scheme"] == "http"
+
+
+def test_internal_nginx_preserves_tls_and_sanitizes_forwarded_host():
+    nginx = (Path(__file__).resolve().parents[2] / "frontend" / "nginx.conf").read_text(encoding="utf-8")
+
+    assert "map $http_x_forwarded_proto $tls_forwarded_proto" in nginx
+    assert "proxy_set_header X-Forwarded-Proto $scheme;" not in nginx
+    assert nginx.count("proxy_set_header X-Forwarded-Host $host;") == 7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       JWT_SECRET: "${JWT_SECRET:?Set JWT_SECRET in .env before deploying}"
       AUTH_COOKIE_DOMAIN: "${AUTH_COOKIE_DOMAIN:-}"
       TRUST_PROXY_HEADERS: "${TRUST_PROXY_HEADERS:-true}"
+      TRUSTED_PROXY_CIDRS: "${TRUSTED_PROXY_CIDRS:-127.0.0.1/32,::1/128,172.16.0.0/12}"
+      TRUSTED_HOSTS: "${TRUSTED_HOSTS:-}"
       SENDER_EMAIL: "${SENDER_EMAIL:-noreply@lionsquad.at}"
       RESEND_API_KEY: "${RESEND_API_KEY:-}"
       DISABLE_SCHEDULER: "${DISABLE_SCHEDULER:-false}"
@@ -43,7 +45,7 @@ services:
       USER_UPLOAD_RATE_WINDOW_SECONDS: "${USER_UPLOAD_RATE_WINDOW_SECONDS:-3600}"
       ALLOW_INSECURE_CORS: "${ALLOW_INSECURE_CORS:-false}"
     ports:
-      - "${BACKEND_BIND:-0.0.0.0}:${BACKEND_PORT:-8001}:8001"
+      - "${BACKEND_BIND:-127.0.0.1}:${BACKEND_PORT:-8001}:8001"
     volumes:
       - uploads_data:${UPLOAD_DIR:-/app/backend/uploads}
     extra_hosts:
@@ -74,7 +76,7 @@ services:
       backend:
         condition: service_healthy
     ports:
-      - "${FRONTEND_BIND:-0.0.0.0}:${FRONTEND_PORT:-3000}:80"
+      - "${FRONTEND_BIND:-127.0.0.1}:${FRONTEND_PORT:-3000}:80"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1/health"]
       interval: 15s

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,6 +3,14 @@ map $http_user_agent $tls_seo_preview_bot {
   ~*(googlebot|google-inspectiontool|googleother|adsbot-google|bingbot|bingpreview|duckduckbot|duckassistbot|yandexbot|baiduspider|applebot|facebookexternalhit|facebot|twitterbot|linkedinbot|slackbot|discordbot|telegrambot|whatsapp|skypeuripreview|pinterest|embedly|quora\ link\ preview|oai-searchbot|chatgpt-user|gptbot|claude-searchbot|claude-user|claudebot|anthropic-ai|perplexitybot|perplexity-user|bytespider|amazonbot) 1;
 }
 
+# TLS terminates at the outer reverse proxy. Preserve only a valid forwarded
+# scheme; otherwise fall back to the scheme seen by this internal nginx.
+map $http_x_forwarded_proto $tls_forwarded_proto {
+  default $scheme;
+  "http" http;
+  "https" https;
+}
+
 # Gzip-Kompression für bessere Performance (LCP/TTFB)
 gzip on;
 gzip_vary on;
@@ -110,9 +118,10 @@ server {
     proxy_pass http://backend:8001/api/settings/indexnow-key.txt;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     add_header Cache-Control "public, max-age=300" always;
   }
 
@@ -120,9 +129,10 @@ server {
     proxy_pass http://backend:8001/sitemap.xml;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     add_header Cache-Control "public, max-age=300" always;
   }
 
@@ -130,9 +140,10 @@ server {
     proxy_pass http://backend:8001/sitemap-news.xml;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     add_header Cache-Control "public, max-age=300" always;
   }
 
@@ -140,9 +151,10 @@ server {
     proxy_pass http://backend:8001/robots.txt;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     add_header Cache-Control "public, max-age=300" always;
   }
 
@@ -150,9 +162,10 @@ server {
     proxy_pass http://backend:8001;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     proxy_set_header Connection "";
     proxy_buffering off;
     proxy_cache off;
@@ -172,9 +185,10 @@ server {
     proxy_pass http://backend:8001;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     # Keepalive für bessere Performance
     proxy_set_header Connection "";
     proxy_connect_timeout 30s;
@@ -199,9 +213,10 @@ server {
     proxy_pass http://backend:8001/api/seo/preview?path=$uri;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $tls_forwarded_proto;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/mobile/scripts/logging-security.test.mjs
+++ b/mobile/scripts/logging-security.test.mjs
@@ -8,5 +8,6 @@ test("remote mobile logs never include local stack traces", async () => {
   const source = await readFile(sourceUrl, "utf8");
 
   assert.doesNotMatch(source, /error\.stack/);
+  assert.doesNotMatch(source, /console\.(?:warn|error)\s*=/);
   assert.match(source, /if \(!clientLoggingEnabled\) return/);
 });

--- a/mobile/src/lib/mobileLog.ts
+++ b/mobile/src/lib/mobileLog.ts
@@ -138,23 +138,6 @@ export function installMobileLogHandlers() {
   if (installed || !clientLoggingEnabled) return;
   installed = true;
 
-  const originalWarn = console.warn.bind(console);
-  const originalError = console.error.bind(console);
-
-  console.warn = (...args: unknown[]) => {
-    originalWarn(...args);
-    sendMobileLog("warn", args.map(describeArg).join(" "), { source: "console.warn" });
-  };
-
-  console.error = (...args: unknown[]) => {
-    originalError(...args);
-    const firstError = args.find((arg) => arg instanceof Error);
-    sendMobileLog("error", args.map(describeArg).join(" "), {
-      error: firstError,
-      source: "console.error",
-    });
-  };
-
   const previousHandler = typeof ErrorUtils !== "undefined" ? ErrorUtils?.getGlobalHandler?.() : undefined;
   if (typeof ErrorUtils !== "undefined" && ErrorUtils?.setGlobalHandler) {
     ErrorUtils.setGlobalHandler((error, isFatal) => {


### PR DESCRIPTION
## Ziel

Paket 3 härtet die Anwendung für den realen Betrieb hinter einem TLS-terminierenden Reverse Proxy. Forwarding-Header werden nicht mehr pauschal vertraut, und der interne Nginx bewahrt das öffentliche HTTPS-Schema korrekt.

## Sicherheitsänderungen

- Uvicorn akzeptiert `X-Forwarded-For`/`X-Forwarded-Proto` nur aus `TRUSTED_PROXY_CIDRS`
- Wildcard und Default-Routen (`*`, `0.0.0.0/0`, `::/0`) werden abgelehnt
- Rate-Limits und Mobile-Session-Audits verwenden ausschließlich die von Uvicorn validierte Client-IP
- Host-Header-Allowlist wird aus `FRONTEND_URL`, `CORS_ORIGINS` und optional `TRUSTED_HOSTS` gebildet
- HSTS und öffentliche URLs verlassen sich auf das validierte Request-Schema statt rohe Proxy-Header
- Frontend-Nginx bewahrt gültiges `https` vom äußeren Proxy und setzt `X-Forwarded-Host` selbst
- veröffentlichte Frontend-/Backend-Ports binden standardmäßig nur noch an Loopback
- globale Mobile-`console.warn`/`console.error`-Weiterleitung entfernt; explizite und globale Fehlerbehandlung bleibt bestehen
- verbliebene Scheduler-Logs enthalten keine potentiell sensiblen Ergebnisdaten

## Deployment-Hinweis

TLS bleibt am äußeren Reverse Proxy. Vor dem Server-Rollout `TRUSTED_PROXY_CIDRS` in `.env` auf die tatsächliche Proxy-/Docker-Quelle zuschneiden. Für einen host-nativen Proxy genügt typischerweise:

```env
TRUST_PROXY_HEADERS=true
TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
```

Bei Docker-Proxy oder der Topologie „alles zuerst zum Frontend“ müssen die tatsächlich beteiligten Proxy-/App-Netze ergänzt werden. README und INSTALL beschreiben beide Varianten. Die Compose-Vorgabe enthält für bestehende Docker-Installationen vorübergehend `172.16.0.0/12`; dieser Bereich sollte in Produktion eingegrenzt werden.

## Dauerhafte Verifikation

Der verpflichtende Frontend-CI-Job prüft nun zusätzlich:

- `docker compose config -q`
- `nginx -t` gegen die echte `frontend/nginx.conf`

## Lokal verifiziert

- Backend: 170 passed, 5 skipped, 277 live deselected
- Backend compileall und pip-audit: grün / keine bekannten Schwachstellen
- Frontend Audit-Gate: nur dokumentierte React-Router-Ausnahme
- Frontend Production-Build: grün
- Frontend Unit: 6 passed
- Frontend E2E: 20 passed, 8 Live-Admin-Checks skipped
- Mobile npm audit: 0
- Mobile TypeScript, 3 Security-Tests und Release-Preflight: grün
- YAML-Parsing und Diff-Check: grün