### PR TITLE
fix: enforce canonical public routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
             --add-host backend:127.0.0.1 \
             --volume "$PWD/frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
             nginx:alpine nginx -t
+      - name: Validate public and legacy route contract
+        run: bash scripts/check-public-routes.sh
       - uses: actions/setup-node@v7
         with:
           node-version: "20"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -122,6 +122,11 @@ proxy_max_temp_file_size 0;
 Die Website trennt bewusst zwischen indexierbaren Vereins-/Content-Seiten und nicht wichtigen
 Profil-/Systemseiten.
 
+Der vollstaendige Vertrag fuer kanonische, private, umgeleitete und entfernte Pfade steht in
+[`PUBLIC_ROUTE_INVENTORY.md`](PUBLIC_ROUTE_INVENTORY.md). Der aeussere Reverse Proxy terminiert
+HTTPS und reicht den Pfad unveraendert weiter; `301`-/`410`-Entscheidungen trifft das versionierte
+Frontend-Nginx. Dadurch gelten dieselben Regeln auch nach einem Wechsel des Proxy-Produkts.
+
 Indexierbar und in der Sitemap:
 
 - Startseite, Verein, Vorstand, Werte, Kontakt, Sponsoren, Partner, Galerie, Referenzen

--- a/PUBLIC_ROUTE_INVENTORY.md
+++ b/PUBLIC_ROUTE_INVENTORY.md
@@ -1,0 +1,75 @@
+# Inventar der oeffentlichen Routen
+
+Dieses Dokument ist der Deployment-Vertrag fuer oeffentliche, private, kanonische und alte Website-URLs. Die Anwendung laeuft hinter einem aeusseren Reverse Proxy, der HTTPS terminiert. Dieser Proxy muss den oeffentlichen `Host` bewahren, einen vertrauenswuerdigen `X-Forwarded-Proto`-Wert setzen und Pfade unveraendert an den Frontend-Container weiterreichen. Redirects bleiben in `frontend/nginx.conf`, damit dieselben Regeln unabhaengig vom eingesetzten Proxy-Produkt gelten.
+
+## Kanonische indexierbare Routen
+
+Statische Routen in der XML-Sitemap:
+
+| Zweck | Kanonische Route |
+| --- | --- |
+| Start und Verein | `/`, `/about`, `/board`, `/values`, `/contact` |
+| Inhalte | `/news`, `/events`, `/galerie`, `/references` |
+| eSports | `/esports`, `/tournaments`, `/fastlap` |
+| Community und Verein | `/teams`, `/servers`, `/members`, `/membership/join` |
+| Unterstuetzung | `/sponsors`, `/partners` |
+
+Dynamische Sitemap-Routen sind auf veroeffentlichte/oeffentliche Datensaetze begrenzt:
+
+- `/news/<slug>`
+- `/events/<slug>`
+- `/tournaments/<slug>` sowie `/bracket`, `/matches` und `/standings`
+- `/fastlap/<slug>`
+- `/seasons/<slug>`
+- `/members/<slug>` fuer offizielle Vereinsprofile
+- `/teams/<id>`
+- `/references/<id>`
+- `/galerie/<slug>`
+
+`backend/routes/setup_routes.py` verwaltet die statische Sitemap-Liste und wendet Veroeffentlichungs-/Sichtbarkeitsfilter auf dynamische Datensaetze an. Die Slug-Historie leitet auf den aktuellen kanonischen Slug weiter.
+
+## Oeffentlich, aber bewusst nicht indexiert
+
+Diese Routen bleiben erreichbar, damit Menschen sie verwenden und Crawler `noindex, follow` lesen koennen. Sie stehen nicht in der Sitemap:
+
+- `/privacy` und `/imprint`
+- `/players` und `/u/<username>`
+- `/membership/apply`
+- `/matches/<id>`
+- Login-, Registrierungs- und Passwort-Routen
+
+## Private und betriebliche Routen
+
+`robots.txt` sperrt `/admin/`, `/dashboard`, `/profile`, `/privacy-account`, `/members/area`, die weiteren Mitglieder-Routen, `/my/`, `/setup`, `/display/` und `/api/`. Die Autorisierung bleibt die Sicherheitsgrenze; Robots-Regeln sind nur Hinweise fuer Crawler.
+
+## Permanente Weiterleitungen
+
+| Alter oder doppelter Pfad | Kanonisches Ziel |
+| --- | --- |
+| `/der-verein`, `/ueber-uns` | `/about` |
+| `/datenschutzerklaerung`, `/datenschutz` | `/privacy` |
+| `/impressum` | `/imprint` |
+| `/kontakt` | `/contact` |
+| `/sponsoren` | `/sponsors` |
+| `/partner` | `/partners` |
+| `/mitglieder` | `/members` |
+| `/mitglied-werden`, `/mitgliedschaft` | `/membership/join` |
+| `/turniere` | `/tournaments` |
+| `/gallerie`, `/galerie-2`, `/gallery` und deren Album-Pfade | `/galerie` und der passende Album-Pfad |
+| `/server` | `/servers` |
+| `/spielerprofil/<username>`, `/players/<username>` | `/u/<username>` |
+| `/lan-party-2024` | `/events` |
+| `/f1` und `/f1/<slug>` | `/fastlap` und `/fastlap/<slug>` |
+| `www.lionsquad.at/<path>` | `lionsquad.at/<path>` |
+
+Die SPA besitzt passende clientseitige Fallbacks fuer Aliase, die in der lokalen Entwicklung ohne Nginx geoeffnet werden.
+
+## Entfernte Inhalte
+
+WordPress-/Demo-Familien unter `/elements`, `/product`, `/portfolio`, `/tag`, `/category` und `/author` liefern `410 Gone` mit `X-Robots-Tag: noindex, nofollow`. Sie duerfen nie auf die SPA-Shell zurueckfallen.
+
+## Automatische und manuelle Pruefung
+
+Die CI startet das produktive Nginx-Image und fuehrt `scripts/check-public-routes.sh` aus. Geprueft werden repraesentative kanonische `200`, alte `301`, entfernte `410`, der kanonische Host und der Crawler-Header. Backend-Tests stellen zusaetzlich sicher, dass die Sitemap kanonische Pfade enthaelt und bekannte Aliase ausschliesst.
+
+Nach dem Deployment werden die oeffentliche Proxy-Grenze und Suchmaschinen wie in `OPERATIONS.md` beschrieben geprueft. Aktionen in Google Search Console und Bing Webmaster Tools bleiben bewusst manuell, weil die Repository-CI keinen Zugriff auf diese Konten hat.

--- a/backend/routes/setup_routes.py
+++ b/backend/routes/setup_routes.py
@@ -273,6 +273,11 @@ TOURNAMENT_SITEMAP_PATHS = [
     ("matches", "0.65"),
     ("standings", "0.65"),
 ]
+STATIC_SITEMAP_PATHS = [
+    "/", "/about", "/news", "/events", "/esports", "/tournaments", "/fastlap",
+    "/teams", "/servers", "/members", "/membership/join",
+    "/sponsors", "/partners", "/contact", "/board", "/values", "/galerie", "/references",
+]
 
 
 def _parse_sitemap_dt(value):
@@ -304,11 +309,6 @@ async def sitemap():
     branding = await db.settings.find_one({"id": "branding"}, {"_id": 0}) or {}
     base = _normalise_base_url(branding.get("domain"))
 
-    static_paths = [
-        "/", "/about", "/news", "/events", "/esports", "/tournaments", "/fastlap",
-        "/teams", "/servers", "/members", "/membership/join",
-        "/sponsors", "/partners", "/contact", "/board", "/values", "/galerie", "/references",
-    ]
     urls: list[dict] = [
         {
             "loc": base + p,
@@ -316,7 +316,7 @@ async def sitemap():
             "changefreq": "daily" if p in ("/", "/news", "/events") else "weekly",
             "priority": "1.0" if p == "/" else "0.8" if p in ("/news", "/events", "/esports", "/tournaments", "/fastlap") else "0.6",
         }
-        for p in static_paths
+        for p in STATIC_SITEMAP_PATHS
     ]
 
     # tournaments

--- a/backend/tests/test_sitemap_public_routes.py
+++ b/backend/tests/test_sitemap_public_routes.py
@@ -68,3 +68,16 @@ def test_sitemap_lists_public_tournament_subpages(monkeypatch):
     assert "<loc>https://example.test/tournaments/summer-cup/matches</loc>" in body
     assert "<loc>https://example.test/tournaments/summer-cup/standings</loc>" in body
     assert "<lastmod>2026-05-20</lastmod>" in body
+
+
+def test_static_sitemap_uses_only_canonical_public_paths(monkeypatch):
+    monkeypatch.setattr(setup_routes, "get_db", lambda: _SitemapDb())
+
+    response = asyncio.run(setup_routes.sitemap())
+    body = response.body.decode("utf-8")
+
+    for path in setup_routes.STATIC_SITEMAP_PATHS:
+        assert f"<loc>https://example.test{path}</loc>" in body
+
+    for legacy_path in ("/f1", "/gallery", "/players", "/turniere", "/mitglieder", "/esports/"):
+        assert f"<loc>https://example.test{legacy_path}</loc>" not in body

--- a/backend/tests/test_sitemap_public_routes.py
+++ b/backend/tests/test_sitemap_public_routes.py
@@ -71,7 +71,7 @@ def test_sitemap_lists_public_tournament_subpages(monkeypatch):
 
 
 def test_static_sitemap_uses_only_canonical_public_paths(monkeypatch):
-    monkeypatch.setattr(setup_routes, "get_db", lambda: _SitemapDb())
+    monkeypatch.setattr(setup_routes, "get_db", _SitemapDb)
 
     response = asyncio.run(setup_routes.sitemap())
     body = response.body.decode("utf-8")

--- a/frontend/e2e/public.spec.js
+++ b/frontend/e2e/public.spec.js
@@ -34,6 +34,19 @@ test("public community structure is reachable", async ({ page }) => {
   await expect(page.getByRole("link", { name: /mitglieder öffnen/i })).toBeVisible();
 });
 
+test("legacy SPA aliases converge on canonical routes", async ({ page }) => {
+  for (const [legacy, canonical] of [
+    ["/f1", "/fastlap"],
+    ["/f1/example", "/fastlap/example"],
+    ["/gallery", "/galerie"],
+    ["/gallery/example", "/galerie/example"],
+    ["/players/example", "/u/example"],
+  ]) {
+    await page.goto(legacy);
+    await expect(page).toHaveURL(new RegExp(`${canonical.replaceAll("/", "\\/")}$`));
+  }
+});
+
 test("verein and community navigation are separated", async ({ page, isMobile }) => {
   await page.goto("/");
   await acceptCookies(page);

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -101,9 +101,11 @@ server {
   location ~ ^/turniere/?$ { return 301 https://lionsquad.at/tournaments; }
   location ~ ^/(gallerie|galerie-2)/?$ { return 301 https://lionsquad.at/galerie; }
   location ~ ^/gallerie/(.+)$ { return 301 https://lionsquad.at/galerie/$1; }
-  location ~ ^/esports/?$ { return 301 https://lionsquad.at/tournaments; }
+  location ~ ^/gallery/?$ { return 301 https://lionsquad.at/galerie; }
+  location ~ ^/gallery/(.+)$ { return 301 https://lionsquad.at/galerie/$1; }
   location ~ ^/server/?$ { return 301 https://lionsquad.at/servers; }
   location ~ ^/spielerprofil/([^/?#]+)/?$ { return 301 https://lionsquad.at/u/$1; }
+  location ~ ^/players/([^/?#]+)/?$ { return 301 https://lionsquad.at/u/$1; }
   location ~ ^/lan-party-2024/?$ { return 301 https://lionsquad.at/events; }
   location ~ ^/f1/?$ { return 301 https://lionsquad.at/fastlap; }
   location ~ ^/f1/(.+)$ { return 301 https://lionsquad.at/fastlap/$1; }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,6 +36,16 @@ function FastLapLegacyRedirect() {
   return <Navigate to={slug ? `/fastlap/${slug}` : "/fastlap"} replace />;
 }
 
+function GalleryLegacyRedirect() {
+  const { slug } = useParams();
+  return <Navigate to={slug ? `/galerie/${slug}` : "/galerie"} replace />;
+}
+
+function PlayerLegacyRedirect() {
+  const { username } = useParams();
+  return <Navigate to={`/u/${username}`} replace />;
+}
+
 import HomePage from "@/pages/public/HomePage";
 import TournamentsPage from "@/pages/public/TournamentsPage";
 import TournamentDetailPage from "@/pages/public/TournamentDetailPage";
@@ -233,13 +243,13 @@ function App() {
           <Route path="/seasons/:slug" element={<SeasonPage />} />
           <Route path="/u/me" element={<MeRedirect />} />
           <Route path="/u/:username" element={<PublicProfilePage />} />
-          <Route path="/players/:username" element={<PublicProfilePage />} />
+          <Route path="/players/:username" element={<PlayerLegacyRedirect />} />
           <Route path="/fastlap" element={<F1ListPage />} />
           <Route path="/fastlap/:slug" element={<F1DetailPage />} />
           <Route path="/galerie" element={<GalleryPage />} />
           <Route path="/galerie/:slug" element={<GalleryAlbumPage />} />
-          <Route path="/gallery" element={<GalleryPage />} />
-          <Route path="/gallery/:slug" element={<GalleryAlbumPage />} />
+          <Route path="/gallery" element={<GalleryLegacyRedirect />} />
+          <Route path="/gallery/:slug" element={<GalleryLegacyRedirect />} />
 
           {/* Admin */}
           <Route path="/admin/sponsors" element={<ProtectedRoute requireAdmin><AdminSponsorsPage /></ProtectedRoute>} />

--- a/scripts/check-public-routes.sh
+++ b/scripts/check-public-routes.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container_name="tls-public-routes-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+
+cleanup() {
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run --rm -d \
+  --name "$container_name" \
+  --add-host backend:127.0.0.1 \
+  --publish 127.0.0.1::80 \
+  --volume "$PWD/frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+  --volume "$PWD/frontend/public:/usr/share/nginx/html:ro" \
+  nginx:alpine >/dev/null
+
+port="$(docker port "$container_name" 80/tcp | sed -E 's/.*:([0-9]+)$/\1/')"
+base_url="http://127.0.0.1:${port}"
+
+for attempt in {1..20}; do
+  if curl --silent --fail --head --header "Host: lionsquad.at" "${base_url}/health" >/dev/null; then
+    break
+  fi
+  if test "$attempt" = "20"; then
+    printf 'Nginx route-contract container did not become ready.\n' >&2
+    docker logs "$container_name" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+request_headers() {
+  local path="$1"
+  local host="${2:-lionsquad.at}"
+  curl --silent --show-error --head --header "Host: ${host}" "${base_url}${path}"
+}
+
+expect_status() {
+  local path="$1"
+  local expected="$2"
+  local headers status
+  headers="$(request_headers "$path")"
+  status="$(printf '%s\n' "$headers" | awk 'NR == 1 { print $2 }')"
+  test "$status" = "$expected" || {
+    printf 'Expected %s for %s, received %s\n%s\n' "$expected" "$path" "$status" "$headers" >&2
+    return 1
+  }
+}
+
+expect_redirect() {
+  local path="$1"
+  local target="$2"
+  local host="${3:-lionsquad.at}"
+  local headers status location
+  headers="$(request_headers "$path" "$host")"
+  status="$(printf '%s\n' "$headers" | awk 'NR == 1 { print $2 }')"
+  location="$(printf '%s\n' "$headers" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }')"
+  test "$status" = "301" && test "$location" = "$target" || {
+    printf 'Expected 301 -> %s for %s, received %s -> %s\n%s\n' "$target" "$path" "$status" "$location" "$headers" >&2
+    return 1
+  }
+}
+
+expect_gone() {
+  local path="$1"
+  local headers status robots
+  headers="$(request_headers "$path")"
+  status="$(printf '%s\n' "$headers" | awk 'NR == 1 { print $2 }')"
+  robots="$(printf '%s\n' "$headers" | awk 'BEGIN { IGNORECASE=1 } /^X-Robots-Tag:/ { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }')"
+  test "$status" = "410" && test "$robots" = "noindex, nofollow" || {
+    printf 'Expected 410 with noindex, nofollow for %s, received %s with %s\n%s\n' "$path" "$status" "$robots" "$headers" >&2
+    return 1
+  }
+}
+
+for path in / /about /esports /tournaments /fastlap /galerie /players; do
+  expect_status "$path" 200
+done
+
+while IFS='|' read -r legacy canonical; do
+  expect_redirect "$legacy" "https://lionsquad.at${canonical}"
+done <<'ROUTES'
+/der-verein|/about
+/ueber-uns/|/about
+/datenschutzerklaerung|/privacy
+/datenschutz/|/privacy
+/impressum|/imprint
+/kontakt|/contact
+/sponsoren|/sponsors
+/partner|/partners
+/mitglieder|/members
+/mitglied-werden|/membership/join
+/mitgliedschaft|/membership/join
+/turniere|/tournaments
+/gallerie|/galerie
+/galerie-2|/galerie
+/gallerie/sommerfest|/galerie/sommerfest
+/gallery|/galerie
+/gallery/sommerfest|/galerie/sommerfest
+/server|/servers
+/spielerprofil/tabsi98|/u/tabsi98
+/players/tabsi98|/u/tabsi98
+/lan-party-2024|/events
+/f1|/fastlap
+/f1/monza|/fastlap/monza
+ROUTES
+
+for path in /elements/blockquote/ /product/demo /portfolio/demo /tag/demo /category/demo /author/demo; do
+  expect_gone "$path"
+done
+
+expect_redirect "/esports?view=live" "https://lionsquad.at/esports?view=live" "www.lionsquad.at"
+
+printf 'Public route contract passed.\n'


### PR DESCRIPTION
## Zweck

Beginnt #95 gemaess P0-Reihenfolge mit einem pruefbaren Vertrag fuer kanonische, alte, entfernte und private Web-Routen.

## Behobener Fehler

`/esports` war gleichzeitig kanonische React-/Sitemap-Route und produktiver `301` nach `/tournaments`. Der eSports-Hub war dadurch hinter dem Frontend-Nginx nicht erreichbar.

## Aenderungen

- `/esports` bleibt kanonisch und erreichbar
- doppelte `/gallery/*`- und `/players/<name>`-Pfade konvergieren per Nginx und SPA-Fallback auf `/galerie/*` bzw. `/u/<name>`
- vollstaendiges Routeninventar inklusive Reverse-Proxy-Grenze und manueller Webmaster-Schritte
- statische Sitemap-Routen als expliziter, testbarer Vertrag
- Linux-/Docker-CI prueft reale `200`, `301`, `410`, `Location`, kanonischen Host und `X-Robots-Tag`
- Browser-Smoke prueft Aliase auf Desktop und Mobile

## Verifikation

- Frontend Production Build: gruen
- Frontend Unit-Smokes: 3 Suites / 6 Tests gruen
- Playwright: 22 gruen, 8 erwartete Live-Admin-Skips
- SEO-/Sitemap-Pytest: 12 gruen
- Shell-Syntax und `git diff --check`: gruen

Die Search-Console-/Bing-Checkbox bleibt offen, bis die Aktion extern tatsaechlich ausgefuehrt wurde.

Refs #95
