### PR TITLE
fix: zentrale öffentliche Kontakt- und Rechtsdaten

### DIFF
--- a/backend/routes/extras_routes.py
+++ b/backend/routes/extras_routes.py
@@ -14,6 +14,7 @@ from auth import require_admin, require_role, require_super, get_current_user, g
 from services.visibility import user_can_see
 from services.slug_utils import apply_slug_history, find_by_slug_or_history, slug_source_for_update, unique_slug
 from services.access_links import validate_access_link
+from services.public_site_settings import PUBLIC_LEGAL_SOURCE_FIELDS, build_public_legal_settings
 from models import now_utc, new_id
 from email_service import send_template, _get_email_config
 from pdf_service import (
@@ -534,10 +535,9 @@ async def public_settings(response: Response):
     tagline = b.get("tagline", "eSports Verein")
     if str(tagline).strip().lower() == "esports arena":
         tagline = "eSports Verein"
-    city = b.get("city") or ""
-    state = b.get("state") or "Tirol"
-    country = b.get("country") or "Österreich"
-    contact_email = b.get("contact_email") or "office@lionsquad.at"
+    legal_settings = build_public_legal_settings(b)
+    legal_settings.pop("contact_ready", None)
+    legal_settings.pop("missing_legal_fields", None)
     return {
         "club_name": b.get("club_name", "THE LION SQUAD"),
         "tagline": tagline,
@@ -555,32 +555,7 @@ async def public_settings(response: Response):
         "favicon_dark_url": b.get("favicon_dark_url"),
         "domain": domain,
         "timezone": b.get("timezone") or "Europe/Vienna",
-        "contact_email": contact_email,
-        "imprint": b.get("imprint"),
-        "privacy_policy": b.get("privacy_policy"),
-        "legal_name": b.get("legal_name") or b.get("club_name") or "THE LION SQUAD eSports",
-        "legal_form": b.get("legal_form") or "eingetragener Verein nach österreichischem Vereinsrecht",
-        "zvr_number": b.get("zvr_number") or "",
-        "street_address": b.get("street_address") or "",
-        "address_extra": b.get("address_extra") or "",
-        "postal_code": b.get("postal_code") or "",
-        "city": city,
-        "state": state,
-        "country": country,
-        "registered_seat": b.get("registered_seat") or city or state,
-        "register_authority": b.get("register_authority") or "Vereinsbehörde am Vereinssitz in Tirol",
-        "representative_name": b.get("representative_name") or "",
-        "representative_role": b.get("representative_role") or "Obmann/Obfrau bzw. vertretungsbefugtes Vereinsorgan",
-        "content_responsible": b.get("content_responsible") or b.get("representative_name") or "",
-        "phone": b.get("phone") or "",
-        "privacy_contact_email": b.get("privacy_contact_email") or contact_email,
-        "hosting_provider": b.get("hosting_provider") or "",
-        "hosting_country": b.get("hosting_country") or "Österreich/EU",
-        "vat_number": b.get("vat_number") or "",
-        "tournament_terms_url": b.get("tournament_terms_url") or "",
-        "paid_tournaments_enabled": bool(b.get("paid_tournaments_enabled", False)),
-        "legal_extra": b.get("legal_extra") or "",
-        "privacy_extra": b.get("privacy_extra") or "",
+        **legal_settings,
         "discord_invite_url": b.get("discord_invite_url") or "https://discord.com/invite/thelionsquadesports",
         "twitch_channel": b.get("twitch_channel") or "the_lion_squad_esports",
         "whatsapp_channel_url": b.get("whatsapp_channel_url") or "https://whatsapp.com/channel/0029VaaWufTGU3BNG6VOxo1I",
@@ -982,6 +957,8 @@ async def update_branding(body: BrandingSettings, me: dict = Depends(require_adm
     if not changed_fields:
         return current or {"ok": True, "changed": False}
     updates["updated_at"] = now_utc().isoformat()
+    if set(changed_fields) & PUBLIC_LEGAL_SOURCE_FIELDS:
+        updates["legal_updated_at"] = updates["updated_at"]
     await db.settings.update_one(
         {"id": "branding"}, {"$set": updates, "$setOnInsert": {"id": "branding"}}, upsert=True,
     )

--- a/backend/routes/setup_routes.py
+++ b/backend/routes/setup_routes.py
@@ -11,6 +11,7 @@ import bcrypt
 from database import get_db
 from auth import require_admin, require_super, get_current_user
 from models import MIN_PASSWORD_LENGTH, now_utc, new_id
+from services.public_site_settings import build_public_legal_settings
 
 router = APIRouter(prefix="/api/setup", tags=["setup"])
 HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
@@ -56,13 +57,14 @@ def _truthy_mail_config(mail: dict, legacy_email: dict) -> bool:
 
 
 def _setup_checks(s: dict, branding: dict, mail: dict, legacy_email: dict, has_admin: bool) -> list[dict]:
+    public_legal = build_public_legal_settings(branding)
     return [
         {"key": "admin", "label": "Superadmin vorhanden", "ok": has_admin, "target": "/admin/users"},
         {"key": "completed", "label": "Setup abgeschlossen", "ok": bool(s.get("completed")), "target": "/setup"},
         {"key": "club_name", "label": "Vereinsname gepflegt", "ok": bool(branding.get("club_name")), "target": "/admin/settings?tab=brand"},
         {"key": "domain", "label": "Öffentliche Domain gesetzt", "ok": bool(branding.get("domain")), "target": "/admin/settings?tab=brand"},
-        {"key": "contact_email", "label": "Kontakt-E-Mail gesetzt", "ok": bool(branding.get("contact_email")), "target": "/admin/settings?tab=brand"},
-        {"key": "legal", "label": "Impressum/Datenschutz ergänzt", "ok": bool(branding.get("imprint") or branding.get("privacy_policy")), "target": "/admin/settings?tab=legal"},
+        {"key": "contact_email", "label": "Kontakt-E-Mail gesetzt", "ok": public_legal["contact_ready"], "target": "/admin/settings?tab=brand"},
+        {"key": "legal", "label": "Impressum/Datenschutz vollständig", "ok": public_legal["legal_ready"], "target": "/admin/settings?tab=legal"},
         {"key": "mail", "label": "E-Mail-Versand konfiguriert", "ok": _truthy_mail_config(mail, legacy_email), "target": "/admin/settings?tab=smtp"},
     ]
 
@@ -186,6 +188,8 @@ async def complete_setup(body: SetupWizardBody, me: dict = Depends(require_super
     brand_updates = {k: getattr(body, k) for k in brand_keys if getattr(body, k) is not None}
     if brand_updates:
         brand_updates["updated_at"] = now_iso
+        if {"club_name", "domain", "contact_email", "imprint", "privacy_policy"} & set(brand_updates):
+            brand_updates["legal_updated_at"] = now_iso
         await db.settings.update_one(
             {"id": "branding"},
             {"$set": brand_updates, "$setOnInsert": {"id": "branding"}},

--- a/backend/services/public_site_settings.py
+++ b/backend/services/public_site_settings.py
@@ -1,0 +1,156 @@
+"""Canonical public contact and legal settings derived from the branding document."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+PUBLIC_LEGAL_SOURCE_FIELDS = frozenset({
+    "club_name",
+    "domain",
+    "contact_email",
+    "imprint",
+    "privacy_policy",
+    "legal_name",
+    "legal_form",
+    "zvr_number",
+    "street_address",
+    "address_extra",
+    "postal_code",
+    "city",
+    "state",
+    "country",
+    "registered_seat",
+    "register_authority",
+    "representative_name",
+    "representative_role",
+    "content_responsible",
+    "phone",
+    "privacy_contact_email",
+    "hosting_provider",
+    "hosting_country",
+    "vat_number",
+    "tournament_terms_url",
+    "paid_tournaments_enabled",
+    "legal_extra",
+    "privacy_extra",
+})
+
+PUBLIC_LEGAL_REQUIRED_FIELDS = (
+    "legal_name",
+    "legal_form",
+    "zvr_number",
+    "street_address",
+    "postal_code",
+    "city",
+    "country",
+    "registered_seat",
+    "register_authority",
+    "representative_name",
+    "representative_role",
+    "content_responsible",
+    "contact_email",
+    "privacy_contact_email",
+)
+
+_PLACEHOLDER_VALUES = {
+    "-",
+    "demo",
+    "example",
+    "image: null",
+    "lorem ipsum",
+    "n/a",
+    "na",
+    "none",
+    "noch im adminbereich zu hinterlegen",
+    "not set",
+    "null",
+    "test",
+    "todo",
+    "tbd",
+    "undefined",
+}
+_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+_RESERVED_EMAIL_DOMAINS = ("example.com", "example.org", "example.net", "example.test", "test", "invalid", "localhost")
+
+
+def public_text(value: Any) -> str:
+    """Return configured public text while suppressing common seed placeholders."""
+    text = str(value or "").strip()
+    if not text or text.casefold() in _PLACEHOLDER_VALUES:
+        return ""
+    return text
+
+
+def public_email(value: Any) -> str:
+    """Return only a plausible configured public email address."""
+    email = public_text(value)
+    if not _EMAIL_RE.fullmatch(email):
+        return ""
+    domain = email.rsplit("@", 1)[1].casefold().rstrip(".")
+    if domain in _RESERVED_EMAIL_DOMAINS or any(domain.endswith(f".{item}") for item in _RESERVED_EMAIL_DOMAINS):
+        return ""
+    return email
+
+
+def _merge_unique_text(*values: Any) -> str:
+    blocks: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = public_text(value)
+        key = " ".join(text.split()).casefold()
+        if text and key not in seen:
+            seen.add(key)
+            blocks.append(text)
+    return "\n\n".join(blocks)
+
+
+def build_public_legal_settings(branding: dict[str, Any] | None) -> dict[str, Any]:
+    """Build the sole public contact/legal contract from the branding document.
+
+    Old imprint/privacy free-text fields are retained as additional content, but
+    folded into one output field each so they can never be rendered twice.
+    """
+    source = branding or {}
+    contact_email = public_email(source.get("contact_email"))
+    privacy_contact_email = public_email(source.get("privacy_contact_email")) or contact_email
+    representative_name = public_text(source.get("representative_name"))
+    city = public_text(source.get("city"))
+
+    result: dict[str, Any] = {
+        "contact_email": contact_email,
+        "legal_name": public_text(source.get("legal_name")) or public_text(source.get("club_name")),
+        "legal_form": public_text(source.get("legal_form")),
+        "zvr_number": public_text(source.get("zvr_number")),
+        "street_address": public_text(source.get("street_address")),
+        "address_extra": public_text(source.get("address_extra")),
+        "postal_code": public_text(source.get("postal_code")),
+        "city": city,
+        "state": public_text(source.get("state")),
+        "country": public_text(source.get("country")),
+        "registered_seat": public_text(source.get("registered_seat")) or city,
+        "register_authority": public_text(source.get("register_authority")),
+        "representative_name": representative_name,
+        "representative_role": public_text(source.get("representative_role")),
+        "content_responsible": public_text(source.get("content_responsible")) or representative_name,
+        "phone": public_text(source.get("phone")),
+        "privacy_contact_email": privacy_contact_email,
+        "hosting_provider": public_text(source.get("hosting_provider")),
+        "hosting_country": public_text(source.get("hosting_country")),
+        "vat_number": public_text(source.get("vat_number")),
+        "tournament_terms_url": public_text(source.get("tournament_terms_url")),
+        "paid_tournaments_enabled": bool(source.get("paid_tournaments_enabled", False)),
+        "legal_extra": _merge_unique_text(source.get("legal_extra"), source.get("imprint")),
+        "privacy_extra": _merge_unique_text(source.get("privacy_extra"), source.get("privacy_policy")),
+        "legal_updated_at": public_text(source.get("legal_updated_at") or source.get("updated_at")),
+    }
+    missing = [field for field in PUBLIC_LEGAL_REQUIRED_FIELDS if not result.get(field)]
+    result["contact_ready"] = bool(contact_email)
+    result["legal_ready"] = not missing
+    result["missing_legal_fields"] = missing
+    return result
+
+
+def missing_public_legal_fields(branding: dict[str, Any] | None) -> list[str]:
+    return list(build_public_legal_settings(branding)["missing_legal_fields"])

--- a/backend/services/public_site_settings.py
+++ b/backend/services/public_site_settings.py
@@ -143,7 +143,7 @@ def build_public_legal_settings(branding: dict[str, Any] | None) -> dict[str, An
         "paid_tournaments_enabled": bool(source.get("paid_tournaments_enabled", False)),
         "legal_extra": _merge_unique_text(source.get("legal_extra"), source.get("imprint")),
         "privacy_extra": _merge_unique_text(source.get("privacy_extra"), source.get("privacy_policy")),
-        "legal_updated_at": public_text(source.get("legal_updated_at") or source.get("updated_at")),
+        "legal_updated_at": public_text(source.get("legal_updated_at")),
     }
     missing = [field for field in PUBLIC_LEGAL_REQUIRED_FIELDS if not result.get(field)]
     result["contact_ready"] = bool(contact_email)

--- a/backend/tests/test_public_site_settings_unit.py
+++ b/backend/tests/test_public_site_settings_unit.py
@@ -30,6 +30,7 @@ COMPLETE_BRANDING = {
     "phone": "+43 123 456",
     "hosting_provider": "Eigenhosting",
     "hosting_country": "Österreich/EU",
+    "legal_updated_at": "2026-08-12T10:00:00+00:00",
     "updated_at": "2026-08-12T10:00:00+00:00",
 }
 
@@ -59,7 +60,7 @@ def test_canonical_contract_uses_configured_values_and_folds_legacy_text_once():
     assert result["privacy_extra"] == "Neuer Zusatz\n\nBestehender Datenschutztext"
     assert result["legal_ready"] is True
     assert result["missing_legal_fields"] == []
-    assert result["legal_updated_at"] == COMPLETE_BRANDING["updated_at"]
+    assert result["legal_updated_at"] == COMPLETE_BRANDING["legal_updated_at"]
 
 
 def test_missing_contact_is_not_replaced_with_a_fabricated_address():

--- a/backend/tests/test_public_site_settings_unit.py
+++ b/backend/tests/test_public_site_settings_unit.py
@@ -1,0 +1,104 @@
+import asyncio
+from types import SimpleNamespace
+
+from fastapi import Response
+
+import routes.extras_routes as extras_routes
+from routes.setup_routes import _setup_checks
+from services.public_site_settings import build_public_legal_settings, public_email, public_text
+
+
+COMPLETE_BRANDING = {
+    "id": "branding",
+    "club_name": "THE LION SQUAD - eSPORTS",
+    "domain": "https://lionsquad.at",
+    "contact_email": "office@lionsquad.at",
+    "privacy_contact_email": "dsgvo@lionsquad.at",
+    "legal_name": "THE LION SQUAD - eSPORTS",
+    "legal_form": "eingetragener Verein",
+    "zvr_number": "1234567890",
+    "street_address": "Vereinsstraße 1",
+    "postal_code": "6410",
+    "city": "Telfs",
+    "state": "Tirol",
+    "country": "Österreich",
+    "registered_seat": "Telfs",
+    "register_authority": "Bezirkshauptmannschaft Innsbruck",
+    "representative_name": "Vereinsvertretung",
+    "representative_role": "Obmann",
+    "content_responsible": "Vereinsvertretung",
+    "phone": "+43 123 456",
+    "hosting_provider": "Eigenhosting",
+    "hosting_country": "Österreich/EU",
+    "updated_at": "2026-08-12T10:00:00+00:00",
+}
+
+
+def test_public_values_suppress_internal_and_reserved_placeholders():
+    for value in (None, "", "Image: null", "TODO", "Noch im Adminbereich zu hinterlegen"):
+        assert public_text(value) == ""
+    for value in ("demo@example.com", "person@example.test", "not-an-email"):
+        assert public_email(value) == ""
+    assert public_email("office@lionsquad.at") == "office@lionsquad.at"
+
+
+def test_canonical_contract_uses_configured_values_and_folds_legacy_text_once():
+    branding = {
+        **COMPLETE_BRANDING,
+        "imprint": "Alter Zusatz",
+        "legal_extra": "Alter Zusatz",
+        "privacy_policy": "Bestehender Datenschutztext",
+        "privacy_extra": "Neuer Zusatz",
+    }
+
+    result = build_public_legal_settings(branding)
+
+    assert result["contact_email"] == "office@lionsquad.at"
+    assert result["privacy_contact_email"] == "dsgvo@lionsquad.at"
+    assert result["legal_extra"] == "Alter Zusatz"
+    assert result["privacy_extra"] == "Neuer Zusatz\n\nBestehender Datenschutztext"
+    assert result["legal_ready"] is True
+    assert result["missing_legal_fields"] == []
+    assert result["legal_updated_at"] == COMPLETE_BRANDING["updated_at"]
+
+
+def test_missing_contact_is_not_replaced_with_a_fabricated_address():
+    result = build_public_legal_settings({"club_name": "THE LION SQUAD", "contact_email": "demo@example.com"})
+
+    assert result["contact_email"] == ""
+    assert result["privacy_contact_email"] == ""
+    assert result["contact_ready"] is False
+    assert result["legal_ready"] is False
+    assert "contact_email" in result["missing_legal_fields"]
+
+
+def test_setup_health_uses_structured_legal_data_instead_of_legacy_free_text():
+    checks = _setup_checks({"completed": True}, COMPLETE_BRANDING, {}, {}, True)
+    by_key = {check["key"]: check for check in checks}
+    assert by_key["legal"]["ok"] is True
+    assert by_key["contact_email"]["ok"] is True
+
+    legacy_only = {"club_name": "TLS", "domain": "https://lionsquad.at", "imprint": "Text", "privacy_policy": "Text"}
+    legacy_checks = _setup_checks({"completed": True}, legacy_only, {}, {}, True)
+    legacy_by_key = {check["key"]: check for check in legacy_checks}
+    assert legacy_by_key["legal"]["ok"] is False
+    assert legacy_by_key["contact_email"]["ok"] is False
+
+
+class _SettingsCollection:
+    async def find_one(self, *args, **kwargs):
+        return {**COMPLETE_BRANDING, "imprint": "Nur einmal", "legal_extra": "Nur einmal"}
+
+
+def test_public_endpoint_exposes_canonical_contract_without_legacy_fields(monkeypatch):
+    monkeypatch.setattr(extras_routes, "get_db", lambda: SimpleNamespace(settings=_SettingsCollection()))
+
+    payload = asyncio.run(extras_routes.public_settings(Response()))
+
+    assert payload["contact_email"] == "office@lionsquad.at"
+    assert payload["legal_extra"] == "Nur einmal"
+    assert payload["legal_ready"] is True
+    assert "imprint" not in payload
+    assert "privacy_policy" not in payload
+    assert "missing_legal_fields" not in payload
+    assert "contact_ready" not in payload

--- a/frontend/e2e/public.spec.js
+++ b/frontend/e2e/public.spec.js
@@ -25,6 +25,77 @@ async function expectNoPageXOverflow(page) {
   expect(overflow).toBeLessThanOrEqual(1);
 }
 
+const canonicalPublicSettings = {
+  club_name: "THE LION SQUAD - eSPORTS",
+  tagline: "Verein",
+  domain: "https://lionsquad.at",
+  contact_email: "kontakt@lionsquad.at",
+  privacy_contact_email: "datenschutz@lionsquad.at",
+  legal_name: "THE LION SQUAD - eSPORTS",
+  legal_form: "eingetragener Verein",
+  zvr_number: "1234567890",
+  street_address: "Vereinsstraße 1",
+  postal_code: "6410",
+  city: "Telfs",
+  state: "Tirol",
+  country: "Österreich",
+  registered_seat: "Telfs",
+  register_authority: "Bezirkshauptmannschaft Innsbruck",
+  representative_name: "Vereinsvertretung",
+  representative_role: "Obmann",
+  content_responsible: "Vereinsvertretung",
+  phone: "+43 123 456",
+  hosting_provider: "Eigenhosting",
+  hosting_country: "Österreich/EU",
+  legal_updated_at: "2026-08-12T10:00:00Z",
+  legal_ready: true,
+};
+
+test("contact and legal pages share one configured public data source", async ({ page }) => {
+  await page.route("**/api/settings/public**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(canonicalPublicSettings),
+  }));
+  await page.route("**/api/contact/topics", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify([{ value: "general", label: "Allgemein" }]),
+  }));
+
+  await page.goto("/contact");
+  await expect(page.getByTestId("contact-email-link")).toHaveAttribute("href", "mailto:kontakt@lionsquad.at");
+
+  await page.goto("/imprint");
+  await expect(page.getByRole("heading", { name: "Impressum" })).toBeVisible();
+  await expect(page.locator('a[href="mailto:kontakt@lionsquad.at"]')).toBeVisible();
+  await expect(page.locator('a[href="mailto:datenschutz@lionsquad.at"]')).toBeVisible();
+  await expect(page.getByText("Stand: 12.08.2026")).toBeVisible();
+
+  await page.goto("/privacy");
+  await expect(page.getByRole("heading", { name: "Datenschutzerklärung" })).toBeVisible();
+  await expect(page.locator('a[href="mailto:kontakt@lionsquad.at"]')).toBeVisible();
+  await expect(page.locator('a[href="mailto:datenschutz@lionsquad.at"]').first()).toBeVisible();
+  await expect(page.locator("body")).not.toContainText(/noch im adminbereich zu hinterlegen|image:\s*null|example\.(com|test)/i);
+});
+
+test("missing public settings never create a fake email or internal placeholder", async ({ page }) => {
+  await page.route("**/api/settings/public**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ club_name: "THE LION SQUAD", legal_ready: false }),
+  }));
+  await page.route("**/api/contact/topics", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify([{ value: "general", label: "Allgemein" }]),
+  }));
+
+  await page.goto("/contact");
+  await expect(page.getByTestId("contact-email-unavailable")).toBeVisible();
+  await expect(page.locator('a[href^="mailto:"]')).toHaveCount(0);
+
+  await page.goto("/imprint");
+  await expect(page.getByTestId("legal-data-incomplete")).toBeVisible();
+  await expect(page.locator("body")).not.toContainText(/office@|info@|noch im adminbereich zu hinterlegen|image:\s*null|example\.(com|test)/i);
+});
+
 test("public community structure is reachable", async ({ page }) => {
   await page.goto("/community");
   await acceptCookies(page);

--- a/frontend/src/hooks/usePublicSiteSettings.js
+++ b/frontend/src/hooks/usePublicSiteSettings.js
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { getCachedBranding, onBrandingUpdated, setCachedBranding } from "@/lib/brandingEvents";
+import { useApiInvalidation } from "@/hooks/useApiInvalidation";
+
+/** Shared read path for the canonical public branding/contact/legal contract. */
+export function usePublicSiteSettings() {
+  const [settings, setSettings] = useState(() => getCachedBranding() || {});
+  const load = useCallback(async () => {
+    try {
+      const { data } = await api.get("/settings/public");
+      setCachedBranding(data || {});
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = onBrandingUpdated((next) => setSettings(next || {}));
+    load();
+    return unsubscribe;
+  }, [load]);
+  useApiInvalidation(load, ["settings", "branding"]);
+
+  return settings;
+}

--- a/frontend/src/pages/admin/AdminSettingsPage.jsx
+++ b/frontend/src/pages/admin/AdminSettingsPage.jsx
@@ -168,6 +168,11 @@ function brandPayload(source = {}) {
   return payload;
 }
 
+function mergedLegacyText(primary, legacy) {
+  const values = [primary, legacy].map((value) => String(value || "").trim()).filter(Boolean);
+  return [...new Map(values.map((value) => [value.replace(/\s+/g, " ").toLocaleLowerCase(), value])).values()].join("\n\n");
+}
+
 function discordPayload(source) {
   const payload = { ...(source || {}) };
   if (!payload.webhook_url) delete payload.webhook_url;
@@ -406,6 +411,11 @@ export default function AdminSettingsPage() {
     setDiscord((prev) => ({ ...prev, [key]: value }));
   };
 
+  const setCanonicalLegalText = (key, legacyKey, value) => {
+    brandDirtyRef.current = true;
+    setBrand((prev) => ({ ...prev, [key]: value, [legacyKey]: "" }));
+  };
+
   const loadDiscordCounters = useCallback((query = discordCounterQuery) => {
     api.get(`/admin/discord/counters?q=${encodeURIComponent(query)}&limit=50`)
       .then(({ data }) => setDiscordCounters(Array.isArray(data) ? data : []))
@@ -422,9 +432,7 @@ export default function AdminSettingsPage() {
     try {
       const { data } = await api.get("/settings/public", { params: { _: Date.now() } });
       setCachedBranding(data || {});
-    } catch {
-      setCachedBranding(brand);
-    }
+    } catch {}
   };
 
   const saveEmail = async () => {
@@ -1711,7 +1719,7 @@ export default function AdminSettingsPage() {
           <div className="border border-white/10 bg-[#121212] rounded-sm p-5 space-y-5">
             <div>
               <div className="font-heading font-bold uppercase">Vereinsdaten für Impressum und Datenschutz</div>
-              <p className="text-xs text-white/50 mt-1">Diese Angaben werden dynamisch auf /imprint und /privacy ausgegeben. ZVR, Adresse und vertretungsbefugte Person bitte mit den echten Vereinsdaten eintragen.</p>
+              <p className="text-xs text-white/50 mt-1">Dies ist die zentrale Datenquelle für /contact, /imprint und /privacy. ZVR, Adresse, Kontakt und vertretungsbefugte Person bitte ausschließlich hier mit den echten Vereinsdaten pflegen.</p>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <BrandField label="Rechtlicher Vereinsname" value={brand.legal_name} onChange={(v) => setBrandField("legal_name", v)} testId="legal-name" />
@@ -1745,10 +1753,8 @@ export default function AdminSettingsPage() {
               <input type="checkbox" checked={!!brand.paid_tournaments_enabled} onChange={(e) => setBrandField("paid_tournaments_enabled", e.target.checked)} data-testid="legal-paid-tournaments" className="accent-[#29B6E8] mt-1" />
               <span>Preisturniere oder Turniere mit Startgeld können stattfinden.</span>
             </label>
-            <LegalTextArea label="Freitext Impressum" value={brand.imprint} onChange={(v) => setBrandField("imprint", v)} testId="brand-imprint" rows={4} />
-            <LegalTextArea label="Zusätzliche rechtliche Hinweise" value={brand.legal_extra} onChange={(v) => setBrandField("legal_extra", v)} testId="legal-extra" rows={4} />
-            <LegalTextArea label="Freitext Datenschutz" value={brand.privacy_policy} onChange={(v) => setBrandField("privacy_policy", v)} testId="brand-privacy" rows={5} />
-            <LegalTextArea label="Zusätzliche Datenschutzhinweise" value={brand.privacy_extra} onChange={(v) => setBrandField("privacy_extra", v)} testId="privacy-extra" rows={5} />
+            <LegalTextArea label="Zusätzliche rechtliche Hinweise (optional)" value={mergedLegacyText(brand.legal_extra, brand.imprint)} onChange={(v) => setCanonicalLegalText("legal_extra", "imprint", v)} testId="legal-extra" rows={5} />
+            <LegalTextArea label="Zusätzliche Datenschutzhinweise (optional)" value={mergedLegacyText(brand.privacy_extra, brand.privacy_policy)} onChange={(v) => setCanonicalLegalText("privacy_extra", "privacy_policy", v)} testId="privacy-extra" rows={6} />
             <button onClick={saveBrand} disabled={imageUploadBusy || savingBrand} data-testid="legal-save" className="px-5 py-2 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm disabled:opacity-50">{savingBrand ? "Speichere..." : "Rechtliches speichern"}</button>
           </div>
         </div>

--- a/frontend/src/pages/public/ContactPage.jsx
+++ b/frontend/src/pages/public/ContactPage.jsx
@@ -6,6 +6,7 @@ import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
 import { useAuth } from "@/context/AuthContext";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { usePublicSiteSettings } from "@/hooks/usePublicSiteSettings";
 import { toast } from "sonner";
 import { Mail, MessageSquare, MapPin, Send, Check } from "lucide-react";
 
@@ -16,7 +17,7 @@ export default function ContactPage() {
   );
 
   const { user } = useAuth();
-  const [branding, setBranding] = useState(null);
+  const branding = usePublicSiteSettings();
   const [topics, setTopics] = useState([]);
   const [done, setDone] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -29,12 +30,11 @@ export default function ContactPage() {
     accept_privacy: false,
   });
 
-  const loadInfo = useCallback(() => {
-    api.get("/settings/public").then(({ data }) => setBranding(data)).catch(() => {});
+  const loadTopics = useCallback(() => {
     api.get("/contact/topics").then(({ data }) => setTopics(data)).catch(() => {});
   }, []);
-  useEffect(() => { loadInfo(); }, [loadInfo]);
-  useApiInvalidation(loadInfo, ["settings", "contact"]);
+  useEffect(() => { loadTopics(); }, [loadTopics]);
+  useApiInvalidation(loadTopics, ["contact"]);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -50,7 +50,7 @@ export default function ContactPage() {
     setSubmitting(false);
   };
 
-  const contactEmail = branding?.contact_email || "info@lionsquad.at";
+  const contactEmail = branding?.contact_email;
 
   return (
     <PublicLayout>
@@ -68,11 +68,19 @@ export default function ContactPage() {
             <h3 className="font-heading font-black uppercase text-base">Discord Server</h3>
             <p className="mt-1 text-sm text-white/60">Schnellster Weg zu uns.</p>
           </a>
-          <a href={`mailto:${contactEmail}`} data-testid="contact-email-link" className="border border-white/10 hover:border-[#29B6E8]/60 rounded-sm bg-[#121212] p-5 transition group">
-            <Mail className="w-6 h-6 text-[#29B6E8] mb-3" />
-            <h3 className="font-heading font-black uppercase text-base">E-Mail direkt</h3>
-            <p className="mt-1 text-sm text-white/60 group-hover:text-white/80 break-all transition">{contactEmail}</p>
-          </a>
+          {contactEmail ? (
+            <a href={`mailto:${contactEmail}`} data-testid="contact-email-link" className="border border-white/10 hover:border-[#29B6E8]/60 rounded-sm bg-[#121212] p-5 transition group">
+              <Mail className="w-6 h-6 text-[#29B6E8] mb-3" />
+              <h3 className="font-heading font-black uppercase text-base">E-Mail direkt</h3>
+              <p className="mt-1 text-sm text-white/60 group-hover:text-white/80 break-all transition">{contactEmail}</p>
+            </a>
+          ) : (
+            <div data-testid="contact-email-unavailable" className="border border-white/10 rounded-sm bg-[#121212] p-5">
+              <Mail className="w-6 h-6 text-white/35 mb-3" />
+              <h3 className="font-heading font-black uppercase text-base">Kontaktformular</h3>
+              <p className="mt-1 text-sm text-white/60">Nutze bitte das Formular auf dieser Seite.</p>
+            </div>
+          )}
         </div>
 
         {/* Formular */}

--- a/frontend/src/pages/public/LegalPages.jsx
+++ b/frontend/src/pages/public/LegalPages.jsx
@@ -1,25 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { api } from "@/lib/api";
 import { PublicLayout } from "@/components/tls/PublicLayout";
 import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
-import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { usePublicSiteSettings } from "@/hooks/usePublicSiteSettings";
 
-const UPDATED_AT = "18.05.2026";
-
-function useBranding() {
-  const [branding, setBranding] = useState({});
-  const load = useCallback(() => {
-    api.get("/settings/public").then(({ data }) => setBranding(data || {})).catch(() => {});
-  }, []);
-  useEffect(() => { load(); }, [load]);
-  useApiInvalidation(load, ["settings", "branding"]);
-  return branding;
-}
-
-function valueOrOpen(value) {
-  return value && String(value).trim() ? value : "Noch im Adminbereich zu hinterlegen";
+function formatLegalDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("de-AT", { day: "2-digit", month: "2-digit", year: "numeric" }).format(date);
 }
 
 function addressLines(branding) {
@@ -31,8 +20,9 @@ function addressLines(branding) {
   ].filter(Boolean);
 }
 
-function LegalArticle({ title, intro, children }) {
+function LegalArticle({ title, intro, updatedAt, children }) {
   useDocumentTitle(title, intro, { robots: "noindex, follow" });
+  const formattedUpdatedAt = formatLegalDate(updatedAt);
 
   return (
     <PublicLayout>
@@ -41,7 +31,7 @@ function LegalArticle({ title, intro, children }) {
         <p className="mt-4 text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8]">Rechtliches</p>
         <h1 className="font-heading text-4xl md:text-5xl font-black uppercase mt-2">{title}</h1>
         <p className="mt-3 text-white/60 max-w-2xl">{intro}</p>
-        <p className="mt-2 text-xs text-white/40">Stand: {UPDATED_AT}</p>
+        {formattedUpdatedAt && <p className="mt-2 text-xs text-white/40">Stand: {formattedUpdatedAt}</p>}
         <div className="mt-10 space-y-8 text-sm leading-relaxed text-white/75">{children}</div>
       </article>
     </PublicLayout>
@@ -58,9 +48,11 @@ function Section({ title, children }) {
 }
 
 function InfoList({ items }) {
+  const configuredItems = items.filter(([, value]) => value !== null && value !== undefined && value !== "");
+  if (!configuredItems.length) return null;
   return (
     <dl className="grid sm:grid-cols-[210px_1fr] gap-x-5 gap-y-2">
-      {items.map(([label, value]) => (
+      {configuredItems.map(([label, value]) => (
         <div key={label} className="contents">
           <dt className="text-white/45">{label}</dt>
           <dd className="text-white break-words">{value}</dd>
@@ -68,6 +60,25 @@ function InfoList({ items }) {
       ))}
     </dl>
   );
+}
+
+function LegalDataNotice({ branding }) {
+  if (branding.legal_ready !== false) return null;
+  return (
+    <div data-testid="legal-data-incomplete" className="rounded-sm border border-amber-300/30 bg-amber-300/10 p-4 text-amber-100">
+      Die rechtlichen Kontaktdaten sind derzeit nicht vollständig verfügbar. Bitte nutze bei Fragen das Kontaktformular.
+    </div>
+  );
+}
+
+function EmailLink({ email }) {
+  if (!email) return null;
+  return <a href={`mailto:${email}`} className="text-[#29B6E8] hover:underline">{email}</a>;
+}
+
+function WebsiteLink({ url }) {
+  if (!url) return null;
+  return <a href={url} className="text-[#29B6E8] hover:underline">{url}</a>;
 }
 
 function TextBlock({ children }) {
@@ -80,11 +91,11 @@ function TextBlock({ children }) {
 }
 
 export function ImprintPage() {
-  const branding = useBranding();
+  const branding = usePublicSiteSettings();
   const clubName = branding.club_name || "THE LION SQUAD";
   const legalName = branding.legal_name || clubName;
-  const domain = branding.domain || "https://lionsquad.at";
-  const contactEmail = branding.contact_email || "office@lionsquad.at";
+  const domain = branding.domain;
+  const contactEmail = branding.contact_email;
   const privacyEmail = branding.privacy_contact_email || contactEmail;
   const lines = addressLines(branding);
 
@@ -92,18 +103,20 @@ export function ImprintPage() {
     <LegalArticle
       title="Impressum"
       intro="Anbieterkennzeichnung, Offenlegung und Kontaktinformationen des Vereins."
+      updatedAt={branding.legal_updated_at}
     >
+      <LegalDataNotice branding={branding} />
       <Section title="Medieninhaber und Betreiber">
         <InfoList
           items={[
             ["Verein", legalName],
-            ["Rechtsform", branding.legal_form || "eingetragener Verein nach österreichischem Vereinsrecht"],
-            ["ZVR-Zahl", valueOrOpen(branding.zvr_number)],
-            ["Vereinssitz", branding.registered_seat || branding.city || "Tirol, Österreich"],
-            ["Adresse", lines.length ? lines.map((line) => <div key={line}>{line}</div>) : valueOrOpen("")],
-            ["Website", <a href={domain} className="text-[#29B6E8] hover:underline">{domain}</a>],
-            ["E-Mail", <a href={`mailto:${contactEmail}`} className="text-[#29B6E8] hover:underline">{contactEmail}</a>],
-            ["Telefon", valueOrOpen(branding.phone)],
+            ["Rechtsform", branding.legal_form],
+            ["ZVR-Zahl", branding.zvr_number],
+            ["Vereinssitz", branding.registered_seat || branding.city],
+            ["Adresse", lines.length ? lines.map((line) => <div key={line}>{line}</div>) : ""],
+            ["Website", domain ? <WebsiteLink url={domain} /> : ""],
+            ["E-Mail", contactEmail ? <EmailLink email={contactEmail} /> : ""],
+            ["Telefon", branding.phone],
           ]}
         />
       </Section>
@@ -111,10 +124,10 @@ export function ImprintPage() {
       <Section title="Vertretung und Verantwortung">
         <InfoList
           items={[
-            ["Vertretungsbefugt", valueOrOpen(branding.representative_name)],
-            ["Funktion", branding.representative_role || "Obmann/Obfrau bzw. vertretungsbefugtes Vereinsorgan"],
-            ["Inhaltlich verantwortlich", valueOrOpen(branding.content_responsible || branding.representative_name)],
-            ["Vereinsbehoerde", branding.register_authority || "Vereinsbehoerde am Vereinssitz in Tirol"],
+            ["Vertretungsbefugt", branding.representative_name],
+            ["Funktion", branding.representative_role],
+            ["Inhaltlich verantwortlich", branding.content_responsible || branding.representative_name],
+            ["Vereinsbehörde", branding.register_authority],
           ]}
         />
       </Section>
@@ -126,8 +139,8 @@ export function ImprintPage() {
           eSports-Turniere, Fast-Lap-Challenges, Ranglisten, News, Sponsoren und Kontaktmöglichkeiten.
         </p>
         <p>
-          Der Vereinssitz liegt in Tirol. Die Vereinstätigkeit ist nicht auf Gewinn gerichtet,
-          soweit sich aus den Statuten nichts anderes ergibt.
+          {branding.registered_seat && <>Der Vereinssitz liegt in {branding.registered_seat}. </>}
+          Die Vereinstätigkeit ist nicht auf Gewinn gerichtet, soweit sich aus den Statuten nichts anderes ergibt.
         </p>
       </Section>
 
@@ -159,13 +172,11 @@ export function ImprintPage() {
         )}
       </Section>
 
-      <Section title="UID und wirtschaftliche Angaben">
-        <InfoList
-          items={[
-            ["UID-Nummer", branding.vat_number || "Nicht hinterlegt bzw. nicht anwendbar"],
-          ]}
-        />
-      </Section>
+      {branding.vat_number && (
+        <Section title="UID und wirtschaftliche Angaben">
+          <InfoList items={[["UID-Nummer", branding.vat_number]]} />
+        </Section>
+      )}
 
       <Section title="Haftung und externe Links">
         <p>
@@ -190,18 +201,18 @@ export function ImprintPage() {
         </p>
       </Section>
 
-      <Section title="Datenschutzkontakt">
+      {privacyEmail && <Section title="Datenschutzkontakt">
         <p>
           Datenschutzanfragen können an{" "}
-          <a href={`mailto:${privacyEmail}`} className="text-[#29B6E8] hover:underline">{privacyEmail}</a>{" "}
+          <EmailLink email={privacyEmail} />{" "}
           gerichtet werden. Weitere Informationen stehen in der{" "}
           <Link to="/privacy" className="text-[#29B6E8] hover:underline">Datenschutzerklärung</Link>.
         </p>
-      </Section>
+      </Section>}
 
-      {(branding.imprint || branding.legal_extra) && (
+      {branding.legal_extra && (
         <Section title="Ergänzende Angaben">
-          <TextBlock>{[branding.imprint, branding.legal_extra].filter(Boolean).join("\n\n")}</TextBlock>
+          <TextBlock>{branding.legal_extra}</TextBlock>
         </Section>
       )}
     </LegalArticle>
@@ -209,10 +220,10 @@ export function ImprintPage() {
 }
 
 export function PrivacyPage() {
-  const branding = useBranding();
+  const branding = usePublicSiteSettings();
   const clubName = branding.legal_name || branding.club_name || "THE LION SQUAD";
-  const domain = branding.domain || "https://lionsquad.at";
-  const contactEmail = branding.contact_email || "office@lionsquad.at";
+  const domain = branding.domain;
+  const contactEmail = branding.contact_email;
   const privacyEmail = branding.privacy_contact_email || contactEmail;
   const lines = addressLines(branding);
 
@@ -220,15 +231,17 @@ export function PrivacyPage() {
     <LegalArticle
       title="Datenschutzerklärung"
       intro="Informationen zur Verarbeitung personenbezogener Daten auf dieser Vereinsplattform."
+      updatedAt={branding.legal_updated_at}
     >
+      <LegalDataNotice branding={branding} />
       <Section title="Verantwortlicher">
         <InfoList
           items={[
             ["Verantwortlicher", clubName],
-            ["Adresse", lines.length ? lines.map((line) => <div key={line}>{line}</div>) : valueOrOpen("")],
-            ["Website", <a href={domain} className="text-[#29B6E8] hover:underline">{domain}</a>],
-            ["Kontakt", <a href={`mailto:${contactEmail}`} className="text-[#29B6E8] hover:underline">{contactEmail}</a>],
-            ["Datenschutz", <a href={`mailto:${privacyEmail}`} className="text-[#29B6E8] hover:underline">{privacyEmail}</a>],
+            ["Adresse", lines.length ? lines.map((line) => <div key={line}>{line}</div>) : ""],
+            ["Website", domain ? <WebsiteLink url={domain} /> : ""],
+            ["Kontakt", contactEmail ? <EmailLink email={contactEmail} /> : ""],
+            ["Datenschutz", privacyEmail ? <EmailLink email={privacyEmail} /> : ""],
           ]}
         />
       </Section>
@@ -334,12 +347,10 @@ export function PrivacyPage() {
           Die Plattform verarbeitet Daten auf den eingesetzten Servern, Datenbanken und
           Backup-Speichern. Technische Logs dienen Sicherheit, Fehleranalyse und Betrieb.
         </p>
-        <InfoList
-          items={[
-            ["Hosting / Betrieb", branding.hosting_provider || "Vom Verein bzw. beauftragten Dienstleistern betrieben"],
-            ["Hosting-Region", branding.hosting_country || "Österreich/EU"],
-          ]}
-        />
+        <InfoList items={[
+          ["Hosting / Betrieb", branding.hosting_provider],
+          ["Hosting-Region", branding.hosting_country],
+        ]} />
       </Section>
 
       <Section title="Cookies und lokale Speicherung">
@@ -391,8 +402,8 @@ export function PrivacyPage() {
         <p>
           Betroffene Personen haben nach Maßgabe der DSGVO Rechte auf Information, Auskunft,
           Berichtigung, Löschung, Einschränkung, Datenübertragbarkeit, Widerspruch sowie Widerruf
-          erteilter Einwilligungen. Zur Ausübung genügt eine Nachricht an{" "}
-          <a href={`mailto:${privacyEmail}`} className="text-[#29B6E8] hover:underline">{privacyEmail}</a>.
+          erteilter Einwilligungen. Zur Ausübung nutze bitte{" "}
+          {privacyEmail ? <EmailLink email={privacyEmail} /> : <Link to="/contact" className="text-[#29B6E8] hover:underline">das Kontaktformular</Link>}.
         </p>
         <p>
           Außerdem besteht das Recht auf Beschwerde bei der Österreichischen Datenschutzbehörde,
@@ -401,9 +412,9 @@ export function PrivacyPage() {
         </p>
       </Section>
 
-      {(branding.privacy_policy || branding.privacy_extra) && (
+      {branding.privacy_extra && (
         <Section title="Ergänzende Datenschutzhinweise">
-          <TextBlock>{[branding.privacy_policy, branding.privacy_extra].filter(Boolean).join("\n\n")}</TextBlock>
+          <TextBlock>{branding.privacy_extra}</TextBlock>
         </Section>
       )}
 


### PR DESCRIPTION
## Was sich ändert

- Kontakt-, Impressums- und Datenschutzangaben werden aus einem kanonischen öffentlichen Vertrag des Branding-Dokuments abgeleitet.
- Widersprüchliche E-Mail-Fallbacks und interne Platzhaltertexte werden nicht mehr öffentlich ausgegeben.
- Alte Impressums-/Datenschutz-Freitexte werden verlustfrei und dedupliziert in je einem Zusatzfeld ausgegeben; die doppelten Admin-Eingaben sind zusammengeführt.
- Der Setup-Status prüft nun die tatsächlich benötigten strukturierten Rechtsdaten.
- Der angezeigte Stand der Rechtstexte folgt echten Änderungen statt einem fest codierten Datum.

## Warum

Die öffentlichen Seiten nutzten zwar dasselbe Branding-Dokument, interpretierten fehlende Werte aber unterschiedlich. Dadurch konnten erfundene Kontaktadressen, interne Hinweise und ein falscher Setup-Gesundheitsstatus entstehen. Dieser PR vereinheitlicht den Datenfluss und macht unvollständige Konfiguration sichtbar, ohne falsche Angaben zu veröffentlichen.

## Wirkung

Administratoren pflegen Kontakt- und Rechtsdaten zentral unter Einstellungen → Rechtliches. Besucher sehen auf Kontakt, Impressum und Datenschutz konsistente Werte. Bestehende Alttexte bleiben erhalten.

## Prüfungen

- `python -m compileall -q backend`
- `python -m pytest -m "not live" -q` — 188 bestanden, 5 übersprungen
- `corepack yarn test --watchAll=false --passWithNoTests` — 6 bestanden
- `corepack yarn build` — erfolgreich
- `corepack yarn test:e2e` — 26 bestanden, 8 Live-Admin-Tests ohne Zugangsdaten übersprungen
- `git diff --check`

Teil von #95.