### PR TITLE
fix: harden public links and error states

### DIFF
--- a/PUBLIC_ROUTE_INVENTORY.md
+++ b/PUBLIC_ROUTE_INVENTORY.md
@@ -37,6 +37,7 @@ Diese Routen bleiben erreichbar, damit Menschen sie verwenden und Crawler `noind
 - `/membership/apply`
 - `/matches/<id>`
 - Login-, Registrierungs- und Passwort-Routen
+- Fehleransichten `/403`, `/500` und der SPA-404-Fallback; sie setzen `noindex, nofollow`
 
 ## Private und betriebliche Routen
 

--- a/frontend/e2e/public.spec.js
+++ b/frontend/e2e/public.spec.js
@@ -51,6 +51,52 @@ const canonicalPublicSettings = {
   legal_ready: true,
 };
 
+test("403, 404 and 500 views explain recovery and stay out of search indexes", async ({ page }) => {
+  await mockPublicChrome(page);
+
+  for (const entry of [
+    { path: "/403", code: "403", title: "Kein Zugriff" },
+    { path: "/audit-does-not-exist", code: "404", title: "Seite nicht gefunden" },
+    { path: "/500", code: "500", title: "Etwas ist schiefgelaufen" },
+  ]) {
+    await page.goto(entry.path);
+    await expect(page.getByTestId(`error-title-${entry.code}`)).toHaveText(entry.title);
+    await expect(page.getByTestId("error-home-btn")).toHaveAttribute("href", "/");
+    await expect(page.getByRole("link", { name: "Turniere" })).toHaveAttribute("href", "/tournaments");
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "noindex, nofollow");
+    await expect(page).toHaveTitle(new RegExp(`^${entry.code} .+THE LION SQUAD$`));
+  }
+
+  await page.goto("/403");
+  await expect(page.getByTestId("error-login-btn")).toHaveAttribute("href", "/login");
+  await page.goto("/500");
+  await expect(page.getByTestId("error-retry-btn")).toBeVisible();
+});
+
+test("news keeps stale mentions as text without linking to unavailable profiles", async ({ page }) => {
+  await mockPublicChrome(page);
+  await page.route("**/api/news/stale-profile-mention", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      id: "news-1",
+      slug: "stale-profile-mention",
+      title: "Rennbericht",
+      category: "Turniere",
+      published: true,
+      published_at: "2026-08-12T10:00:00Z",
+      content: "[@PublicPlayer](/u/PublicPlayer) und [@FormerPlayer](/u/FormerPlayer)",
+      mentioned_users: [{ id: "user-1", username: "PublicPlayer", display_name: "Public Player" }],
+      content_embeds: [],
+    }),
+  }));
+
+  await page.goto("/news/stale-profile-mention");
+  const content = page.locator(".prose-cms");
+  await expect(content).toContainText("@PublicPlayer und @FormerPlayer");
+  await expect(content.locator('a[href="/u/PublicPlayer"]')).toHaveCount(1);
+  await expect(content.locator('a[href="/u/FormerPlayer"]')).toHaveCount(0);
+});
+
 test("contact and legal pages share one configured public data source", async ({ page }) => {
   await page.route("**/api/settings/public**", (route) => route.fulfill({
     contentType: "application/json",

--- a/frontend/scripts/audit-public-content.js
+++ b/frontend/scripts/audit-public-content.js
@@ -1,14 +1,92 @@
 const { chromium } = require("@playwright/test");
 
 const baseUrl = (process.env.PUBLIC_AUDIT_BASE_URL || "https://lionsquad.at").replace(/\/+$/, "");
-const limit = Math.max(1, Number(process.env.PUBLIC_AUDIT_LIMIT || 120));
+const limit = Math.max(1, Number(process.env.PUBLIC_AUDIT_LIMIT || 250));
 const concurrency = Math.max(1, Math.min(8, Number(process.env.PUBLIC_AUDIT_CONCURRENCY || 5)));
+const resourceConcurrency = Math.max(1, Math.min(2, Number(process.env.PUBLIC_AUDIT_RESOURCE_CONCURRENCY || 1)));
+const resourceTimeout = Math.max(5_000, Number(process.env.PUBLIC_AUDIT_RESOURCE_TIMEOUT_MS || 60_000));
 const staticPaths = [
   "/", "/about", "/board", "/values", "/contact", "/news", "/events", "/galerie",
   "/references", "/esports", "/tournaments", "/fastlap", "/teams", "/servers", "/members",
   "/membership/join", "/membership/apply", "/sponsors", "/partners", "/privacy", "/imprint", "/players",
 ];
 const placeholderPattern = /Image:\s*null|Lorem ipsum|demo(?:daten|text|inhalt| player)?|sample content|coming soon|noch im adminbereich zu hinterlegen|\bTBD\b/gi;
+
+function normalizedHostname(value) {
+  return String(value || "").toLowerCase().replace(/^www\./, "");
+}
+
+function isInternalUrl(value) {
+  try {
+    const candidate = new URL(value, baseUrl);
+    const root = new URL(baseUrl);
+    return ["http:", "https:"].includes(candidate.protocol)
+      && normalizedHostname(candidate.hostname) === normalizedHostname(root.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function urlPath(value) {
+  const url = new URL(value, baseUrl);
+  return `${url.pathname}${url.search}`;
+}
+
+function isBrowserPageLink(link) {
+  const path = new URL(link.url).pathname;
+  if (link.download || path.startsWith("/api/")) return false;
+  return !/\.(?:aab|apk|avif|bmp|csv|docx?|gif|ico|ics|jpe?g|json|mp4|pdf|png|svg|webm|webp|xlsx?|xml|zip)$/i.test(path);
+}
+
+async function checkResourceLink(link) {
+  const visited = new Set();
+  let current = link.url;
+
+  for (let hop = 0; hop <= 10; hop += 1) {
+    if (visited.has(current)) return { error: "Redirect-Schleife", finalUrl: current };
+    visited.add(current);
+
+    let response;
+    try {
+      response = await fetch(current, {
+        redirect: "manual",
+        headers: { "user-agent": "Lionsquad-Public-Audit/1.0" },
+        signal: AbortSignal.timeout(resourceTimeout),
+      });
+    } catch (error) {
+      return { error: error.message, finalUrl: current };
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      await response.body?.cancel();
+      if (!location) return { status: response.status, error: "Redirect ohne Location-Header", finalUrl: current };
+      const next = new URL(location, current).toString();
+      if (!isInternalUrl(next)) return { status: response.status, finalUrl: next };
+      current = next;
+      continue;
+    }
+
+    await response.body?.cancel();
+    if (response.status >= 400) return { status: response.status, finalUrl: current };
+    return { status: response.status, finalUrl: current };
+  }
+
+  return { error: "Mehr als 10 Redirects", finalUrl: current };
+}
+
+async function runPool(items, worker, size = concurrency) {
+  const results = [];
+  let cursor = 0;
+  async function run() {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await worker(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(size, items.length) }, () => run()));
+  return results;
+}
 
 async function auditPage(context, path) {
   const page = await context.newPage();
@@ -31,31 +109,84 @@ async function auditPage(context, path) {
   try {
     const response = await page.goto(`${baseUrl}${path}`, { waitUntil: "domcontentloaded", timeout: 30_000 });
     await page.waitForTimeout(900);
-    const content = await page.evaluate((placeholderSource) => {
+    const content = await page.evaluate(({ placeholderSource, auditBaseUrl }) => {
       const text = document.body?.innerText || "";
       const pattern = new RegExp(placeholderSource, "gi");
       const placeholders = [...text.matchAll(pattern)].map((match) => match[0]);
-      const reservedLinks = [...document.querySelectorAll("a[href]")]
+      const anchors = [...document.querySelectorAll("a")];
+      const reservedLinks = anchors
         .map((anchor) => anchor.href)
         .filter((href) => /example\.(com|org|net|test)|@demo\./i.test(href));
+      const invalidLinks = anchors.flatMap((anchor) => {
+        const href = anchor.getAttribute("href");
+        if (href != null && href.trim() && href.trim() !== "#" && !/^javascript:/i.test(href.trim())) return [];
+        return [{ href: href || "", text: (anchor.textContent || anchor.getAttribute("aria-label") || "").trim().slice(0, 120) }];
+      });
+      const rootHost = new URL(auditBaseUrl).hostname.replace(/^www\./i, "").toLowerCase();
+      const internalLinks = anchors.flatMap((anchor) => {
+        const raw = anchor.getAttribute("href");
+        if (!raw || /^(?:mailto:|tel:|sms:|javascript:)/i.test(raw)) return [];
+        try {
+          const url = new URL(raw, window.location.href);
+          if (!["http:", "https:"].includes(url.protocol)) return [];
+          if (url.hostname.replace(/^www\./i, "").toLowerCase() !== rootHost) return [];
+          url.hash = "";
+          return [{ url: url.toString(), download: anchor.hasAttribute("download") }];
+        } catch {
+          return [];
+        }
+      });
       const brokenImages = [...document.images]
         .filter((image) => image.currentSrc && image.complete && image.naturalWidth === 0)
         .map((image) => image.currentSrc);
+      const imagesWithoutAlt = [...document.images]
+        .filter((image) => !image.hasAttribute("alt"))
+        .map((image) => (image.currentSrc || image.getAttribute("src") || image.outerHTML).slice(0, 240));
+      const imageOnlyLinksWithoutText = anchors.flatMap((anchor) => {
+        const images = [...anchor.querySelectorAll("img")].filter((image) => image.getAttribute("alt") === "");
+        if (!images.length || anchor.getAttribute("aria-label") || anchor.getAttribute("title")) return [];
+        const textWithoutImages = [...anchor.childNodes]
+          .filter((node) => node.nodeType === Node.TEXT_NODE || node.nodeName !== "IMG")
+          .map((node) => node.textContent || "")
+          .join("")
+          .trim();
+        if (textWithoutImages) return [];
+        return images.map((image) => (image.currentSrc || image.getAttribute("src") || "unbekannt").slice(0, 240));
+      });
+      const errorView = document.querySelector('[data-testid^="error-title-"]')?.getAttribute("data-testid") || "";
       return {
         title: document.title,
         placeholders: [...new Set(placeholders)],
         reservedLinks: [...new Set(reservedLinks)],
+        invalidLinks,
+        internalLinks,
         brokenImages: [...new Set(brokenImages)],
+        imagesWithoutAlt: [...new Set(imagesWithoutAlt)],
+        imageOnlyLinksWithoutText: [...new Set(imageOnlyLinksWithoutText)],
+        errorView,
       };
-    }, placeholderPattern.source);
+    }, { placeholderSource: placeholderPattern.source, auditBaseUrl: baseUrl });
     const uniqueErrors = [...new Set(errors)];
     const status = response?.status() || 0;
-    if (status >= 400 || content.placeholders.length || content.reservedLinks.length || content.brokenImages.length || uniqueErrors.length) {
-      return { path, status, ...content, errors: uniqueErrors };
-    }
-    return null;
+    const { internalLinks, ...publicContent } = content;
+    const hasFinding = status >= 400
+      || publicContent.placeholders.length
+      || publicContent.reservedLinks.length
+      || publicContent.invalidLinks.length
+      || publicContent.brokenImages.length
+      || publicContent.imagesWithoutAlt.length
+      || publicContent.imageOnlyLinksWithoutText.length
+      || publicContent.errorView
+      || uniqueErrors.length;
+    return {
+      internalLinks,
+      finding: hasFinding ? { kind: "page", path, status, finalUrl: page.url(), ...publicContent, errors: uniqueErrors } : null,
+    };
   } catch (error) {
-    return { path, navigationError: error.message, errors: [...new Set(errors)] };
+    return {
+      internalLinks: [],
+      finding: { kind: "page", path, navigationError: error.message, errors: [...new Set(errors)] },
+    };
   } finally {
     await page.close();
   }
@@ -75,22 +206,76 @@ async function main() {
     }
   });
   const paths = [...new Set([...staticPaths, ...dynamicPaths])].slice(0, limit);
+  const scheduledPaths = new Set(paths);
+  const linkSources = new Map();
+  const resourceLinks = new Map();
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
   const findings = [];
   let cursor = 0;
 
-  async function worker() {
-    while (cursor < paths.length) {
-      const path = paths[cursor++];
-      const finding = await auditPage(context, path);
-      if (finding) findings.push(finding);
-    }
+  while (cursor < paths.length) {
+    const batch = paths.slice(cursor, cursor + concurrency);
+    cursor += batch.length;
+    const results = await Promise.all(batch.map((path) => auditPage(context, path)));
+    results.forEach((result, index) => {
+      const sourcePath = batch[index];
+      if (result.finding) findings.push(result.finding);
+      result.internalLinks.forEach((link) => {
+        if (!isInternalUrl(link.url)) return;
+        if (!linkSources.has(link.url)) linkSources.set(link.url, new Set());
+        linkSources.get(link.url).add(sourcePath);
+        if (isBrowserPageLink(link)) {
+          const path = urlPath(link.url);
+          if (!scheduledPaths.has(path) && paths.length < limit) {
+            scheduledPaths.add(path);
+            paths.push(path);
+          }
+        } else {
+          resourceLinks.set(link.url, link);
+        }
+      });
+    });
   }
 
-  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  const uncrawledPageLinks = [...linkSources.keys()]
+    .filter((url) => !resourceLinks.has(url) && !scheduledPaths.has(urlPath(url)));
+  if (uncrawledPageLinks.length) {
+    findings.push({
+      kind: "audit-limit",
+      error: `Audit-Limit ${limit} reicht nicht für alle entdeckten internen Seitenlinks`,
+      urls: uncrawledPageLinks,
+    });
+  }
+
+  const resourceResults = await runPool([...resourceLinks.values()], checkResourceLink, resourceConcurrency);
+  [...resourceLinks.values()].forEach((link, index) => {
+    const result = resourceResults[index];
+    if (result?.error || Number(result?.status || 0) >= 400) {
+      findings.push({
+        kind: "resource-link",
+        url: link.url,
+        linkedFrom: [...(linkSources.get(link.url) || [])],
+        ...result,
+      });
+    }
+  });
+
   await browser.close();
-  const result = { baseUrl, audited: paths.length, passed: paths.length - findings.length, findings };
+  findings.forEach((finding) => {
+    if (finding.kind !== "page" || finding.linkedFrom) return;
+    const target = `${baseUrl}${finding.path}`;
+    finding.linkedFrom = [...(linkSources.get(target) || [])];
+  });
+  const failedPages = findings.filter((finding) => finding.kind === "page").length;
+  const result = {
+    baseUrl,
+    audited: paths.length,
+    passed: paths.length - failedPages,
+    internalLinksChecked: linkSources.size,
+    resourceLinksChecked: resourceLinks.size,
+    findings,
+  };
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (findings.length) process.exitCode = 1;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -138,7 +138,7 @@ const AdminBoardPage = lazy(() => import("@/pages/admin/AdminBoardPage"));
 const AdminReferencesPage = lazy(() => import("@/pages/admin/AdminReferencesPage"));
 const AdminGameServersPage = lazy(() => import("@/pages/admin/AdminGameServersPage"));
 const SetupWizardPage = lazy(() => import("@/pages/SetupWizardPage"));
-import { NotFoundPage, ForbiddenPage } from "@/pages/ErrorPages";
+import { NotFoundPage, ForbiddenPage, ServerErrorPage } from "@/pages/ErrorPages";
 import { BoardPage, ValuesPage } from "@/pages/public/ClubPages";
 import CurrentSeasonRedirect from "@/pages/public/CurrentSeasonRedirect";
 
@@ -280,6 +280,7 @@ function App() {
 
           {/* Error pages */}
           <Route path="/403" element={<ForbiddenPage />} />
+          <Route path="/500" element={<ServerErrorPage />} />
           <Route path="*" element={<NotFoundPage />} />
             </Routes>
             </Suspense>

--- a/frontend/src/components/tls/RichContent.jsx
+++ b/frontend/src/components/tls/RichContent.jsx
@@ -47,9 +47,9 @@ function embedMeta(kind, item) {
   return { icon: Flag, accent: "text-[#29B6E8]", border: "hover:border-[#29B6E8]/60", to: `/fastlap/${item.slug || item.id}`, title: item.title, label: "Fast Lap" };
 }
 
-function TextChunk({ text }) {
+function TextChunk({ text, validProfileUsernames }) {
   if (!text) return null;
-  return <div className="prose-cms max-w-none" dangerouslySetInnerHTML={{ __html: renderMarkdownLite(text) }} />;
+  return <div className="prose-cms max-w-none" dangerouslySetInnerHTML={{ __html: renderMarkdownLite(text, { validProfileUsernames }) }} />;
 }
 
 function EmbedCard({ embed }) {
@@ -84,7 +84,7 @@ function EmbedCard({ embed }) {
   );
 }
 
-export function RichContent({ text = "", embeds = [], className = "" }) {
+export function RichContent({ text = "", embeds = [], validProfileUsernames, className = "" }) {
   const byToken = buildEmbedIndex(embeds);
   const parts = [];
   let lastIndex = 0;
@@ -103,7 +103,7 @@ export function RichContent({ text = "", embeds = [], className = "" }) {
       {parts.map((part, idx) => (
         part.type === "embed"
           ? <EmbedCard key={`${part.value.kind}-${part.value.ref}-${idx}`} embed={part.value} />
-          : <TextChunk key={`text-${idx}`} text={part.value} />
+          : <TextChunk key={`text-${idx}`} text={part.value} validProfileUsernames={validProfileUsernames} />
       ))}
     </div>
   );

--- a/frontend/src/lib/markdownLite.js
+++ b/frontend/src/lib/markdownLite.js
@@ -24,10 +24,29 @@ function sanitizeHref(rawHref) {
   }
 }
 
-function linkMentions(html) {
-  return html.replace(/(^|[^A-Za-z0-9_.-])@([A-Za-z0-9_.-]{2,32})/g, (match, prefix, username) => (
-    `${prefix}<a href="/u/${encodeURIComponent(username)}" class="mention-link">@${username}</a>`
-  ));
+function validProfileSet(options = {}) {
+  if (!Array.isArray(options.validProfileUsernames)) return null;
+  return new Set(options.validProfileUsernames.map((username) => String(username || "").toLowerCase()).filter(Boolean));
+}
+
+function allowedProfileLink(href, options = {}) {
+  const validProfiles = validProfileSet(options);
+  if (validProfiles == null) return true;
+  const match = String(href || "").match(/^\/u\/([^/?#]+)\/?(?:[?#].*)?$/i);
+  if (!match) return true;
+  try {
+    return validProfiles.has(decodeURIComponent(match[1]).toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function linkMentions(html, options = {}) {
+  const validProfiles = validProfileSet(options);
+  return html.replace(/(^|[^A-Za-z0-9_.-])@([A-Za-z0-9_.-]{2,32})/g, (match, prefix, username) => {
+    if (validProfiles != null && !validProfiles.has(username.toLowerCase())) return `${prefix}@${username}`;
+    return `${prefix}<a href="/u/${encodeURIComponent(username)}" class="mention-link">@${username}</a>`;
+  });
 }
 
 function formatInlineText(rawText, options = {}) {
@@ -37,23 +56,23 @@ function formatInlineText(rawText, options = {}) {
     .replace(/\+\+(.+?)\+\+/g, "<u>$1</u>")
     .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
     .replace(/\*(.+?)\*/g, "<em>$1</em>");
-  return options.linkMentions === false ? html : linkMentions(html);
+  return options.linkMentions === false ? html : linkMentions(html, options);
 }
 
-function renderInline(rawText) {
+function renderInline(rawText, options = {}) {
   const linkPattern = /(!?)\[([^\]\n]+)\]\(([^)\s]+)\)/g;
   let html = "";
   let lastIndex = 0;
   let match;
 
   while ((match = linkPattern.exec(rawText)) !== null) {
-    html += formatInlineText(rawText.slice(lastIndex, match.index));
+    html += formatInlineText(rawText.slice(lastIndex, match.index), options);
     const isImage = match[1] === "!";
-    const label = formatInlineText(match[2], { linkMentions: false });
+    const label = formatInlineText(match[2], { ...options, linkMentions: false });
     const href = sanitizeHref(match[3]);
     if (href && isImage) {
       html += `<img src="${escapeHtml(href)}" alt="${escapeHtml(match[2])}" loading="lazy"/>`;
-    } else if (href) {
+    } else if (href && allowedProfileLink(href, options)) {
       html += `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${label}</a>`;
     } else {
       html += label;
@@ -61,11 +80,11 @@ function renderInline(rawText) {
     lastIndex = match.index + match[0].length;
   }
 
-  html += formatInlineText(rawText.slice(lastIndex));
+  html += formatInlineText(rawText.slice(lastIndex), options);
   return html;
 }
 
-export function renderMarkdownLite(md) {
+export function renderMarkdownLite(md, options = {}) {
   if (!md) return "";
 
   const lines = String(md).split(/\r?\n/);
@@ -119,12 +138,12 @@ export function renderMarkdownLite(md) {
       }
       i -= 1;
       html += "<div class=\"prose-cms-table\"><table><thead><tr>";
-      html += headers.map((cell) => `<th>${renderInline(cell)}</th>`).join("");
+      html += headers.map((cell) => `<th>${renderInline(cell, options)}</th>`).join("");
       html += "</tr></thead><tbody>";
       rows.forEach((row) => {
         html += "<tr>";
         headers.forEach((_, index) => {
-          html += `<td>${renderInline(row[index] || "")}</td>`;
+          html += `<td>${renderInline(row[index] || "", options)}</td>`;
         });
         html += "</tr>";
       });
@@ -133,17 +152,17 @@ export function renderMarkdownLite(md) {
     }
     if (/^###\s+/.test(raw)) {
       close();
-      html += `<h3>${renderInline(raw.replace(/^###\s+/, ""))}</h3>`;
+      html += `<h3>${renderInline(raw.replace(/^###\s+/, ""), options)}</h3>`;
       continue;
     }
     if (/^##\s+/.test(raw)) {
       close();
-      html += `<h2>${renderInline(raw.replace(/^##\s+/, ""))}</h2>`;
+      html += `<h2>${renderInline(raw.replace(/^##\s+/, ""), options)}</h2>`;
       continue;
     }
     if (/^#\s+/.test(raw)) {
       close();
-      html += `<h1>${renderInline(raw.replace(/^#\s+/, ""))}</h1>`;
+      html += `<h1>${renderInline(raw.replace(/^#\s+/, ""), options)}</h1>`;
       continue;
     }
     if (/^\s*[-*]\s+/.test(raw)) {
@@ -152,12 +171,12 @@ export function renderMarkdownLite(md) {
         html += "<ul>";
         inList = "ul";
       }
-      html += `<li>${renderInline(raw.replace(/^\s*[-*]\s+/, ""))}</li>`;
+      html += `<li>${renderInline(raw.replace(/^\s*[-*]\s+/, ""), options)}</li>`;
       continue;
     }
     if (/^>\s?/.test(raw)) {
       close();
-      html += `<blockquote>${renderInline(raw.replace(/^>\s?/, ""))}</blockquote>`;
+      html += `<blockquote>${renderInline(raw.replace(/^>\s?/, ""), options)}</blockquote>`;
       continue;
     }
     if (/^\s*\d+\.\s+/.test(raw)) {
@@ -166,7 +185,7 @@ export function renderMarkdownLite(md) {
         html += "<ol>";
         inList = "ol";
       }
-      html += `<li>${renderInline(raw.replace(/^\s*\d+\.\s+/, ""))}</li>`;
+      html += `<li>${renderInline(raw.replace(/^\s*\d+\.\s+/, ""), options)}</li>`;
       continue;
     }
     if (/^---+$/.test(raw)) {
@@ -179,7 +198,7 @@ export function renderMarkdownLite(md) {
       continue;
     }
     close();
-    html += `<p>${renderInline(raw)}</p>`;
+    html += `<p>${renderInline(raw, options)}</p>`;
   }
 
   if (inCodeBlock) closeCodeBlock();

--- a/frontend/src/lib/markdownLite.test.js
+++ b/frontend/src/lib/markdownLite.test.js
@@ -1,0 +1,20 @@
+import { renderMarkdownLite } from "./markdownLite";
+
+test("news mentions only link to profiles confirmed as public", () => {
+  const html = renderMarkdownLite(
+    "[@PublicPlayer](/u/PublicPlayer), @PublicPlayer und [@FormerPlayer](/u/FormerPlayer), @FormerPlayer",
+    { validProfileUsernames: ["publicplayer"] },
+  );
+
+  expect(html).toContain('href="/u/PublicPlayer"');
+  expect(html).toContain('href="/u/PublicPlayer" class="mention-link"');
+  expect(html).not.toContain('href="/u/FormerPlayer"');
+  expect(html).toContain("@FormerPlayer");
+});
+
+test("generic markdown keeps existing profile-link behavior without an allowlist", () => {
+  const html = renderMarkdownLite("Hallo @Player und [Profil](/u/Player)");
+
+  expect(html).toContain('href="/u/Player" class="mention-link"');
+  expect(html).toContain('href="/u/Player"');
+});

--- a/frontend/src/pages/ErrorPages.jsx
+++ b/frontend/src/pages/ErrorPages.jsx
@@ -1,6 +1,7 @@
-import { Link, useRouteError } from "react-router-dom";
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
 import { PublicLayout } from "@/components/tls/PublicLayout";
-import { AlertTriangle, Home, ArrowLeft, ShieldOff, Search, Calendar, Trophy, Newspaper, Medal } from "lucide-react";
+import { AlertTriangle, Home, ArrowLeft, ShieldOff, Search, Calendar, Trophy, Newspaper, Medal, LogIn, RefreshCw } from "lucide-react";
 
 const ERROR_DEFS = {
   "404": { code: "404", title: "Seite nicht gefunden", desc: "Diese Seite gibt es nicht (mehr) — vielleicht hast du dich verlaufen.", icon: Search, accent: "#29B6E8" },
@@ -19,17 +20,43 @@ const QUICK_LINKS = [
 export function ErrorPage({ code = "404" }) {
   const def = ERROR_DEFS[code] || ERROR_DEFS["404"];
   const Icn = def.icon;
+  useEffect(() => {
+    const previousTitle = document.title;
+    let robots = document.head.querySelector('meta[name="robots"]');
+    const createdRobots = !robots;
+    const previousRobots = robots?.getAttribute("content");
+    if (!robots) {
+      robots = document.createElement("meta");
+      robots.setAttribute("name", "robots");
+      document.head.appendChild(robots);
+    }
+    robots.setAttribute("content", "noindex, nofollow");
+    document.title = `${def.code} – ${def.title} | THE LION SQUAD`;
+
+    return () => {
+      document.title = previousTitle;
+      if (createdRobots) robots.remove();
+      else if (previousRobots == null) robots.removeAttribute("content");
+      else robots.setAttribute("content", previousRobots);
+    };
+  }, [def.code, def.title]);
+
+  const goBack = () => {
+    if (Number(window.history.state?.idx || 0) > 0) window.history.back();
+    else window.location.assign("/");
+  };
+
   return (
     <PublicLayout>
       <div className="min-h-[70vh] flex items-center justify-center px-4 py-16">
-        <div className="text-center max-w-2xl">
+        <section className="text-center max-w-2xl" aria-labelledby={`error-heading-${def.code}`}>
           <div className="relative inline-block mb-6">
             <span className="font-display text-[160px] md:text-[200px] font-black leading-none" style={{ color: def.accent, opacity: 0.15 }}>
               {def.code}
             </span>
             <Icn className="w-20 h-20 absolute inset-0 m-auto" style={{ color: def.accent }} />
           </div>
-          <h1 className="font-heading text-3xl md:text-5xl font-black uppercase mb-3" data-testid={`error-title-${code}`}>
+          <h1 id={`error-heading-${def.code}`} className="font-heading text-3xl md:text-5xl font-black uppercase mb-3" data-testid={`error-title-${def.code}`}>
             {def.title}
           </h1>
           <p className="text-white/60 mb-8">{def.desc}</p>
@@ -37,7 +64,17 @@ export function ErrorPage({ code = "404" }) {
             <Link to="/" data-testid="error-home-btn" className="px-5 py-2.5 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm inline-flex items-center gap-2">
               <Home className="w-4 h-4" /> Zur Startseite
             </Link>
-            <button onClick={() => window.history.back()} data-testid="error-back-btn" className="px-5 py-2.5 border border-white/20 text-white font-bold uppercase tracking-wider rounded-sm inline-flex items-center gap-2 hover:border-white/40">
+            {def.code === "403" && (
+              <Link to="/login" data-testid="error-login-btn" className="px-5 py-2.5 border border-[#FFD700]/40 text-[#FFD700] font-bold uppercase tracking-wider rounded-sm inline-flex items-center gap-2 hover:bg-[#FFD700]/10">
+                <LogIn className="w-4 h-4" /> Einloggen
+              </Link>
+            )}
+            {def.code === "500" && (
+              <button type="button" onClick={() => window.location.reload()} data-testid="error-retry-btn" className="px-5 py-2.5 border border-[#FF3B30]/40 text-[#FF8A80] font-bold uppercase tracking-wider rounded-sm inline-flex items-center gap-2 hover:bg-[#FF3B30]/10">
+                <RefreshCw className="w-4 h-4" /> Erneut versuchen
+              </button>
+            )}
+            <button type="button" onClick={goBack} data-testid="error-back-btn" className="px-5 py-2.5 border border-white/20 text-white font-bold uppercase tracking-wider rounded-sm inline-flex items-center gap-2 hover:border-white/40">
               <ArrowLeft className="w-4 h-4" /> Zurück
             </button>
           </div>
@@ -56,7 +93,7 @@ export function ErrorPage({ code = "404" }) {
               );
             })}
           </div>
-        </div>
+        </section>
       </div>
     </PublicLayout>
   );
@@ -64,9 +101,4 @@ export function ErrorPage({ code = "404" }) {
 
 export function NotFoundPage() { return <ErrorPage code="404" />; }
 export function ForbiddenPage() { return <ErrorPage code="403" />; }
-export function ServerErrorPage() {
-  const error = useRouteError();
-  // log to console for debugging
-  if (error) console.error("[TLS] route error:", error);
-  return <ErrorPage code="500" />;
-}
+export function ServerErrorPage() { return <ErrorPage code="500" />; }

--- a/frontend/src/pages/public/NewsDetailPage.jsx
+++ b/frontend/src/pages/public/NewsDetailPage.jsx
@@ -69,7 +69,12 @@ export default function NewsDetailPage() {
             <img src={resolveMediaUrl(post.banner_url)} alt="" loading="lazy" decoding="async" className="w-full h-auto" />
           </div>
         )}
-        <RichContent text={post.content} embeds={post.content_embeds || []} className="mt-8 prose prose-invert max-w-none text-white/85" />
+        <RichContent
+          text={post.content}
+          embeds={post.content_embeds || []}
+          validProfileUsernames={(post.mentioned_users || []).map((user) => user.username)}
+          className="mt-8 prose prose-invert max-w-none text-white/85"
+        />
 
         {post.mentioned_users?.length > 0 && (
           <div className="mt-10 border-t border-white/10 pt-8">


### PR DESCRIPTION
## Was geändert wurde

- `audit:public` folgt jetzt dem gerenderten internen Linkgraphen und prüft ungültige Links, Redirect-Konvergenz, interne Download-Ressourcen, fehlende `alt`-Attribute, kaputte Bilder und gerenderte Fehleransichten.
- Das Audit-Limit und die ressourcenschonende PDF-Prüfung wurden für den vollständigen Produktionsbestand angepasst.
- 403-, 404- und 500-Ansichten besitzen klare Wiederherstellungsaktionen, sinnvolle Navigation, Seitentitel und `noindex, nofollow`.
- News verlinken historische Erwähnungen nur noch dann auf `/u/<username>`, wenn das Backend das Profil weiterhin als öffentlich bestätigt. Nicht mehr verfügbare Profile bleiben als lesbarer Text erhalten.

## Warum

Der erweiterte Live-Linkgraph fand einen historischen News-Link auf `/u/Marcel_Ruhs`, dessen öffentliches Profil inzwischen 404 liefert. Der Inhalt soll erhalten bleiben, Besucher dürfen aber nicht auf einer Sackgasse landen. Der bisherige Produktions-Crawler prüfte außerdem nur Sitemap-/Startrouten und Bilder, nicht den gesamten internen Linkgraphen oder Alt-Attribute.

## Auswirkung

- Kaputte interne Ziele und Ressourcen werden reproduzierbar erkannt.
- Historische News bleiben inhaltlich vollständig, erzeugen aber keine Links auf private, inaktive oder entfernte Profile.
- Fehlerzustände helfen Nutzern gezielt zurück zu Login, Startseite oder einem erneuten Versuch.

## Verifikation

- Frontend-Produktionsbuild: grün
- Unit: 10/10 grün
- Playwright Desktop/Mobile: 30 grün, 8 zugangspflichtige Live-Admin-Tests erwartungsgemäß übersprungen
- Erweiterter Live-Audit vor dem Fix: 143 Seiten, 157 interne Links und 14 Ressourcen; einziger reproduzierbarer Treffer war das in diesem PR behandelte historische Profil

Teil von #95.