### PR TITLE
Paket 5: Live-Matches und Ergebniserfassung vereinfachen

### DIFF
--- a/ADMIN_GUIDE.md
+++ b/ADMIN_GUIDE.md
@@ -271,6 +271,9 @@ Vor-Ort-Ablauf und Turnierstart:
 - Organisator und Referee mit turnierweiter Zuweisung duerfen Check-in, Live, Pause und Beendet operativ setzen. Veroeffentlichen, Archivieren oder Absagen bleibt globalen Turnieradmins vorbehalten.
 - Ein Match kann an einer Station erst gestartet werden, wenn die konfigurierte Mindestzahl an Teilnehmern vorhanden ist. Der echte Stationsstart setzt das Match auf `in_progress` und benachrichtigt die Spieler mit der Station.
 - Lokale Turniere mit `Fix durch Turnierleitung` senden keine zeitbasierte 10-Minuten-Erinnerung. Die Startnachricht kommt erst beim tatsaechlichen Stationsstart, damit reale Verzoegerungen keinen falschen Alarm erzeugen.
+- Web-Dashboard und LionsAPP zeigen normalen Teilnehmern nur ihre eigenen offenen Matches. Laufende Matches und Matches mit ausstehendem Ergebnis stehen immer vor lediglich geplanten Matches.
+- Zugewiesene Organisatoren, Referees und Ergebnis-Erfasser erhalten zusaetzlich den Bereich `Turnierleitung · Ergebnisse`. Dort erscheinen nur Matches aktiver Turniere, die von ihrer Turnier-, Phasen-, Stations- oder Match-Zuweisung abgedeckt sind.
+- Beim Oeffnen oder Zurueckkehren auf Dashboard und Matchseite werden Daten sofort aktualisiert; waehrend die Ansicht aktiv ist folgt ein regelmaessiger Live-Refresh. Nach dem Speichern bleibt die Matchseite offen und bestaetigt den aktualisierten Stand sichtbar.
 
 ### Fast Lap
 

--- a/backend/routes/match_routes.py
+++ b/backend/routes/match_routes.py
@@ -1,6 +1,6 @@
 """Match/Score/Dispute routes."""
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, HTTPException, Depends, Request
 from database import get_db
@@ -9,8 +9,8 @@ from services.visibility import user_can_see
 from services.tournament_permissions import (
     READ_STAFF_ROLES,
     RESULT_STAFF_ROLES,
+    has_match_result_permission,
     has_tournament_staff_permission,
-    require_tournament_staff_permission,
 )
 from models import (
     MatchChatCreate,
@@ -26,6 +26,7 @@ from models import (
 from bracket_engine import advance_match_winner
 from match_rules import loser_for_winner, match_allows_draw, validate_winner_id
 from services.match_notifications import notify_match_result_confirmed
+from services.match_overview import operational_match_overviews, own_match_overviews
 from services.match_planning import ensure_station_slot_available, ensure_tournament_accepts_results
 from services.match_v2_results import MatchV2ResultError, build_v2_result_application
 from services.station_runtime import release_station_for_match
@@ -38,8 +39,6 @@ STAFF_ROLES = {"moderator", "tournament_admin", "club_admin", "superadmin"}
 EVENT_MODES = {"local", "online", "hybrid"}
 RESULT_ENTRY_MODES = {"staff_only", "player_confirmed", "hybrid"}
 SCHEDULE_MODES = {"fixed_by_staff", "player_proposal", "hybrid"}
-OPEN_MATCH_STATUSES = {"ready", "scheduled", "in_progress", "waiting_result"}
-ACTIVE_MATCH_REGISTRATION_STATUSES = {"registered", "approved", "checked_in"}
 MENTION_RE = re.compile(r"@([A-Za-z0-9_.-]{2,32})")
 STAFF_MENTION_HANDLES = {"leitung", "turnierleitung", "orga", "organizer", "staff", "admin", "referee", "schiri", "scorekeeper"}
 USER_PUBLIC_PROJECTION = {
@@ -60,28 +59,6 @@ async def _ensure_match_tournament_unlocked(db, match: dict) -> None:
 
 def _is_staff(user: dict | None) -> bool:
     return bool(user and user.get("role") in STAFF_ROLES)
-
-
-def _upcoming_sort_key(match: dict) -> tuple:
-    scheduled = match.get("scheduled_at")
-    if scheduled:
-        try:
-            parsed = datetime.fromisoformat(str(scheduled).replace("Z", "+00:00"))
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            return (0, parsed.astimezone(timezone.utc))
-        except (TypeError, ValueError):
-            pass
-    return (1, int(match.get("round") or 9999), str(match.get("match_key") or match.get("id") or ""))
-
-
-async def _team_ids_for_user(user_id: str) -> list[str]:
-    db = get_db()
-    memberships = await db.team_members.find(
-        {"user_id": user_id},
-        {"_id": 0, "team_id": 1},
-    ).to_list(200)
-    return [row["team_id"] for row in memberships if row.get("team_id")]
 
 
 def _mode_value(value: object, allowed: set[str]) -> str | None:
@@ -463,35 +440,20 @@ async def _acting_registration_for_match(match: dict, user: dict | None) -> dict
 async def _can_act_for_match(match: dict, user: dict | None) -> bool:
     return bool(
         _is_staff(user)
-        or await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES)
-        or await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "match", match.get("id"))
-        or await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "stage", match.get("stage_id"))
+        or await has_match_result_permission(user, match)
         or await _acting_registration_for_match(match, user)
     )
 
 
-async def _can_submit_result_for_match(match: dict, user: dict | None, collection: str) -> bool:
-    if not user:
-        return False
-    if collection == "matches":
-        return bool(
-            await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "tournament")
-            or await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "match", match.get("id"))
-            or (match.get("station_id") and await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "station", match.get("station_id")))
-        )
-    return bool(
-        await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES)
-        or await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "match", match.get("id"))
-        or await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "stage", match.get("stage_id"))
-        or (match.get("station_id") and await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES, "station", match.get("station_id")))
-    )
+async def _can_submit_result_for_match(match: dict, user: dict | None) -> bool:
+    return await has_match_result_permission(user, match)
 
 
 async def _can_forfeit_match(match: dict, user: dict | None, collection: str) -> bool:
     return bool(
         user
         and collection == "matches"
-        and await has_tournament_staff_permission(user, match.get("tournament_id"), RESULT_STAFF_ROLES)
+        and await has_match_result_permission(user, match)
     )
 
 
@@ -507,12 +469,7 @@ async def _can_read_match(match: dict, user: dict | None) -> bool:
 
 
 async def _require_result_permission(user: dict, match: dict) -> None:
-    allowed = (
-        await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES)
-        or await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "match", match["id"])
-        or await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "stage", match.get("stage_id"))
-        or (match.get("station_id") and await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "station", match.get("station_id")))
-    )
+    allowed = await has_match_result_permission(user, match)
     if not allowed:
         raise HTTPException(status_code=403, detail="Keine Turnierberechtigung für diese Aktion")
 
@@ -639,7 +596,7 @@ async def _match_page_payload(match: dict, collection: str, user: dict | None = 
     acting_reg = await _acting_registration_for_match(match, user)
     direct_reg = await _user_registration_for_match(match, user)
     policy = _match_policy(match, collection, tournament, stage)
-    can_submit_result = await _can_submit_result_for_match(match, user, collection)
+    can_submit_result = await _can_submit_result_for_match(match, user)
     can_player_report = bool(collection == "matches" and direct_reg and _players_can_report(policy))
     can_propose_schedule = bool(user and await _can_act_for_match(match, user) and _schedule_proposals_enabled(policy))
     round_number = match.get("matchday_number") or match.get("round")
@@ -675,40 +632,13 @@ async def _match_page_payload(match: dict, collection: str, user: dict | None = 
 
 @router.get("/upcoming")
 async def my_upcoming(me: dict = Depends(get_current_user)):
-    db = get_db()
-    team_ids = await _team_ids_for_user(me["id"])
-    reg_query = {"user_id": me["id"]}
-    if team_ids:
-        reg_query = {"$or": [{"user_id": me["id"]}, {"team_id": {"$in": team_ids}}]}
-    regs = await db.tournament_registrations.find(
-        {**reg_query, "status": {"$in": list(ACTIVE_MATCH_REGISTRATION_STATUSES)}},
-        {"_id": 0, "id": 1, "tournament_id": 1},
-    ).to_list(200)
-    reg_ids = [r["id"] for r in regs]
-    if not reg_ids:
-        return []
-    match_query = {
-        "$or": [{"participant_a_id": {"$in": reg_ids}},
-                {"participant_b_id": {"$in": reg_ids}},
-                {"slots.registration_id": {"$in": reg_ids}}],
-        "status": {"$in": list(OPEN_MATCH_STATUSES)},
-    }
-    legacy = await db.matches.find(match_query, {"_id": 0}).to_list(200)
-    v2 = await db.matches_v2.find(match_query, {"_id": 0}).to_list(200)
-    matches = sorted([{**m, "collection": "matches"} for m in legacy] + [{**m, "collection": "matches_v2"} for m in v2], key=_upcoming_sort_key)[:12]
-    tournament_ids = list({match.get("tournament_id") for match in matches if match.get("tournament_id")})
-    tournaments = {
-        tournament["id"]: tournament
-        for tournament in await db.tournaments.find(
-            {"id": {"$in": tournament_ids}},
-            {"_id": 0, "id": 1, "title": 1, "slug": 1},
-        ).to_list(100)
-    }
-    for match in matches:
-        tournament = tournaments.get(match.get("tournament_id") or "") or {}
-        match["tournament_title"] = tournament.get("title")
-        match["tournament_slug"] = tournament.get("slug")
+    matches, _registrations = await own_match_overviews(get_db(), me)
     return matches
+
+
+@router.get("/operations")
+async def operational_matches(me: dict = Depends(get_current_user)):
+    return await operational_match_overviews(get_db(), me)
 
 
 @router.get("/{match_id}/page")
@@ -1022,11 +952,7 @@ async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_
         m.get("score_a"),
         m.get("score_b"),
     )
-    allowed = (
-        await has_tournament_staff_permission(me, m["tournament_id"], RESULT_STAFF_ROLES, "tournament")
-        or await has_tournament_staff_permission(me, m["tournament_id"], RESULT_STAFF_ROLES, "match", match_id)
-        or (m.get("station_id") and await has_tournament_staff_permission(me, m["tournament_id"], RESULT_STAFF_ROLES, "station", m.get("station_id")))
-    )
+    allowed = await has_match_result_permission(me, m)
     if not allowed:
         raise HTTPException(status_code=403, detail="Keine Turnierberechtigung für diese Aktion")
     nullable_fields = {"winner_id", "scheduled_at", "station_id", "admin_note", "map", "best_of", "duration_minutes"}
@@ -1242,7 +1168,7 @@ async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user
         raise HTTPException(status_code=404)
     await _ensure_match_tournament_unlocked(db, m)
     await ensure_tournament_accepts_results(db, m["tournament_id"])
-    await require_tournament_staff_permission(me, m["tournament_id"], RESULT_STAFF_ROLES)
+    await _require_result_permission(me, m)
     note = (body.get("note") or body.get("reason") or "").strip()
     if len(note) < 5:
         raise HTTPException(

--- a/backend/routes/match_v2_routes.py
+++ b/backend/routes/match_v2_routes.py
@@ -22,6 +22,7 @@ from services.tournament_permissions import (
     CHECKIN_STAFF_ROLES,
     READ_STAFF_ROLES,
     RESULT_STAFF_ROLES,
+    has_match_result_permission,
     has_tournament_staff_permission,
     require_tournament_staff_permission,
 )
@@ -194,24 +195,13 @@ async def _assert_match_visible(match: dict, user: dict | None) -> None:
 
 
 async def _require_v2_result_permission(user: dict, match: dict) -> None:
-    allowed = (
-        await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "match", match["id"])
-        or await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "stage", match.get("stage_id"))
-        or await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "station", match.get("station_id"))
-    )
+    allowed = await has_match_result_permission(user, match)
     if not allowed:
         raise HTTPException(status_code=403, detail="Keine Turnierberechtigung für diese Aktion")
 
 
 async def _can_submit_result_for_match(match: dict, user: dict | None) -> bool:
-    return bool(
-        user
-        and (
-            await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "match", match["id"])
-            or await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "stage", match.get("stage_id"))
-            or await has_tournament_staff_permission(user, match["tournament_id"], RESULT_STAFF_ROLES, "station", match.get("station_id"))
-        )
-    )
+    return await has_match_result_permission(user, match)
 
 
 def _schedule_deadline(match: dict, tournament: dict | None = None):

--- a/backend/routes/mobile_routes.py
+++ b/backend/routes/mobile_routes.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from auth import get_current_user, get_optional_user
 from database import get_db
 from models import new_id, now_utc
+from services.match_overview import operational_match_overviews, own_match_overviews
 from services.profile_references import personal_profile_references
 from services.public_phase import derive_public_phase
 from services.visibility import user_can_see
@@ -21,7 +22,6 @@ router = APIRouter(prefix="/api/mobile", tags=["mobile"])
 STAFF_ROLES = {"moderator", "tournament_admin", "club_admin", "superadmin"}
 ACTIVE_TOURNAMENT_REGISTRATION_STATUSES = {"pending", "registered", "approved", "checked_in", "waitlist"}
 ACTIVE_EVENT_REGISTRATION_STATUSES = {"registered", "checked_in", "waitlist"}
-OPEN_MATCH_STATUSES = {"ready", "scheduled", "in_progress", "waiting_result"}
 HIDDEN_PUBLIC_STATUSES = {"draft", "completed", "results_published", "archived", "cancelled"}
 
 
@@ -266,19 +266,6 @@ def _compact_news(post: dict) -> dict:
     }
 
 
-def _compact_match(match: dict, tournament_map: dict[str, dict]) -> dict:
-    tournament = tournament_map.get(match.get("tournament_id") or "")
-    return {
-        "id": match.get("id"),
-        "status": match.get("status"),
-        "scheduled_at": match.get("scheduled_at"),
-        "tournament_id": match.get("tournament_id"),
-        "tournament_title": (tournament or {}).get("title"),
-        "round": match.get("round"),
-        "round_name": match.get("round_name") or match.get("matchday_label"),
-    }
-
-
 async def _latest_news(user: dict | None) -> list[dict]:
     db = get_db()
     posts = await db.news_posts.find(
@@ -371,33 +358,6 @@ async def _my_event_registrations(user: dict) -> list[dict]:
     ).sort("created_at", -1).to_list(200)
 
 
-async def _my_matches(registrations: list[dict]) -> list[dict]:
-    db = get_db()
-    reg_ids = [reg["id"] for reg in registrations if reg.get("id")]
-    if not reg_ids:
-        return []
-    match_query = {
-        "$or": [
-            {"participant_a_id": {"$in": reg_ids}},
-            {"participant_b_id": {"$in": reg_ids}},
-            {"slots.registration_id": {"$in": reg_ids}},
-        ],
-        "status": {"$in": list(OPEN_MATCH_STATUSES)},
-    }
-    legacy = await db.matches.find(match_query, {"_id": 0}).sort("scheduled_at", 1).to_list(60)
-    v2 = await db.matches_v2.find(match_query, {"_id": 0}).sort("scheduled_at", 1).to_list(60)
-    matches = sorted([*legacy, *v2], key=_date_key)[:12]
-    tournament_ids = list({match.get("tournament_id") for match in matches if match.get("tournament_id")})
-    tournament_map = {
-        tournament["id"]: tournament
-        for tournament in await db.tournaments.find(
-            {"id": {"$in": tournament_ids}},
-            {"_id": 0, "id": 1, "title": 1},
-        ).to_list(100)
-    }
-    return [_compact_match(match, tournament_map) for match in matches]
-
-
 def _dashboard_actions(tournaments: list[dict], events: list[dict], matches: list[dict]) -> list[dict]:
     actions = []
     for tournament in tournaments:
@@ -466,6 +426,7 @@ async def mobile_dashboard(user: dict | None = Depends(get_optional_user)):
     my_tournaments: list[dict] = []
     my_events: list[dict] = []
     my_matches: list[dict] = []
+    staff_matches: list[dict] = []
 
     if user:
         tournament_regs = await _my_tournament_registrations(user)
@@ -496,7 +457,12 @@ async def mobile_dashboard(user: dict | None = Depends(get_optional_user)):
         my_events.sort(key=_date_key)
         my_events = my_events[:12]
 
-        my_matches = await _my_matches(tournament_regs)
+        my_matches, _match_registrations = await own_match_overviews(db, user)
+        staff_matches = await operational_match_overviews(
+            db,
+            user,
+            exclude_match_ids={match.get("id") for match in my_matches if match.get("id")},
+        )
 
     actions = _dashboard_actions(my_tournaments, my_events, my_matches)
     return {
@@ -504,6 +470,7 @@ async def mobile_dashboard(user: dict | None = Depends(get_optional_user)):
             "tournaments": my_tournaments,
             "events": my_events,
             "matches": my_matches,
+            "staff_matches": staff_matches,
             "actions": actions,
         },
         "public": public,
@@ -513,6 +480,7 @@ async def mobile_dashboard(user: dict | None = Depends(get_optional_user)):
             "my_tournaments": len(my_tournaments),
             "my_events": len(my_events),
             "open_matches": len(my_matches),
+            "staff_matches": len(staff_matches),
             "open_actions": len(actions),
             "news": len(news),
             "public_tournaments": len(public["tournaments"]),

--- a/backend/services/match_overview.py
+++ b/backend/services/match_overview.py
@@ -1,0 +1,242 @@
+"""Compact, permission-aware match lists for web and mobile dashboards."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from services.station_labels import attach_station_info
+from services.tournament_permissions import RESULT_STAFF_ROLES, is_global_tournament_staff
+
+
+OPEN_MATCH_STATUSES = {"ready", "scheduled", "in_progress", "waiting_result"}
+ACTIVE_REGISTRATION_STATUSES = {"registered", "approved", "checked_in"}
+ACTIVE_OPERATION_TOURNAMENT_STATUSES = {"check_in", "live", "paused"}
+MATCH_STATUS_PRIORITY = {
+    "in_progress": 0,
+    "waiting_result": 1,
+    "ready": 2,
+    "scheduled": 3,
+}
+
+
+def match_registration_ids(match: dict) -> list[str]:
+    ids: list[str] = []
+    for key in ("participant_a_id", "participant_b_id"):
+        if match.get(key):
+            ids.append(match[key])
+    ids.extend(
+        slot["registration_id"]
+        for slot in match.get("slots") or []
+        if slot.get("registration_id")
+    )
+    return list(dict.fromkeys(ids))
+
+
+def match_overview_sort_key(match: dict) -> tuple:
+    status_priority = MATCH_STATUS_PRIORITY.get(str(match.get("status") or ""), 9)
+    scheduled = match.get("scheduled_at")
+    parsed = datetime.max.replace(tzinfo=timezone.utc)
+    if scheduled:
+        try:
+            parsed = datetime.fromisoformat(str(scheduled).replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            parsed = parsed.astimezone(timezone.utc)
+        except (TypeError, ValueError):
+            pass
+    return (
+        status_priority,
+        parsed,
+        int(match.get("round") or match.get("matchday_number") or 9999),
+        str(match.get("match_key") or match.get("id") or ""),
+    )
+
+
+async def _team_ids_for_user(db, user_id: str) -> list[str]:
+    memberships = await db.team_members.find(
+        {"user_id": user_id},
+        {"_id": 0, "team_id": 1},
+    ).to_list(200)
+    return [row["team_id"] for row in memberships if row.get("team_id")]
+
+
+async def _active_registrations_for_user(db, user: dict) -> list[dict]:
+    team_ids = await _team_ids_for_user(db, user["id"])
+    identity_query: dict = {"user_id": user["id"]}
+    if team_ids:
+        identity_query = {"$or": [{"user_id": user["id"]}, {"team_id": {"$in": team_ids}}]}
+    return await db.tournament_registrations.find(
+        {**identity_query, "status": {"$in": sorted(ACTIVE_REGISTRATION_STATUSES)}},
+        {"_id": 0, "id": 1, "tournament_id": 1},
+    ).to_list(250)
+
+
+async def _matches_for_query(db, query: dict, per_collection_limit: int = 240) -> list[dict]:
+    legacy = await db.matches.find(query, {"_id": 0}).to_list(per_collection_limit)
+    v2 = await db.matches_v2.find(query, {"_id": 0}).to_list(per_collection_limit)
+    return [
+        *({**match, "collection": "matches"} for match in legacy),
+        *({**match, "collection": "matches_v2"} for match in v2),
+    ]
+
+
+def _registration_label(registration: dict | None, team_map: dict[str, dict]) -> str:
+    if not registration:
+        return ""
+    direct = registration.get("display_name") or registration.get("ingame_name")
+    if direct:
+        return str(direct)
+    team = team_map.get(registration.get("team_id") or "") or {}
+    if team.get("tag") and team.get("name"):
+        return f"[{team['tag']}] {team['name']}"
+    return str(team.get("name") or team.get("tag") or "")
+
+
+async def compact_match_overviews(
+    db,
+    matches: list[dict],
+    own_registration_ids: set[str] | None = None,
+    result_match_ids: set[str] | None = None,
+) -> list[dict]:
+    own_registration_ids = own_registration_ids or set()
+    result_match_ids = result_match_ids or set()
+    await attach_station_info(db, matches)
+    tournament_ids = list({match.get("tournament_id") for match in matches if match.get("tournament_id")})
+    registration_ids = list({rid for match in matches for rid in match_registration_ids(match)})
+    tournaments = await db.tournaments.find(
+        {"id": {"$in": tournament_ids}},
+        {"_id": 0, "id": 1, "title": 1, "slug": 1},
+    ).to_list(max(100, len(tournament_ids))) if tournament_ids else []
+    registrations = await db.tournament_registrations.find(
+        {"id": {"$in": registration_ids}},
+        {"_id": 0, "id": 1, "display_name": 1, "ingame_name": 1, "team_id": 1},
+    ).to_list(max(200, len(registration_ids))) if registration_ids else []
+    team_ids = list({row.get("team_id") for row in registrations if row.get("team_id")})
+    teams = await db.teams.find(
+        {"id": {"$in": team_ids}},
+        {"_id": 0, "id": 1, "name": 1, "tag": 1},
+    ).to_list(max(100, len(team_ids))) if team_ids else []
+
+    tournament_map = {row["id"]: row for row in tournaments}
+    registration_map = {row["id"]: row for row in registrations}
+    team_map = {row["id"]: row for row in teams}
+    summaries = []
+    for match in matches:
+        participant_ids = match_registration_ids(match)
+        participant_names = [
+            label
+            for label in (_registration_label(registration_map.get(rid), team_map) for rid in participant_ids)
+            if label
+        ]
+        opponent_names = [
+            label
+            for rid in participant_ids
+            if rid not in own_registration_ids
+            for label in [_registration_label(registration_map.get(rid), team_map)]
+            if label
+        ]
+        tournament = tournament_map.get(match.get("tournament_id") or "") or {}
+        summaries.append({
+            "id": match.get("id"),
+            "collection": match.get("collection") or "matches",
+            "status": match.get("status"),
+            "scheduled_at": match.get("scheduled_at"),
+            "tournament_id": match.get("tournament_id"),
+            "tournament_title": tournament.get("title"),
+            "tournament_slug": tournament.get("slug"),
+            "round": match.get("round") or match.get("matchday_number"),
+            "round_name": match.get("round_name") or match.get("matchday_label"),
+            "match_key": match.get("match_key"),
+            "station_id": match.get("station_id"),
+            "station_label": match.get("station_label") or match.get("station_name") or (match.get("station") or {}).get("name"),
+            "participant_names": participant_names,
+            "opponent_name": ", ".join(opponent_names),
+            "participant_count": len(participant_ids),
+            "is_own_match": bool(own_registration_ids.intersection(participant_ids)),
+            "can_submit_result": match.get("id") in result_match_ids,
+            "needs_result": match.get("status") in {"in_progress", "waiting_result"},
+        })
+    return summaries
+
+
+async def own_match_overviews(db, user: dict, limit: int = 12) -> tuple[list[dict], list[dict]]:
+    registrations = await _active_registrations_for_user(db, user)
+    registration_ids = {row["id"] for row in registrations if row.get("id")}
+    if not registration_ids:
+        return [], registrations
+    query = {
+        "$or": [
+            {"participant_a_id": {"$in": sorted(registration_ids)}},
+            {"participant_b_id": {"$in": sorted(registration_ids)}},
+            {"slots.registration_id": {"$in": sorted(registration_ids)}},
+        ],
+        "status": {"$in": sorted(OPEN_MATCH_STATUSES)},
+    }
+    matches = sorted(await _matches_for_query(db, query), key=match_overview_sort_key)[:limit]
+    return await compact_match_overviews(db, matches, registration_ids), registrations
+
+
+def _assignment_matches(assignment: dict, match: dict) -> bool:
+    scope = assignment.get("scope") or "tournament"
+    scope_id = assignment.get("scope_id")
+    if scope == "tournament":
+        return True
+    if not scope_id:
+        return True
+    field_by_scope = {
+        "match": "id",
+        "stage": "stage_id",
+        "station": "station_id",
+        "group": "group_id",
+    }
+    field = field_by_scope.get(scope)
+    return bool(field and match.get(field) == scope_id)
+
+
+async def operational_match_overviews(
+    db,
+    user: dict,
+    exclude_match_ids: set[str] | None = None,
+    limit: int = 12,
+) -> list[dict]:
+    exclude_match_ids = exclude_match_ids or set()
+    global_staff = is_global_tournament_staff(user)
+    assignments: list[dict] = []
+    if not global_staff:
+        assignments = await db.tournament_staff_assignments.find(
+            {
+                "user_id": user["id"],
+                "role": {"$in": sorted(RESULT_STAFF_ROLES)},
+                "is_active": {"$ne": False},
+            },
+            {"_id": 0, "tournament_id": 1, "scope": 1, "scope_id": 1},
+        ).to_list(250)
+        if not assignments:
+            return []
+
+    assigned_ids = list({row.get("tournament_id") for row in assignments if row.get("tournament_id")})
+    tournament_query: dict = {"status": {"$in": sorted(ACTIVE_OPERATION_TOURNAMENT_STATUSES)}}
+    if not global_staff:
+        tournament_query["id"] = {"$in": assigned_ids}
+    active_tournaments = await db.tournaments.find(
+        tournament_query,
+        {"_id": 0, "id": 1},
+    ).to_list(500)
+    tournament_ids = [row["id"] for row in active_tournaments if row.get("id")]
+    if not tournament_ids:
+        return []
+
+    query = {
+        "tournament_id": {"$in": tournament_ids},
+        "status": {"$in": sorted(OPEN_MATCH_STATUSES)},
+    }
+    candidates = [
+        match for match in await _matches_for_query(db, query)
+        if match.get("id") not in exclude_match_ids
+        and (global_staff or any(
+            row.get("tournament_id") == match.get("tournament_id") and _assignment_matches(row, match)
+            for row in assignments
+        ))
+    ]
+    matches = sorted(candidates, key=match_overview_sort_key)[:limit]
+    result_ids = {match.get("id") for match in matches if match.get("id")}
+    return await compact_match_overviews(db, matches, result_match_ids=result_ids)

--- a/backend/services/match_overview.py
+++ b/backend/services/match_overview.py
@@ -42,7 +42,7 @@ def match_overview_sort_key(match: dict) -> tuple:
                 parsed = parsed.replace(tzinfo=timezone.utc)
             parsed = parsed.astimezone(timezone.utc)
         except (TypeError, ValueError):
-            pass
+            parsed = datetime.max.replace(tzinfo=timezone.utc)
     return (
         status_priority,
         parsed,

--- a/backend/services/tournament_permissions.py
+++ b/backend/services/tournament_permissions.py
@@ -65,6 +65,36 @@ async def has_tournament_staff_permission(
     return False
 
 
+async def has_match_result_permission(user: dict | None, match: dict) -> bool:
+    """Return whether a user may enter the result for one concrete match.
+
+    Keep the scope rules in one place so legacy and v2 routes, dashboards and
+    operational match lists cannot drift apart.
+    """
+    if not user or not match.get("tournament_id"):
+        return False
+    tournament_id = match["tournament_id"]
+    checks = [
+        ("tournament", None),
+        ("match", match.get("id")),
+        ("stage", match.get("stage_id")),
+        ("group", match.get("group_id")),
+        ("station", match.get("station_id")),
+    ]
+    for scope, scope_id in checks:
+        if scope != "tournament" and not scope_id:
+            continue
+        if await has_tournament_staff_permission(
+            user,
+            tournament_id,
+            RESULT_STAFF_ROLES,
+            scope,
+            scope_id,
+        ):
+            return True
+    return False
+
+
 async def require_tournament_staff_permission(
     user: dict | None,
     tournament_id: str,

--- a/backend/tests/test_match_overview_unit.py
+++ b/backend/tests/test_match_overview_unit.py
@@ -89,6 +89,13 @@ def test_live_match_sorts_before_later_scheduled_match():
     assert sorted([scheduled, live], key=match_overview_sort_key)[0]["id"] == "live"
 
 
+def test_invalid_schedule_sorts_after_valid_schedule_in_same_status():
+    invalid = {"id": "invalid", "status": "scheduled", "scheduled_at": "not-a-date"}
+    valid = {"id": "valid", "status": "scheduled", "scheduled_at": "2026-08-06T12:00:00+00:00"}
+
+    assert sorted([invalid, valid], key=match_overview_sort_key)[0]["id"] == "valid"
+
+
 def test_own_overview_only_returns_open_user_matches_with_opponent():
     rows, registrations = asyncio.run(own_match_overviews(FakeDb(), {"id": "u1", "role": "user"}))
 

--- a/backend/tests/test_match_overview_unit.py
+++ b/backend/tests/test_match_overview_unit.py
@@ -1,0 +1,116 @@
+"""Regression tests for Package 5 dashboard match overviews."""
+import asyncio
+
+from services.match_overview import (
+    match_overview_sort_key,
+    operational_match_overviews,
+    own_match_overviews,
+)
+
+
+def _value_at(doc, path):
+    value = doc
+    for part in path.split("."):
+        if isinstance(value, list):
+            return [item.get(part) for item in value if isinstance(item, dict)]
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _matches(doc, query):
+    for key, expected in query.items():
+        if key == "$or":
+            if not any(_matches(doc, child) for child in expected):
+                return False
+            continue
+        value = _value_at(doc, key)
+        if isinstance(expected, dict) and "$in" in expected:
+            allowed = expected["$in"]
+            if isinstance(value, list):
+                if not any(item in allowed for item in value):
+                    return False
+            elif value not in allowed:
+                return False
+        elif isinstance(expected, dict) and "$ne" in expected:
+            if value == expected["$ne"]:
+                return False
+        elif value != expected:
+            return False
+    return True
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = list(docs)
+
+    async def to_list(self, limit):
+        return self.docs[:limit]
+
+
+class FakeCollection:
+    def __init__(self, docs=()):
+        self.docs = list(docs)
+
+    def find(self, query, projection=None):
+        rows = [dict(doc) for doc in self.docs if _matches(doc, query)]
+        if projection:
+            included = {key for key, enabled in projection.items() if enabled and key != "_id"}
+            if included:
+                rows = [{key: row.get(key) for key in included if key in row} for row in rows]
+        return FakeCursor(rows)
+
+
+class FakeDb:
+    def __init__(self, *, assignments=()):
+        self.team_members = FakeCollection()
+        self.tournament_registrations = FakeCollection([
+            {"id": "r-own", "user_id": "u1", "status": "approved", "tournament_id": "t1", "display_name": "Lion"},
+            {"id": "r-other", "user_id": "u2", "status": "approved", "tournament_id": "t1", "display_name": "Opponent"},
+        ])
+        self.matches = FakeCollection([
+            {"id": "m-scheduled", "tournament_id": "t1", "status": "scheduled", "scheduled_at": "2026-08-06T12:00:00+00:00", "participant_a_id": "r-own", "participant_b_id": "r-other", "round": 1},
+            {"id": "m-live", "tournament_id": "t1", "status": "in_progress", "scheduled_at": "2026-08-06T13:00:00+00:00", "participant_a_id": "r-own", "participant_b_id": "r-other", "round": 2},
+            {"id": "m-done", "tournament_id": "t1", "status": "completed", "participant_a_id": "r-own", "participant_b_id": "r-other"},
+            {"id": "m-unrelated", "tournament_id": "t1", "status": "in_progress", "participant_a_id": "r-other", "participant_b_id": "r-x"},
+        ])
+        self.matches_v2 = FakeCollection()
+        self.tournaments = FakeCollection([{"id": "t1", "title": "Cup", "slug": "cup", "status": "live"}])
+        self.teams = FakeCollection()
+        self.stations = FakeCollection()
+        self.tournament_staff_assignments = FakeCollection(assignments)
+
+
+def test_live_match_sorts_before_later_scheduled_match():
+    scheduled = {"id": "scheduled", "status": "scheduled", "scheduled_at": "2026-08-06T10:00:00+00:00"}
+    live = {"id": "live", "status": "in_progress", "scheduled_at": "2026-08-06T12:00:00+00:00"}
+
+    assert sorted([scheduled, live], key=match_overview_sort_key)[0]["id"] == "live"
+
+
+def test_own_overview_only_returns_open_user_matches_with_opponent():
+    rows, registrations = asyncio.run(own_match_overviews(FakeDb(), {"id": "u1", "role": "user"}))
+
+    assert [row["id"] for row in rows] == ["m-live", "m-scheduled"]
+    assert rows[0]["needs_result"] is True
+    assert rows[0]["is_own_match"] is True
+    assert rows[0]["opponent_name"] == "Opponent"
+    assert [row["id"] for row in registrations] == ["r-own"]
+
+
+def test_operational_overview_honors_exact_match_assignment():
+    db = FakeDb(assignments=[{
+        "user_id": "staff1",
+        "tournament_id": "t1",
+        "role": "scorekeeper",
+        "scope": "match",
+        "scope_id": "m-live",
+        "is_active": True,
+    }])
+
+    rows = asyncio.run(operational_match_overviews(db, {"id": "staff1", "role": "user"}))
+
+    assert [row["id"] for row in rows] == ["m-live"]
+    assert rows[0]["can_submit_result"] is True
+    assert rows[0]["is_own_match"] is False

--- a/backend/tests/test_tournament_permissions_unit.py
+++ b/backend/tests/test_tournament_permissions_unit.py
@@ -89,6 +89,23 @@ def test_role_and_scope_permissions(monkeypatch):
     assert asyncio.run(perms.has_tournament_staff_permission(user, "t1", perms.READ_STAFF_ROLES, "match", "m1"))
 
 
+def test_match_result_permission_accepts_only_matching_operational_scope(monkeypatch):
+    db = FakeDb([
+        {"tournament_id": "t1", "user_id": "u1", "role": "scorekeeper", "scope": "stage", "scope_id": "stage-1", "is_active": True},
+        {"tournament_id": "t1", "user_id": "u2", "role": "scorekeeper", "scope": "station", "scope_id": "station-1", "is_active": True},
+    ])
+    monkeypatch.setattr(perms, "get_db", lambda: db)
+
+    assert asyncio.run(perms.has_match_result_permission(
+        {"id": "u1", "role": "user"},
+        {"id": "m1", "tournament_id": "t1", "stage_id": "stage-1", "station_id": "station-2"},
+    ))
+    assert not asyncio.run(perms.has_match_result_permission(
+        {"id": "u1", "role": "user"},
+        {"id": "m2", "tournament_id": "t1", "stage_id": "stage-2", "station_id": "station-2"},
+    ))
+
+
 def test_require_tournament_staff_permission_raises_403(monkeypatch):
     db = FakeDb([])
     monkeypatch.setattr(perms, "get_db", lambda: db)

--- a/frontend/src/pages/public/MatchPage.jsx
+++ b/frontend/src/pages/public/MatchPage.jsx
@@ -102,11 +102,20 @@ export default function MatchPage() {
   }, [id]);
 
   useEffect(() => {
+    const refreshVisible = () => {
+      if (typeof document === "undefined" || !document.hidden) load().catch(() => {});
+    };
     load({ preserveDrafts: false }).catch(() => setData(null));
     const timer = window.setInterval(() => {
-      load().catch(() => {});
+      refreshVisible();
     }, 10000);
-    return () => window.clearInterval(timer);
+    window.addEventListener("focus", refreshVisible);
+    document.addEventListener("visibilitychange", refreshVisible);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refreshVisible);
+      document.removeEventListener("visibilitychange", refreshVisible);
+    };
   }, [load]);
   useApiInvalidation(load, ["matches", "matches_v2", "tournaments"]);
 

--- a/frontend/src/pages/user/DashboardPage.jsx
+++ b/frontend/src/pages/user/DashboardPage.jsx
@@ -44,22 +44,29 @@ function DashboardAvatar({ user, isClubMember }) {
 export default function DashboardPage() {
   const { user, isClubMember } = useAuth();
   const [matches, setMatches] = useState([]);
+  const [staffMatches, setStaffMatches] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const [openPrizes, setOpenPrizes] = useState(0);
   const [completeness, setCompleteness] = useState(null);
   const [penaltyCount, setPenaltyCount] = useState(0);
 
   const load = useCallback(async () => {
-    const [m, n, p, c, pen] = await Promise.allSettled([
+    const [m, operations, n, p, c, pen] = await Promise.allSettled([
       api.get("/matches/upcoming"),
+      api.get("/matches/operations"),
       api.get("/notifications/me"),
       api.get("/prizes/me/open-count"),
       api.get("/users/me/profile-completeness"),
       api.get("/penalties/me"),
     ]);
-    if (m.status === "fulfilled") {
-      const rows = Array.isArray(m.value.data) ? m.value.data : [];
-      setMatches(rows.filter((match) => OPEN_MATCH_STATUSES.has(String(match.status || ""))));
+    const ownRows = m.status === "fulfilled" && Array.isArray(m.value.data)
+      ? m.value.data.filter((match) => OPEN_MATCH_STATUSES.has(String(match.status || "")))
+      : [];
+    const ownIds = new Set(ownRows.map((match) => match.id));
+    if (m.status === "fulfilled") setMatches(ownRows);
+    if (operations.status === "fulfilled") {
+      const rows = Array.isArray(operations.value.data) ? operations.value.data : [];
+      setStaffMatches(rows.filter((match) => !ownIds.has(match.id) && OPEN_MATCH_STATUSES.has(String(match.status || ""))));
     }
     if (n.status === "fulfilled") setNotifications(Array.isArray(n.value.data) ? n.value.data : (n.value.data?.items || []));
     if (p.status === "fulfilled") setOpenPrizes(p.value.data?.count || 0);
@@ -67,11 +74,20 @@ export default function DashboardPage() {
     if (pen.status === "fulfilled") setPenaltyCount(pen.value.data?.count || 0);
   }, []);
   useEffect(() => {
-    load();
+    const refreshVisible = () => {
+      if (typeof document === "undefined" || !document.hidden) load().catch(() => {});
+    };
+    refreshVisible();
     const timer = window.setInterval(() => {
-      load().catch(() => {});
+      refreshVisible();
     }, 10000);
-    return () => window.clearInterval(timer);
+    window.addEventListener("focus", refreshVisible);
+    document.addEventListener("visibilitychange", refreshVisible);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refreshVisible);
+      document.removeEventListener("visibilitychange", refreshVisible);
+    };
   }, [load]);
   useApiInvalidation(load, ["matches", "prizes", "users", "penalties", "achievements", "membership", "tournaments", "f1", "admin/notifications"]);
 
@@ -115,25 +131,10 @@ export default function DashboardPage() {
 
         <div className="grid lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 border border-white/10 rounded-sm bg-[#121212] p-5">
-            <h2 className="font-heading text-xl font-bold uppercase mb-4 flex items-center gap-2"><Trophy className="w-4 h-4 text-[#29B6E8]" /> Nächste Spiele</h2>
+            <h2 className="font-heading text-xl font-bold uppercase mb-4 flex items-center gap-2"><Trophy className="w-4 h-4 text-[#29B6E8]" /> Meine aktiven Matches</h2>
             <div className="space-y-3">
               {matches.length === 0 && <div className="text-sm text-white/40">Keine geplanten Spiele.</div>}
-              {matches.map((m) => (
-                <Link
-                  key={m.id}
-                  to={`/matches/${m.id}`}
-                  data-testid={`dashboard-match-${m.id}`}
-                  className="block border border-white/10 rounded-sm p-3 hover:border-[#29B6E8]/60 transition"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="text-sm text-white">{m.tournament_title || m.round_name || `Runde ${m.round}`}</div>
-                    <StatusBadge status={m.status} />
-                  </div>
-                  {m.tournament_title && <div className="text-xs text-white/45 mt-1">{m.round_name || `Runde ${m.round || "-"}`}</div>}
-                  {m.scheduled_at && <div className="text-xs text-white/50 mt-1">{new Date(m.scheduled_at).toLocaleString("de-DE")}</div>}
-                  <div className="mt-2 text-[10px] font-bold uppercase tracking-wider text-[#29B6E8]">Match öffnen · Ergebnis direkt erfassen</div>
-                </Link>
-              ))}
+              {matches.map((m) => <DashboardMatchCard key={m.id} match={m} testId={`dashboard-match-${m.id}`} />)}
             </div>
           </div>
           <div className="border border-white/10 rounded-sm bg-[#121212] p-5">
@@ -149,6 +150,15 @@ export default function DashboardPage() {
             </div>
           </div>
         </div>
+
+        {staffMatches.length > 0 && (
+          <div className="mt-6 border border-[#FFD700]/25 rounded-sm bg-[#121212] p-5" data-testid="dashboard-staff-matches">
+            <h2 className="font-heading text-xl font-bold uppercase mb-4 flex items-center gap-2"><Trophy className="w-4 h-4 text-[#FFD700]" /> Turnierleitung · Ergebnisse</h2>
+            <div className="grid md:grid-cols-2 gap-3">
+              {staffMatches.map((match) => <DashboardMatchCard key={match.id} match={match} staff />)}
+            </div>
+          </div>
+        )}
 
         <div className="mt-8 grid sm:grid-cols-2 md:grid-cols-3 gap-4">
           {openPrizes > 0 && (
@@ -246,5 +256,34 @@ export default function DashboardPage() {
         </div>
       </div>
     </PublicLayout>
+  );
+}
+
+function DashboardMatchCard({ match, staff = false, testId }) {
+  const details = [
+    match.opponent_name || (match.participant_names || []).join(" · "),
+    match.round_name || (match.round ? `Runde ${match.round}` : ""),
+    match.station_label ? `Station ${match.station_label}` : "",
+  ].filter(Boolean);
+  const attention = Boolean(match.needs_result);
+  const action = staff && match.can_submit_result
+    ? "Ergebnis erfassen"
+    : attention
+      ? "Ergebnis öffnen"
+      : "Match öffnen";
+  return (
+    <Link
+      to={`/matches/${match.id}`}
+      data-testid={testId}
+      className={`block border rounded-sm p-3 transition ${attention ? "border-[#FFD700]/45 bg-[#FFD700]/5 hover:border-[#FFD700]" : "border-white/10 hover:border-[#29B6E8]/60"}`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-sm text-white font-bold">{match.tournament_title || "Turniermatch"}</div>
+        <StatusBadge status={match.status} />
+      </div>
+      {details.length > 0 && <div className="text-xs text-white/50 mt-1">{details.join(" · ")}</div>}
+      {match.scheduled_at && <div className="text-xs text-white/45 mt-1">{new Date(match.scheduled_at).toLocaleString("de-DE")}</div>}
+      <div className={`mt-2 text-[10px] font-bold uppercase tracking-wider ${attention ? "text-[#FFD700]" : "text-[#29B6E8]"}`}>{action}</div>
+    </Link>
   );
 }

--- a/mobile/src/screens/main/DashboardScreen.tsx
+++ b/mobile/src/screens/main/DashboardScreen.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import type { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import React, { useCallback, useMemo, useState } from "react";
 import { Linking, Pressable, RefreshControl, ScrollView, StyleSheet, View } from "react-native";
 import { Card } from "../../components/Card";
 import { ContentCard } from "../../components/ContentCard";
@@ -14,7 +15,7 @@ import { displayName, formatDate, formatStatus } from "../../lib/format";
 import { isGuestUser } from "../../live";
 import type { MainTabParamList } from "../../navigation/types";
 import { colors } from "../../theme";
-import type { ClubEvent, DashboardAction, LiveStream, MobileDashboardData, NewsPost, Tournament } from "../../types";
+import type { ClubEvent, DashboardAction, LiveStream, Match, MobileDashboardData, NewsPost, Tournament } from "../../types";
 
 type Props = BottomTabScreenProps<MainTabParamList, "Dashboard">;
 type TimelineItem = {
@@ -36,11 +37,11 @@ type QuickActionItem = {
 };
 
 const emptyDashboard: MobileDashboardData = {
-  me: { tournaments: [], events: [], matches: [], actions: [] },
+  me: { tournaments: [], events: [], matches: [], staff_matches: [], actions: [] },
   public: { tournaments: [], events: [] },
   news: [],
   streams: [],
-  stats: { my_tournaments: 0, my_events: 0, open_matches: 0, open_actions: 0, news: 0, public_tournaments: 0, public_events: 0, live_streams: 0 },
+  stats: { my_tournaments: 0, my_events: 0, open_matches: 0, staff_matches: 0, open_actions: 0, news: 0, public_tournaments: 0, public_events: 0, live_streams: 0 },
 };
 const OPEN_MATCH_STATUSES = new Set(["ready", "scheduled", "in_progress", "waiting_result"]);
 
@@ -50,6 +51,7 @@ function normalizeDashboard(payload?: Partial<MobileDashboardData> | null): Mobi
       tournaments: Array.isArray(payload?.me?.tournaments) ? payload.me.tournaments : [],
       events: Array.isArray(payload?.me?.events) ? payload.me.events : [],
       matches: Array.isArray(payload?.me?.matches) ? payload.me.matches : [],
+      staff_matches: Array.isArray(payload?.me?.staff_matches) ? payload.me.staff_matches : [],
       actions: Array.isArray(payload?.me?.actions) ? payload.me.actions : [],
     },
     public: {
@@ -103,11 +105,11 @@ export function DashboardScreen({ navigation }: Props) {
     }
   }, [isGuest, refreshMe]);
 
-  useEffect(() => {
-    load();
-    const timer = setInterval(load, 10000);
+  useFocusEffect(useCallback(() => {
+    void load();
+    const timer = setInterval(() => void load(), 10000);
     return () => clearInterval(timer);
-  }, [load]);
+  }, [load]));
 
   const timeline = useMemo(() => {
     const source = isGuest
@@ -197,6 +199,31 @@ export function DashboardScreen({ navigation }: Props) {
           <Stat label="News" value={String(data.stats.news)} />
         </View>
 
+        {!isGuest && data.me.matches.length ? (
+          <Section title="Meine aktiven Matches">
+            {data.me.matches.slice(0, 6).map((match) => (
+              <MatchOverviewCard
+                key={match.id}
+                match={match}
+                onPress={() => navigation.navigate("Tournaments", { screen: "MatchDetail", params: { id: match.id } })}
+              />
+            ))}
+          </Section>
+        ) : null}
+
+        {!isGuest && data.me.staff_matches.length ? (
+          <Section title="Turnierleitung · Ergebnisse">
+            {data.me.staff_matches.slice(0, 6).map((match) => (
+              <MatchOverviewCard
+                key={`staff-${match.id}`}
+                match={match}
+                staff
+                onPress={() => navigation.navigate("Tournaments", { screen: "MatchDetail", params: { id: match.id } })}
+              />
+            ))}
+          </Section>
+        ) : null}
+
         <Section title="Schnellzugriff">
           <View style={styles.quickGrid}>
             {quickActions.map((action) => (
@@ -251,19 +278,6 @@ export function DashboardScreen({ navigation }: Props) {
             ) : (
               <EmptyState icon="checkmark-circle-outline" title="Keine offenen Aktionen" detail="Check-ins, offene Matches und wichtige Hinweise landen automatisch hier." />
             )}
-          </Section>
-        ) : null}
-
-        {!isGuest && data.me.matches.length ? (
-          <Section title="Nächste Matches">
-            {data.me.matches.slice(0, 4).map((match) => (
-              <Pressable key={match.id} onPress={() => navigation.navigate("Tournaments", { screen: "MatchDetail", params: { id: match.id } })} style={({ pressed }) => [pressed && styles.pressed]}>
-                <Card style={styles.compactCard}>
-                  <Body style={styles.rowTitle}>{match.tournament_title || match.opponent_name || "Match"}</Body>
-                  <Muted>{formatDate(match.scheduled_at)} · {match.round_name || formatStatus(match.status)}</Muted>
-                </Card>
-              </Pressable>
-            ))}
           </Section>
         ) : null}
 
@@ -413,6 +427,39 @@ function TimelineCard({ item, onPress }: { item: TimelineItem; onPress: () => vo
   );
 }
 
+function MatchOverviewCard({ match, onPress, staff = false }: { match: Match; onPress: () => void; staff?: boolean }) {
+  const detail = [
+    match.opponent_name || match.participant_names?.join(" · "),
+    match.round_name || (match.round ? `Runde ${match.round}` : null),
+    match.station_label ? `Station ${match.station_label}` : null,
+  ].filter(Boolean).join(" · ");
+  const action = staff && match.can_submit_result
+    ? "Ergebnis erfassen"
+    : match.needs_result
+      ? "Ergebnis öffnen"
+      : "Match öffnen";
+
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [pressed && styles.pressed]}>
+      <Card style={[styles.matchCard, match.needs_result && styles.matchCardUrgent]}>
+        <View style={styles.matchIcon}>
+          <Ionicons name={match.needs_result ? "create-outline" : "game-controller-outline"} color={match.needs_result ? colors.gold : colors.cyan} size={20} />
+        </View>
+        <View style={styles.flex}>
+          <View style={styles.rowTop}>
+            <Body style={styles.rowTitle}>{match.tournament_title || "Turniermatch"}</Body>
+            <Badge label={formatStatus(match.status)} tone={match.needs_result ? "gold" : "cyan"} />
+          </View>
+          {detail ? <Muted numberOfLines={2}>{detail}</Muted> : null}
+          <Muted>{formatDate(match.scheduled_at)}</Muted>
+          <Muted style={match.needs_result ? styles.matchActionUrgent : styles.matchAction}>{action}</Muted>
+        </View>
+        <Ionicons name="chevron-forward" color={colors.muted} size={18} />
+      </Card>
+    </Pressable>
+  );
+}
+
 function NewsCard({ post, onPress }: { post: NewsPost; onPress: () => void }) {
   const detail = [post.category, post.excerpt || post.summary].filter(Boolean).join(" · ");
 
@@ -558,8 +605,34 @@ const styles = StyleSheet.create({
     fontWeight: "900",
     textTransform: "uppercase",
   },
-  compactCard: {
-    gap: 4,
+  matchCard: {
+    alignItems: "center",
+    borderColor: "rgba(41,182,232,0.26)",
+    flexDirection: "row",
+    gap: 12,
+  },
+  matchCardUrgent: {
+    borderColor: "rgba(240,180,41,0.48)",
+  },
+  matchIcon: {
+    alignItems: "center",
+    backgroundColor: "rgba(41,182,232,0.1)",
+    borderRadius: 9,
+    height: 42,
+    justifyContent: "center",
+    width: 42,
+  },
+  matchAction: {
+    color: colors.cyan,
+    fontSize: 11,
+    fontWeight: "900",
+    textTransform: "uppercase",
+  },
+  matchActionUrgent: {
+    color: colors.gold,
+    fontSize: 11,
+    fontWeight: "900",
+    textTransform: "uppercase",
   },
   actionCard: {
     alignItems: "center",

--- a/mobile/src/screens/main/MatchDetailScreen.tsx
+++ b/mobile/src/screens/main/MatchDetailScreen.tsx
@@ -1,4 +1,6 @@
+import { Ionicons } from "@expo/vector-icons";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { useFocusEffect } from "@react-navigation/native";
 import React, { useCallback, useEffect, useState } from "react";
 import { Alert, KeyboardAvoidingView, Platform, Pressable, RefreshControl, ScrollView, StyleSheet, View } from "react-native";
 import { Button } from "../../components/Button";
@@ -10,6 +12,7 @@ import { Screen } from "../../components/Screen";
 import { Body, Heading, Muted, Title } from "../../components/Text";
 import { useAuth } from "../../auth/AuthContext";
 import { api, errorMessage } from "../../lib/api";
+import { invalidateCache } from "../../lib/cache";
 import {
   formatDate,
   formatDateTime,
@@ -90,6 +93,7 @@ export function MatchDetailScreen({ navigation, route }: Props) {
   const [refreshing, setRefreshing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
   const [proposalAt, setProposalAt] = useState("");
   const [proposalNote, setProposalNote] = useState("");
   const [counterAt, setCounterAt] = useState("");
@@ -131,7 +135,6 @@ export function MatchDetailScreen({ navigation, route }: Props) {
       }
     } catch (err) {
       setError(errorMessage(err, "Match konnte nicht geladen werden."));
-      setPage(null);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -152,15 +155,24 @@ export function MatchDetailScreen({ navigation, route }: Props) {
     setForfeitReason("");
     setForfeitWinnerId("");
     setV2Rows([]);
+    setSuccess("");
   }, [route.params.id]);
 
-  useEffect(() => {
-    load({ preserveDrafts: false });
+  useFocusEffect(useCallback(() => {
+    void load({ preserveDrafts: false });
     const timer = setInterval(() => {
       void load();
     }, 10000);
     return () => clearInterval(timer);
-  }, [load]);
+  }, [load]));
+
+  const refreshAfterResult = useCallback(async () => {
+    await Promise.all([
+      invalidateCache("/mobile/dashboard"),
+      invalidateCache(`/matches/${route.params.id}`),
+    ]);
+    await load({ preserveDrafts: false });
+  }, [load, route.params.id]);
 
   const match = page?.match || {};
   const participants = page?.participants || [];
@@ -259,6 +271,7 @@ export function MatchDetailScreen({ navigation, route }: Props) {
     const winnerId = a > b ? duelParticipants[0]?.registration_id : b > a ? duelParticipants[1]?.registration_id : null;
     setBusy(true);
     setError("");
+    setSuccess("");
     try {
       if (canStaffSubmitResult) {
         await api.patch(`/matches/${route.params.id}`, {
@@ -277,18 +290,20 @@ export function MatchDetailScreen({ navigation, route }: Props) {
       }
       setProofUrl("");
       setResultNote("");
-      await load({ preserveDrafts: false });
+      await refreshAfterResult();
+      setSuccess(canStaffSubmitResult ? "Ergebnis gespeichert und Matchstand aktualisiert." : "Ergebnis gemeldet und Matchstand aktualisiert.");
     } catch (err) {
       setError(errorMessage(err, "Ergebnis konnte nicht gemeldet werden."));
     } finally {
       setBusy(false);
     }
-  }, [busy, canStaffSubmitResult, canSubmitLegacyResult, duelParticipants, load, proofUrl, resultNote, route.params.id, scoreA, scoreB]);
+  }, [busy, canStaffSubmitResult, canSubmitLegacyResult, duelParticipants, proofUrl, refreshAfterResult, resultNote, route.params.id, scoreA, scoreB]);
 
   const submitV2Result = useCallback(async () => {
     if (!canSubmitV2Result || busy) return;
     setBusy(true);
     setError("");
+    setSuccess("");
     try {
       await api.post(`/matches/${route.params.id}/result`, {
         proof_url: proofUrl.trim() || null,
@@ -304,13 +319,14 @@ export function MatchDetailScreen({ navigation, route }: Props) {
       });
       setProofUrl("");
       setResultNote("");
-      await load({ preserveDrafts: false });
+      await refreshAfterResult();
+      setSuccess("Heat-Ergebnis gespeichert und Matchstand aktualisiert.");
     } catch (err) {
       setError(errorMessage(err, "Heat-Ergebnis konnte nicht gespeichert werden."));
     } finally {
       setBusy(false);
     }
-  }, [busy, canSubmitV2Result, load, proofUrl, resultNote, route.params.id, v2Rows]);
+  }, [busy, canSubmitV2Result, proofUrl, refreshAfterResult, resultNote, route.params.id, v2Rows]);
 
   const submitDispute = useCallback(async () => {
     const reason = disputeReason.trim();
@@ -401,6 +417,12 @@ export function MatchDetailScreen({ navigation, route }: Props) {
         </View>
 
         {error ? <Muted style={styles.error}>{error}</Muted> : null}
+        {success ? (
+          <View style={styles.successNotice} accessibilityRole="alert">
+            <Ionicons name="checkmark-circle-outline" color={colors.success} size={20} />
+            <Body style={styles.successText}>{success}</Body>
+          </View>
+        ) : null}
 
         <Card style={styles.card}>
           <Heading>Teilnehmer</Heading>
@@ -776,6 +798,21 @@ const styles = StyleSheet.create({
   },
   error: {
     color: colors.live,
+  },
+  successNotice: {
+    alignItems: "center",
+    backgroundColor: "rgba(0,255,136,0.08)",
+    borderColor: "rgba(0,255,136,0.32)",
+    borderRadius: 8,
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 9,
+    padding: 12,
+  },
+  successText: {
+    color: colors.success,
+    flex: 1,
+    fontWeight: "800",
   },
   flex: {
     flex: 1,

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -124,13 +124,23 @@ export type TeamInvite = {
 
 export type Match = {
   id: string;
+  collection?: "matches" | "matches_v2" | string;
   status?: string;
   scheduled_at?: string | null;
   tournament_id?: string | null;
   tournament_title?: string | null;
+  tournament_slug?: string | null;
   opponent_name?: string | null;
+  participant_names?: string[];
+  participant_count?: number;
   round?: number | string | null;
   round_name?: string | null;
+  match_key?: string | null;
+  station_id?: string | null;
+  station_label?: string | null;
+  is_own_match?: boolean;
+  can_submit_result?: boolean;
+  needs_result?: boolean;
 };
 
 export type Achievement = {
@@ -251,6 +261,7 @@ export type MobileDashboardData = {
     tournaments: Tournament[];
     events: ClubEvent[];
     matches: Match[];
+    staff_matches: Match[];
     actions: DashboardAction[];
   };
   public: {
@@ -263,6 +274,7 @@ export type MobileDashboardData = {
     my_tournaments: number;
     my_events: number;
     open_matches: number;
+    staff_matches: number;
     open_actions: number;
     news: number;
     public_tournaments: number;


### PR DESCRIPTION
## Inhalt

- gemeinsame, datensparsame Match-Übersicht für Web und LionsAPP statt doppelter Abfragelogik
- normale Nutzer sehen ausschließlich ihre eigenen offenen Matches; laufende und auf Ergebnis wartende Matches werden vor geplanten Matches priorisiert
- Gegner, Runde, Station und Handlungsbedarf werden direkt auf den Matchkarten angezeigt
- separater Arbeitsbereich `Turnierleitung · Ergebnisse` für globale und zugewiesene Organisatoren, Referees und Ergebnis-Erfasser
- Staff-Liste respektiert Turnier-, Match-, Phasen-, Gruppen- und Stations-Zuweisungen sowie den aktiven Turnierstatus
- Legacy- und v2-Ergebnisrechte verwenden nun dieselbe scope-genaue Berechtigungsprüfung
- Web und App aktualisieren beim Öffnen bzw. Zurückkehren sofort und pollen nur in der aktiven Ansicht weiter
- Matchdaten werden nach Ergebnisänderungen sofort neu geladen; die App bestätigt den aktualisierten Stand sichtbar
- ein vorübergehender Refresh-/Netzfehler entfernt keine bereits geladene mobile Matchseite mehr
- Vor-Ort- und Ergebnisablauf im Admin-Handbuch ergänzt

## Tests

- Backend: 181 bestanden, 5 übersprungen, 277 abgewählt
- neue Match-Overview-/Rechte-Regressionen: 15 bestanden
- Backend-Compile und pip-audit: bestanden, keine bekannten Schwachstellen
- Frontend Dependency-Gate und Produktionsbuild: bestanden
- Frontend Unit-Tests: 6 bestanden
- Playwright Desktop/Mobile: 20 bestanden, 8 bewusst übersprungen
- Mobile Audit: 0 Schwachstellen
- Mobile Typecheck und Security-Regressionen: bestanden (3 Tests)
- Expo Doctor: 21/21 bestanden
- git diff --check: bestanden

Closes #45
Closes #50