### PR TITLE
chore: prepare LionsAPP beta 2 build 56

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Validate Expo SDK compatibility
         working-directory: mobile
         run: |
-          npm audit --audit-level=moderate
+          npm run audit:ci
           npx expo install --check
           npx expo-doctor
 

--- a/mobile/CHANGELOG.md
+++ b/mobile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0-beta.2 - 2026-08-12
+
+- Mobile: Das Dashboard priorisiert eigene und betreute offene Matches und fuehrt direkt zur Ergebniserfassung; Erfolgs- und Fehlerfeedback ist in den Match-Workflow integriert.
+- Mobile: Abgeschlossene Turniere stellen Sieger, Podium, finale Rangliste, Abschlusszeit und Turnierstatistiken in den Vordergrund; alte Matches erscheinen als kompakte Historie.
+- Backend/Web/Mobile: E-Mail, Push und In-App lassen sich global sowie je Thema konfigurieren; Deduplizierung und Cooldowns reduzieren wiederholte Hinweise.
+- Release: Android-Build 56 verwendet die aktualisierten Expo-kompatiblen Abhaengigkeiten und das streng begrenzte, befristete Mobile-Audit-Gate.
+
 ## 2.0.0-beta.1 - 2026-06-02
 
 - Backend/Web: Gewinnabholungen koennen fuer veroeffentlichte Turniere und Fast-Lap-Challenges nachtraeglich erzeugt werden; Stage-/Custom-Bracket-Ergebnisse werden dabei korrekt ausgewertet.

--- a/mobile/RELEASES.md
+++ b/mobile/RELEASES.md
@@ -71,6 +71,7 @@ Der Build-Zusatz kommt aus `expo.android.versionCode`. Dadurch ist fuer Tester k
 Historische Einordnung, neueste Version oben:
 
 ```text
+2.0.0-beta.2
 2.0.0-beta.1
 1.5.0-beta.9
 1.5.0-beta.8

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,13 +2,13 @@
   "expo": {
     "name": "LionsAPP",
     "slug": "lionsapp",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0-beta.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
     "ios": {
       "supportsTablet": true,
-      "buildNumber": "55",
+      "buildNumber": "56",
       "bundleIdentifier": "at.lionsquad.app",
       "infoPlist": {
         "NSAppTransportSecurity": {
@@ -18,7 +18,7 @@
     },
     "android": {
       "package": "at.lionsquad.app",
-      "versionCode": 55,
+      "versionCode": 56,
       "googleServicesFile": "./google-services.json",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobile",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/bottom-tabs": "^7.18.15",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Zweck

Bereitet den naechsten LionsAPP-Testbuild vor, nachdem #48 und #49 abgeschlossen und auf `main` verifiziert wurden.

## Aenderungen

- App-Version auf `2.0.0-beta.2` und Android/iOS-Build auf `56`
- Release Notes und Versionshistorie aktualisiert
- Mobile-Release verwendet denselben begrenzten Audit-Gate wie die bereits gruene CI

## Verifikation

- `npm ci`
- `npm run audit:ci`
- `npm run typecheck`
- `npm run test:security`
- `npm run release:preflight`
- `npx expo install --check`
- `npx expo-doctor` (21/21)

Nach gruenem Merge wird `mobile-v2.0.0-beta.2-build56` gesetzt; der vorhandene Release-Workflow baut und veroeffentlicht danach die APK.
