### PR TITLE
fix: öffentliche Produktionskonsole bereinigen

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -51,6 +51,35 @@ Im Admin:
 - `Einstellungen -> Discord`
 - `Einstellungen -> Twitch`
 
+## Oeffentlichen Inhalt im echten Browser pruefen
+
+Der wiederholbare Produktions-Crawl rendert statische Routen und alle URLs der Sitemap hinter
+dem aeusseren Reverse Proxy. Er meldet sichtbare Demo-/Theme-Platzhalter, reservierte
+Beispiel-Links, kaputte Bilder, Browserfehler, fehlgeschlagene Requests und HTTP-Fehler:
+
+```bash
+cd frontend
+yarn audit:public
+```
+
+Eine andere Umgebung oder ein kleinerer Diagnose-Lauf kann explizit gesetzt werden:
+
+```bash
+PUBLIC_AUDIT_BASE_URL=https://staging.example.at PUBLIC_AUDIT_LIMIT=20 yarn audit:public
+```
+
+Erwartet wird `findings: []` und Exit-Code 0. Der Crawl ist bewusst kein CI-Schritt gegen die
+Produktivseite; er wird nach Deployments oder Inhaltsmigrationen manuell ausgefuehrt.
+
+Das interne Nginx erzeugt pro HTML-Antwort eine CSP-Nonce. Runtime-JSON-LD, serverseitige
+SEO-Previews und Cloudflares injizierte JavaScript Detection verwenden dieselbe Nonce. Damit
+bleibt `script-src` strikt und braucht kein `unsafe-inline`. Cloudflare beschreibt dieses
+Nonce-Verhalten in der offiziellen Dokumentation:
+https://developers.cloudflare.com/cloudflare-challenges/challenge-types/javascript-detections/#if-you-have-a-content-security-policy-csp
+
+Externe Google-Fonts werden nicht geladen; die Seite verwendet lokale System-Fallbacks. Damit
+entsteht weder ein CSP-Fehler noch ein unangekuendigter Drittanbieter-Request fuer Schriften.
+
 ## Wenn `/community` alte Assets referenziert
 
 Symptom:

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from database import get_db
 from auth import (
     hash_password, verify_password, create_access_token, create_refresh_token,
-    set_auth_cookies, clear_auth_cookies, get_current_user, _decode,
+    set_auth_cookies, clear_auth_cookies, get_current_user, get_optional_user, _decode,
     hash_token, refresh_expires_at,
 )
 from email_service import send_template
@@ -346,7 +346,15 @@ async def logout(request: Request, response: Response):
 
 
 @router.get("/me")
-async def me(user: dict = Depends(get_current_user)):
+async def me(request: Request, response: Response, user: dict | None = Depends(get_optional_user)):
+    """Return a quiet guest response while preserving refreshable sessions.
+
+    Public pages can bootstrap auth without producing an expected 401 in every
+    guest browser. A stale access cookie is refreshed explicitly by the client.
+    """
+    response.headers["Cache-Control"] = "no-store"
+    if user is None and request.cookies.get("refresh_token"):
+        response.headers["X-Session-Refresh"] = "required"
     return user
 
 

--- a/backend/tests/test_auth_session_bootstrap_unit.py
+++ b/backend/tests/test_auth_session_bootstrap_unit.py
@@ -1,0 +1,31 @@
+import asyncio
+from types import SimpleNamespace
+
+from fastapi import Response
+
+from routes.auth_routes import me
+
+
+def test_guest_auth_bootstrap_returns_null_without_refresh_request():
+    response = Response()
+    result = asyncio.run(me(SimpleNamespace(cookies={}), response, None))
+
+    assert result is None
+    assert response.headers["cache-control"] == "no-store"
+    assert "x-session-refresh" not in response.headers
+
+
+def test_expired_access_session_signals_refresh_without_a_401():
+    response = Response()
+    result = asyncio.run(me(SimpleNamespace(cookies={"refresh_token": "opaque"}), response, None))
+
+    assert result is None
+    assert response.headers["x-session-refresh"] == "required"
+
+
+def test_authenticated_bootstrap_returns_the_user_without_refresh():
+    response = Response()
+    user = {"id": "user-1", "role": "player"}
+
+    assert asyncio.run(me(SimpleNamespace(cookies={"refresh_token": "opaque"}), response, user)) == user
+    assert "x-session-refresh" not in response.headers

--- a/backend/tests/test_security_hardening_unit.py
+++ b/backend/tests/test_security_hardening_unit.py
@@ -120,3 +120,16 @@ def test_internal_nginx_preserves_tls_and_sanitizes_forwarded_host():
     assert "map $http_x_forwarded_proto $tls_forwarded_proto" in nginx
     assert "proxy_set_header X-Forwarded-Proto $scheme;" not in nginx
     assert nginx.count("proxy_set_header X-Forwarded-Host $host;") == 7
+
+
+def test_internal_nginx_uses_one_nonce_based_csp_without_external_fonts():
+    root = Path(__file__).resolve().parents[2]
+    nginx = (root / "frontend" / "nginx.conf").read_text(encoding="utf-8")
+    css = (root / "frontend" / "src" / "index.css").read_text(encoding="utf-8")
+
+    assert "map $request_id $tls_content_security_policy" in nginx
+    assert "script-src 'self' 'nonce-$request_id'" in nginx
+    assert "script-src 'self' 'unsafe-inline'" not in nginx
+    assert nginx.count("add_header Content-Security-Policy $tls_content_security_policy always;") == 7
+    assert 'meta name="csp-nonce" content="$request_id"' in nginx
+    assert "fonts.googleapis.com" not in css

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -11,6 +11,12 @@ map $http_x_forwarded_proto $tls_forwarded_proto {
   "https" https;
 }
 
+# One strict policy for every response. The per-request nonce lets Cloudflare
+# attach its injected JavaScript Detection snippet without enabling unsafe-inline.
+map $request_id $tls_content_security_policy {
+  default "default-src 'self'; script-src 'self' 'nonce-$request_id'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'";
+}
+
 # Gzip-Kompression für bessere Performance (LCP/TTFB)
 gzip on;
 gzip_vary on;
@@ -71,7 +77,13 @@ server {
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
   add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+  add_header Content-Security-Policy $tls_content_security_policy always;
+
+  # Make the same nonce available to runtime JSON-LD and add it to the
+  # server-rendered SEO preview. Cloudflare also reads it from the CSP header.
+  sub_filter_once off;
+  sub_filter '<head>' '<head><meta name="csp-nonce" content="$request_id" />';
+  sub_filter '<script type="application/ld+json">' '<script type="application/ld+json" nonce="$request_id">';
 
   if ($host = "www.lionsquad.at") {
     return 301 https://lionsquad.at$request_uri;
@@ -85,7 +97,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy $tls_content_security_policy always;
     return 200 "ok\n";
   }
 
@@ -180,7 +192,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy $tls_content_security_policy always;
   }
 
   location ^~ /api/ {
@@ -205,7 +217,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy $tls_content_security_policy always;
     add_header Cache-Control "no-store" always;
     add_header Pragma "no-cache" always;
     add_header Expires "0" always;
@@ -224,7 +236,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy $tls_content_security_policy always;
     add_header Cache-Control "public, max-age=300" always;
   }
 
@@ -238,7 +250,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy $tls_content_security_policy always;
     add_header Pragma "no-cache" always;
     add_header Expires "0" always;
     try_files $uri /index.html;
@@ -254,7 +266,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy $tls_content_security_policy always;
     add_header Pragma "no-cache" always;
     add_header Expires "0" always;
     try_files $uri /index.html;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
     "test": "craco test",
     "test:e2e": "playwright test",
     "audit:high": "node scripts/audit-high.js",
+    "audit:public": "node scripts/audit-public-content.js",
     "check:contrast": "node scripts/check-contrast.js"
   },
   "resolutions": {

--- a/frontend/scripts/audit-public-content.js
+++ b/frontend/scripts/audit-public-content.js
@@ -1,0 +1,101 @@
+const { chromium } = require("@playwright/test");
+
+const baseUrl = (process.env.PUBLIC_AUDIT_BASE_URL || "https://lionsquad.at").replace(/\/+$/, "");
+const limit = Math.max(1, Number(process.env.PUBLIC_AUDIT_LIMIT || 120));
+const concurrency = Math.max(1, Math.min(8, Number(process.env.PUBLIC_AUDIT_CONCURRENCY || 5)));
+const staticPaths = [
+  "/", "/about", "/board", "/values", "/contact", "/news", "/events", "/galerie",
+  "/references", "/esports", "/tournaments", "/fastlap", "/teams", "/servers", "/members",
+  "/membership/join", "/membership/apply", "/sponsors", "/partners", "/privacy", "/imprint", "/players",
+];
+const placeholderPattern = /Image:\s*null|Lorem ipsum|demo(?:daten|text|inhalt| player)?|sample content|coming soon|noch im adminbereich zu hinterlegen|\bTBD\b/gi;
+
+async function auditPage(context, path) {
+  const page = await context.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+  page.on("requestfailed", (request) => {
+    const failure = request.failure()?.errorText || "unknown";
+    if (failure === "net::ERR_ABORTED" && request.resourceType() === "media") return;
+    errors.push(`requestfailed: ${request.url()} (${failure})`);
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 400 && response.url().startsWith(baseUrl)) {
+      errors.push(`response: ${response.status()} ${response.url()}`);
+    }
+  });
+
+  try {
+    const response = await page.goto(`${baseUrl}${path}`, { waitUntil: "domcontentloaded", timeout: 30_000 });
+    await page.waitForTimeout(900);
+    const content = await page.evaluate((placeholderSource) => {
+      const text = document.body?.innerText || "";
+      const pattern = new RegExp(placeholderSource, "gi");
+      const placeholders = [...text.matchAll(pattern)].map((match) => match[0]);
+      const reservedLinks = [...document.querySelectorAll("a[href]")]
+        .map((anchor) => anchor.href)
+        .filter((href) => /example\.(com|org|net|test)|@demo\./i.test(href));
+      const brokenImages = [...document.images]
+        .filter((image) => image.currentSrc && image.complete && image.naturalWidth === 0)
+        .map((image) => image.currentSrc);
+      return {
+        title: document.title,
+        placeholders: [...new Set(placeholders)],
+        reservedLinks: [...new Set(reservedLinks)],
+        brokenImages: [...new Set(brokenImages)],
+      };
+    }, placeholderPattern.source);
+    const uniqueErrors = [...new Set(errors)];
+    const status = response?.status() || 0;
+    if (status >= 400 || content.placeholders.length || content.reservedLinks.length || content.brokenImages.length || uniqueErrors.length) {
+      return { path, status, ...content, errors: uniqueErrors };
+    }
+    return null;
+  } catch (error) {
+    return { path, navigationError: error.message, errors: [...new Set(errors)] };
+  } finally {
+    await page.close();
+  }
+}
+
+async function main() {
+  const sitemap = await fetch(`${baseUrl}/sitemap.xml`).then((response) => {
+    if (!response.ok) throw new Error(`Sitemap returned ${response.status}`);
+    return response.text();
+  });
+  const dynamicPaths = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].flatMap((match) => {
+    try {
+      const url = new URL(match[1]);
+      return url.origin === baseUrl ? [`${url.pathname}${url.search}`] : [];
+    } catch {
+      return [];
+    }
+  });
+  const paths = [...new Set([...staticPaths, ...dynamicPaths])].slice(0, limit);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  const findings = [];
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < paths.length) {
+      const path = paths[cursor++];
+      const finding = await auditPage(context, path);
+      if (finding) findings.push(finding);
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  await browser.close();
+  const result = { baseUrl, audited: paths.length, passed: paths.length - findings.length, findings };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (findings.length) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -11,8 +11,12 @@ export function AuthProvider({ children }) {
 
   const fetchMe = useCallback(async () => {
     try {
-      const { data } = await api.get("/auth/me");
-      setUser(data);
+      let response = await api.get("/auth/me");
+      if (response.headers?.["x-session-refresh"] === "required") {
+        await api.post("/auth/refresh", null, { skipInvalidation: true });
+        response = await api.get("/auth/me");
+      }
+      setUser(response.data || null);
     } catch {
       setUser(null);
     }

--- a/frontend/src/hooks/useSeoPage.js
+++ b/frontend/src/hooks/useSeoPage.js
@@ -5,6 +5,7 @@
  */
 import { useCallback, useEffect } from "react";
 import { api } from "@/lib/api";
+import { applyCspNonce } from "@/lib/csp";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 
 const JSON_LD_ID = "tls-jsonld-cms";
@@ -109,6 +110,7 @@ export function useSeoPage(slug) {
           s = document.createElement("script");
           s.type = "application/ld+json";
           s.id = JSON_LD_ID;
+          applyCspNonce(s);
           document.head.appendChild(s);
         }
         s.textContent = JSON.stringify(data.json_ld);
@@ -169,6 +171,7 @@ export function useJsonLd(obj, key = "tls-jsonld-runtime") {
       s = document.createElement("script");
       s.type = "application/ld+json";
       s.id = key;
+      applyCspNonce(s);
       document.head.appendChild(s);
     }
     s.textContent = JSON.stringify(obj);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Unbounded:wght@400;500;600;700;800;900&family=Outfit:wght@300;400;500;600;700&family=Rajdhani:wght@400;500;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -51,7 +49,7 @@ html, body, #root {
 
 body {
   margin: 0;
-  font-family: 'Outfit', -apple-system, sans-serif;
+  font-family: 'Outfit', 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
   -webkit-font-smoothing: antialiased;
   background: var(--tls-black);
   color: var(--tls-white);
@@ -63,9 +61,9 @@ img, video, canvas, svg {
   max-width: 100%;
 }
 
-.font-heading { font-family: 'Unbounded', sans-serif; }
-.font-display { font-family: 'Rajdhani', sans-serif; }
-.font-body { font-family: 'Outfit', sans-serif; }
+.font-heading { font-family: 'Unbounded', 'Arial Black', 'Segoe UI Black', sans-serif; }
+.font-display { font-family: 'Rajdhani', 'Bahnschrift Condensed', 'Arial Narrow', sans-serif; }
+.font-body { font-family: 'Outfit', 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif; }
 
 /* Selection */
 ::selection { background: var(--tls-cyan); color: #000; }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -118,7 +118,7 @@ function attachResponseInterceptors(client) {
   client.interceptors.response.use(
     (response) => {
       const method = (response.config?.method || "get").toUpperCase();
-      if (UNSAFE_METHODS.has(method) && response.status < 400) {
+      if (UNSAFE_METHODS.has(method) && response.status < 400 && !response.config?.skipInvalidation) {
         emitApiInvalidation({
           source: "client",
           method,
@@ -136,13 +136,13 @@ function attachResponseInterceptors(client) {
       const csrfError = error.response?.status === 403 && /csrf token missing or invalid/i.test(detail);
       if (error.response?.status === 401 && original && !original._retry && !authRequest) {
         original._retry = true;
-        refreshPromise = refreshPromise || api.post("/auth/refresh").finally(() => { refreshPromise = null; });
+        refreshPromise = refreshPromise || api.post("/auth/refresh", null, { skipInvalidation: true }).finally(() => { refreshPromise = null; });
         await refreshPromise;
         return client(original);
       }
       if (csrfError && original && !original._csrfRetry && !authRequest) {
         original._csrfRetry = true;
-        refreshPromise = refreshPromise || api.post("/auth/refresh").finally(() => { refreshPromise = null; });
+        refreshPromise = refreshPromise || api.post("/auth/refresh", null, { skipInvalidation: true }).finally(() => { refreshPromise = null; });
         await refreshPromise;
         applyCsrfHeader(original);
         return client(original);

--- a/frontend/src/lib/csp.js
+++ b/frontend/src/lib/csp.js
@@ -1,0 +1,6 @@
+export function applyCspNonce(element) {
+  if (!element || typeof document === "undefined") return element;
+  const nonce = document.querySelector('meta[name="csp-nonce"]')?.getAttribute("content")?.trim();
+  if (nonce) element.setAttribute("nonce", nonce);
+  return element;
+}

--- a/frontend/src/lib/csp.test.js
+++ b/frontend/src/lib/csp.test.js
@@ -1,0 +1,23 @@
+import { applyCspNonce } from "./csp";
+
+afterEach(() => {
+  document.head.innerHTML = "";
+});
+
+test("applies the nginx CSP nonce to runtime scripts", () => {
+  const meta = document.createElement("meta");
+  meta.name = "csp-nonce";
+  meta.content = "request-nonce-123";
+  document.head.appendChild(meta);
+  const script = document.createElement("script");
+
+  applyCspNonce(script);
+
+  expect(script.getAttribute("nonce")).toBe("request-nonce-123");
+});
+
+test("leaves scripts unchanged when local development has no nonce", () => {
+  const script = document.createElement("script");
+  expect(applyCspNonce(script)).toBe(script);
+  expect(script.hasAttribute("nonce")).toBe(false);
+});

--- a/frontend/src/pages/public/HomePage.jsx
+++ b/frontend/src/pages/public/HomePage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { api } from "@/lib/api";
+import { applyCspNonce } from "@/lib/csp";
 import { PublicLayout } from "@/components/tls/PublicLayout";
 import { PhaseBadge } from "@/components/tls/PhaseBadge";
 import { MascotBadge } from "@/components/tls/Logo";
@@ -180,6 +181,7 @@ function useHomeStructuredData(state) {
     script.type = "application/ld+json";
     script.dataset.tlsHomeStructuredData = "true";
     script.textContent = JSON.stringify(data);
+    applyCspNonce(script);
     document.head.appendChild(script);
     return () => script.remove();
   }, [state]);

--- a/scripts/check-public-routes.sh
+++ b/scripts/check-public-routes.sh
@@ -75,6 +75,26 @@ expect_gone() {
   }
 }
 
+expect_nonce_csp() {
+  local response headers body nonce
+  response="$(curl --silent --show-error --include --header "Host: lionsquad.at" "${base_url}/about")"
+  headers="${response%%$'\r\n\r\n'*}"
+  body="${response#*$'\r\n\r\n'}"
+  nonce="$(printf '%s\n' "$headers" | sed -nE "s/.*script-src 'self' 'nonce-([^']+)'.*/\1/p" | head -n 1)"
+  test -n "$nonce" || {
+    printf 'Expected a per-request script nonce in Content-Security-Policy.\n%s\n' "$headers" >&2
+    return 1
+  }
+  printf '%s' "$headers" | grep -Fq "script-src 'self' 'unsafe-inline'" && {
+    printf 'script-src must not allow unsafe-inline.\n%s\n' "$headers" >&2
+    return 1
+  }
+  printf '%s' "$body" | grep -Fq "<meta name=\"csp-nonce\" content=\"$nonce\" />" || {
+    printf 'HTML CSP nonce does not match its response header.\n' >&2
+    return 1
+  }
+}
+
 for path in / /about /esports /tournaments /fastlap /galerie /players; do
   expect_status "$path" 200
 done
@@ -112,5 +132,6 @@ for path in /elements/blockquote/ /product/demo /portfolio/demo /tag/demo /categ
 done
 
 expect_redirect "/esports?view=live" "https://lionsquad.at/esports?view=live" "www.lionsquad.at"
+expect_nonce_csp
 
 printf 'Public route contract passed.\n'


### PR DESCRIPTION
## Was sich ändert

- Gast-Browser initialisieren Auth ohne erwartete `401`-Fehler; refreshbare Sitzungen bleiben erhalten.
- Der unnötige zweite Refresh-/Invalidierungszyklus wird unterdrückt.
- Der externe Google-Font-Import entfällt zugunsten lokaler System-Fallbacks.
- Nginx erzeugt pro Antwort eine CSP-Nonce für Runtime-JSON-LD, SEO-Preview und Cloudflares JavaScript Detection, ohne `script-src unsafe-inline` zu erlauben.
- Der produktive Nginx-Routentest verifiziert Header- und HTML-Nonce gemeinsam.
- `yarn audit:public` crawlt die statischen Seiten plus dynamische Sitemap-URLs im echten Browser und meldet Platzhalter, Beispiel-Links, kaputte Bilder, Console-/Request-/HTTP-Fehler.
- Der Betriebsablauf ist in `OPERATIONS.md` dokumentiert.

## Warum

Ein read-only Produktionscrawl über 77 öffentliche Seiten fand keine sichtbaren Demo-/Theme-Platzhalter, Beispiel-Links oder kaputten Bilder. Auf jeder Seite traten aber dieselben drei Konsolenprobleme auf: CSP blockierte Google Fonts, Gast-Auth erzeugte `401` plus erfolglosen Refresh und Cloudflares injizierte JavaScript Detection hatte keine Nonce. Dieser PR beseitigt die Ursachen, ohne die CSP abzuschwächen.

## Wirkung

Öffentliche Seiten laden ohne unnötigen Drittanbieter-Font-Request und ohne erwartete Gast-Auth-Fehler. Cloudflare und strukturierte Daten bleiben mit einer strikten, nonce-basierten Script-Policy kompatibel. Der Produktionsaudit ist reproduzierbar.

## Prüfungen

- `python -m pytest -m "not live" -q` — 192 bestanden, 5 übersprungen
- `corepack yarn test --watchAll=false --passWithNoTests` — 8 bestanden
- `corepack yarn build` — erfolgreich
- `corepack yarn test:e2e` — 26 bestanden, 8 Live-Admin-Tests ohne Zugangsdaten übersprungen
- `node --check frontend/scripts/audit-public-content.js`
- `python -m compileall -q backend`
- `git diff --check`
- Live-Negativprobe des Crawlers reproduziert vor Deployment exakt die drei erwarteten Fehler

Docker/Nginx steht lokal unter Windows nicht zur Verfügung; `nginx -t` und der reale Container-Routenvertrag laufen deshalb verpflichtend im Frontend-CI-Job.

Teil von #95.