### PR TITLE
fix: harden core form submissions

### DIFF
--- a/backend/routes/contact_board_routes.py
+++ b/backend/routes/contact_board_routes.py
@@ -8,7 +8,7 @@
 from html import escape
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from typing import Optional, Literal, List
 
 from database import get_db
@@ -48,6 +48,15 @@ class ContactSubmit(BaseModel):
     message: str = Field(min_length=5, max_length=4000)
     related_id: Optional[str] = None  # tournament_id / event_id / etc.
     accept_privacy: bool = Field(..., description="Must be explicitly true")
+
+    @field_validator("name", "subject", "message")
+    @classmethod
+    def clean_required_text(cls, value: str, info):
+        cleaned = value.strip()
+        minimum = {"name": 2, "subject": 2, "message": 5}[info.field_name]
+        if len(cleaned) < minimum:
+            raise ValueError(f"{info.field_name} ist zu kurz")
+        return cleaned
 
 
 def _html(value: object) -> str:

--- a/backend/routes/phase_c_routes.py
+++ b/backend/routes/phase_c_routes.py
@@ -9,7 +9,7 @@ Endpoints:
 import html
 
 from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Literal
 
 from database import get_db
@@ -58,7 +58,21 @@ class ApplyBody(BaseModel):
     contribution_pref: Literal["full", "supporter", "youth", "honorary"] = "full"
     accept_statutes: bool
     accept_privacy: bool
-    notes: Optional[str] = None
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+    @field_validator("motivation")
+    @classmethod
+    def clean_motivation(cls, value: str):
+        cleaned = value.strip()
+        if len(cleaned) < 20:
+            raise ValueError("Motivation muss mindestens 20 Zeichen enthalten")
+        return cleaned
+
+    @field_validator("notes")
+    @classmethod
+    def clean_notes(cls, value: Optional[str]):
+        cleaned = str(value or "").strip()
+        return cleaned or None
 
 
 @router.post("/membership/apply")

--- a/backend/tests/test_form_validation_unit.py
+++ b/backend/tests/test_form_validation_unit.py
@@ -1,0 +1,75 @@
+import pytest
+from pydantic import ValidationError
+
+from routes.contact_board_routes import ContactSubmit
+from routes.phase_c_routes import ApplyBody
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("name", "  "),
+        ("subject", " \n "),
+        ("message", "     "),
+    ],
+)
+def test_contact_rejects_required_text_that_is_only_whitespace(field, value):
+    payload = {
+        "name": "Test Person",
+        "email": "person@example.com",
+        "topic": "general",
+        "subject": "Testanfrage",
+        "message": "Eine echte Nachricht",
+        "accept_privacy": True,
+    }
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        ContactSubmit(**payload)
+
+
+def test_contact_normalizes_required_text_before_persisting():
+    body = ContactSubmit(
+        name="  Test Person  ",
+        email="person@example.com",
+        topic="general",
+        subject="  Testanfrage  ",
+        message="  Eine echte Nachricht  ",
+        accept_privacy=True,
+    )
+
+    assert body.name == "Test Person"
+    assert body.subject == "Testanfrage"
+    assert body.message == "Eine echte Nachricht"
+
+
+def test_membership_application_rejects_whitespace_motivation_and_bounds_notes():
+    with pytest.raises(ValidationError):
+        ApplyBody(
+            motivation=" " * 30,
+            contribution_pref="full",
+            accept_statutes=True,
+            accept_privacy=True,
+        )
+
+    with pytest.raises(ValidationError):
+        ApplyBody(
+            motivation="Ich möchte den Verein aktiv unterstützen.",
+            contribution_pref="full",
+            accept_statutes=True,
+            accept_privacy=True,
+            notes="x" * 2001,
+        )
+
+
+def test_membership_application_normalizes_optional_text():
+    body = ApplyBody(
+        motivation="  Ich möchte den Verein aktiv unterstützen.  ",
+        contribution_pref="full",
+        accept_statutes=True,
+        accept_privacy=True,
+        notes="   ",
+    )
+
+    assert body.motivation == "Ich möchte den Verein aktiv unterstützen."
+    assert body.notes is None

--- a/frontend/e2e/public.spec.js
+++ b/frontend/e2e/public.spec.js
@@ -25,6 +25,16 @@ async function expectNoPageXOverflow(page) {
   expect(overflow).toBeLessThanOrEqual(1);
 }
 
+async function dispatchDoubleSubmit(page, submitTestId) {
+  await page.evaluate((testId) => {
+    const submitter = document.querySelector(`[data-testid="${testId}"]`);
+    const form = submitter?.closest("form");
+    if (!form) throw new Error(`Form for ${testId} not found`);
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  }, submitTestId);
+}
+
 const canonicalPublicSettings = {
   club_name: "THE LION SQUAD - eSPORTS",
   tagline: "Verein",
@@ -95,6 +105,172 @@ test("news keeps stale mentions as text without linking to unavailable profiles"
   await expect(content).toContainText("@PublicPlayer und @FormerPlayer");
   await expect(content.locator('a[href="/u/PublicPlayer"]')).toHaveCount(1);
   await expect(content.locator('a[href="/u/FormerPlayer"]')).toHaveCount(0);
+});
+
+test("contact form validates fields, prevents duplicate submits and confirms success", async ({ page }) => {
+  await mockPublicChrome(page);
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
+  await page.route("**/api/contact/topics", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify([{ value: "general", label: "Allgemein" }]),
+  }));
+  let submissions = 0;
+  await page.route("**/api/contact/submit", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ ok: true, id: "contact-1" }) });
+  });
+
+  await page.goto("/contact");
+  await acceptCookies(page);
+  await page.getByTestId("contact-submit").click();
+  await expect(page.locator("#contact-name-error")).toBeVisible();
+  await expect(page.getByTestId("contact-name")).toBeFocused();
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("contact-name").fill("Test Person");
+  await page.getByTestId("contact-email-input").fill("person@example.com");
+  await page.getByTestId("contact-subject").fill("Testanfrage");
+  await page.getByTestId("contact-message").fill("Das ist eine echte Testnachricht.");
+  await page.getByTestId("contact-privacy").check();
+  await dispatchDoubleSubmit(page, "contact-submit");
+
+  await expect(page.getByTestId("contact-success")).toBeVisible();
+  expect(submissions).toBe(1);
+});
+
+test("membership application waits for auth, validates inline and submits only once", async ({ page }) => {
+  await mockPublicChrome(page);
+  const user = { id: "user-1", username: "testplayer", display_name: "Test Player", role: "player", user_type: "community_user" };
+  let application = null;
+  let submissions = 0;
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: JSON.stringify(user) }));
+  await page.route("**/api/membership/apply/me", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(application),
+  }));
+  await page.route("**/api/membership/apply", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    application = { id: "application-1", status: "pending", created_at: "2026-08-12T10:00:00Z" };
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(application) });
+  });
+
+  await page.goto("/membership/apply");
+  await acceptCookies(page);
+  await expect(page.getByTestId("apply-form")).toBeVisible();
+  await page.getByTestId("apply-submit").click();
+  await expect(page.locator("#apply-motivation-error")).toBeVisible();
+  await expect(page.getByTestId("apply-motivation")).toBeFocused();
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("apply-motivation").fill("Ich möchte den Verein langfristig aktiv unterstützen.");
+  await page.getByTestId("apply-statutes").check();
+  await page.getByTestId("apply-privacy").check();
+  await dispatchDoubleSubmit(page, "apply-submit");
+
+  await expect(page.getByTestId("apply-pending")).toBeVisible();
+  expect(submissions).toBe(1);
+});
+
+test("login shows inline validation and blocks simultaneous requests", async ({ page }) => {
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
+  let submissions = 0;
+  await page.route("**/api/auth/login", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({ status: 401, contentType: "application/json", body: JSON.stringify({ detail: "Ungültige Zugangsdaten" }) });
+  });
+
+  await page.goto("/login");
+  await acceptCookies(page);
+  await page.getByTestId("login-submit").click();
+  await expect(page.locator("#login-email-error")).toBeVisible();
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("login-email").fill("person@example.com");
+  await page.getByTestId("login-password").fill("ungueltiges-passwort");
+  await dispatchDoubleSubmit(page, "login-submit");
+
+  await expect(page.locator("#login-error")).toContainText("Ungültige Zugangsdaten");
+  await expect(page.getByTestId("login-submit")).toBeEnabled();
+  expect(submissions).toBe(1);
+});
+
+test("registration validates consent and exposes a single API failure", async ({ page }) => {
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
+  let submissions = 0;
+  await page.route("**/api/auth/register", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({ status: 409, contentType: "application/json", body: JSON.stringify({ detail: "Benutzername bereits vergeben" }) });
+  });
+
+  await page.goto("/register");
+  await acceptCookies(page);
+  await page.getByTestId("register-submit").click();
+  await expect(page.locator("#register-username-error")).toBeVisible();
+  await expect(page.getByTestId("register-username")).toBeFocused();
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("register-username").fill("newplayer");
+  await page.getByTestId("register-email").fill("newplayer@example.com");
+  await page.getByTestId("register-password").fill("sicheres-passwort");
+  await page.getByTestId("register-accept").check();
+  await page.getByTestId("register-accept-terms").check();
+  await dispatchDoubleSubmit(page, "register-submit");
+
+  await expect(page.locator("#register-error")).toContainText("Benutzername bereits vergeben");
+  await expect(page.getByTestId("register-submit")).toBeEnabled();
+  expect(submissions).toBe(1);
+});
+
+test("password recovery prevents duplicate mail requests and shows a stable success state", async ({ page }) => {
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
+  let submissions = 0;
+  await page.route("**/api/auth/forgot-password", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/forgot-password");
+  await acceptCookies(page);
+  await page.getByTestId("forgot-submit").click();
+  await expect(page.locator("#forgot-email-error")).toBeVisible();
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("forgot-email").fill("person@example.com");
+  await dispatchDoubleSubmit(page, "forgot-submit");
+
+  await expect(page.locator("#forgot-success")).toBeVisible();
+  expect(submissions).toBe(1);
+});
+
+test("password reset validates confirmation and keeps an API error visible", async ({ page }) => {
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
+  let submissions = 0;
+  await page.route("**/api/auth/reset-password", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({ status: 400, contentType: "application/json", body: JSON.stringify({ detail: "Token abgelaufen" }) });
+  });
+
+  await page.goto("/reset-password?token=expired-token");
+  await acceptCookies(page);
+  await page.getByTestId("reset-submit").click();
+  await expect(page.locator("#reset-password-error")).toBeVisible();
+  await expect(page.getByTestId("reset-password")).toBeFocused();
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("reset-password").fill("neues-passwort");
+  await page.getByTestId("reset-password-confirm").fill("neues-passwort");
+  await dispatchDoubleSubmit(page, "reset-submit");
+
+  await expect(page.locator("#reset-submit-error")).toContainText("Token abgelaufen");
+  await expect(page.getByTestId("reset-submit")).toBeEnabled();
+  expect(submissions).toBe(1);
 });
 
 test("contact and legal pages share one configured public data source", async ({ page }) => {

--- a/frontend/src/hooks/useSubmissionGuard.js
+++ b/frontend/src/hooks/useSubmissionGuard.js
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Runs at most one form submission at a time.
+ *
+ * The ref is updated synchronously, unlike React state, so two submit events in
+ * the same render cycle cannot start duplicate requests. State remains the
+ * public UI signal for disabled/loading feedback.
+ */
+export function useSubmissionGuard() {
+  const lockedRef = useRef(false);
+  const mountedRef = useRef(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const submitOnce = useCallback(async (task) => {
+    if (lockedRef.current) return { started: false };
+    lockedRef.current = true;
+    setSubmitting(true);
+    try {
+      return { started: true, value: await task() };
+    } catch (error) {
+      return { started: true, error };
+    } finally {
+      lockedRef.current = false;
+      if (mountedRef.current) setSubmitting(false);
+    }
+  }, []);
+
+  return { submitting, submitOnce };
+}

--- a/frontend/src/pages/public/ContactPage.jsx
+++ b/frontend/src/pages/public/ContactPage.jsx
@@ -7,8 +7,12 @@ import { useAuth } from "@/context/AuthContext";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { usePublicSiteSettings } from "@/hooks/usePublicSiteSettings";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { toast } from "sonner";
 import { Mail, MessageSquare, MapPin, Send, Check } from "lucide-react";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function ContactPage() {
   useDocumentTitle(
@@ -20,7 +24,9 @@ export default function ContactPage() {
   const branding = usePublicSiteSettings();
   const [topics, setTopics] = useState([]);
   const [done, setDone] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
+  const { submitting, submitOnce } = useSubmissionGuard();
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState("");
   const [form, setForm] = useState({
     name: user?.display_name || user?.username || "",
     email: user?.email || "",
@@ -36,18 +42,49 @@ export default function ContactPage() {
   useEffect(() => { loadTopics(); }, [loadTopics]);
   useApiInvalidation(loadTopics, ["contact"]);
 
+  const updateField = (field, value) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: null }));
+    setSubmitError("");
+  };
+
+  const validate = () => {
+    const errors = {};
+    if (form.name.trim().length < 2) errors.name = "Bitte gib deinen Namen mit mindestens 2 Zeichen ein.";
+    if (!form.email.trim()) errors.email = "Bitte gib deine E-Mail-Adresse ein.";
+    else if (!EMAIL_RE.test(form.email.trim())) errors.email = "Bitte gib eine gültige E-Mail-Adresse ein.";
+    if (!form.topic) errors.topic = "Bitte wähle ein Thema aus.";
+    if (form.subject.trim().length < 2) errors.subject = "Bitte gib einen Betreff mit mindestens 2 Zeichen ein.";
+    if (form.message.trim().length < 5) errors.message = "Bitte beschreibe dein Anliegen mit mindestens 5 Zeichen.";
+    if (!form.accept_privacy) errors.accept_privacy = "Bitte akzeptiere den Datenschutz-Hinweis.";
+    setFieldErrors(errors);
+    const first = ["name", "email", "topic", "subject", "message", "accept_privacy"].find((field) => errors[field]);
+    if (first) document.getElementById(`contact-${first.replace("accept_privacy", "privacy")}`)?.focus();
+    return Object.keys(errors).length === 0;
+  };
+
   const submit = async (e) => {
     e.preventDefault();
-    if (!form.accept_privacy) { toast.error("Bitte Datenschutz-Hinweis bestätigen."); return; }
-    setSubmitting(true);
-    try {
-      await api.post("/contact/submit", form);
+    if (!validate()) return;
+    const payload = {
+      ...form,
+      name: form.name.trim(),
+      email: form.email.trim(),
+      subject: form.subject.trim(),
+      message: form.message.trim(),
+    };
+    setSubmitError("");
+    const attempt = await submitOnce(() => api.post("/contact/submit", payload));
+    if (!attempt.started) return;
+    if (!attempt.error) {
       setDone(true);
       toast.success("Nachricht gesendet — Bestätigungsmail folgt.");
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail) || "Fehler beim Versand.");
+    } else {
+      const err = attempt.error;
+      const message = formatApiError(err.response?.data?.detail) || "Fehler beim Versand.";
+      setSubmitError(message);
+      toast.error(message);
     }
-    setSubmitting(false);
   };
 
   const contactEmail = branding?.contact_email;
@@ -86,40 +123,41 @@ export default function ContactPage() {
         {/* Formular */}
         <div className="mt-10 border border-white/10 rounded-sm bg-[#121212] p-6 md:p-8">
           {done ? (
-            <div className="text-center py-12" data-testid="contact-success">
+            <div className="text-center py-12" data-testid="contact-success" role="status" aria-live="polite">
               <div className="w-14 h-14 rounded-full bg-[#00FF88]/10 border-2 border-[#00FF88] flex items-center justify-center mx-auto mb-4">
                 <Check className="w-7 h-7 text-[#00FF88]" />
               </div>
               <h2 className="font-heading text-2xl font-black uppercase">Nachricht gesendet</h2>
               <p className="mt-2 text-white/70">Eine Bestätigungsmail ist unterwegs. Wir melden uns so bald wie möglich.</p>
-              <button onClick={() => { setDone(false); setForm({ ...form, subject: "", message: "" }); }} className="mt-5 text-xs uppercase tracking-wider text-[#29B6E8] hover:underline">Weitere Nachricht senden</button>
+              <button type="button" onClick={() => { setDone(false); setFieldErrors({}); setSubmitError(""); setForm((current) => ({ ...current, subject: "", message: "", accept_privacy: false })); }} className="mt-5 text-xs uppercase tracking-wider text-[#29B6E8] hover:underline">Weitere Nachricht senden</button>
             </div>
           ) : (
-            <form onSubmit={submit} className="space-y-4">
+            <form onSubmit={submit} className="space-y-4" noValidate>
               <h2 className="font-heading text-xl font-black uppercase mb-2">Schreib uns</h2>
               <div className="grid md:grid-cols-2 gap-4">
-                <Field label="Name *">
-                  <input required value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} data-testid="contact-name" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
+                <Field id="contact-name" label="Name *" error={fieldErrors.name}>
+                  <input id="contact-name" required value={form.name} onChange={(e) => updateField("name", e.target.value)} data-testid="contact-name" aria-invalid={!!fieldErrors.name} aria-describedby={fieldErrors.name ? "contact-name-error" : undefined} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
                 </Field>
-                <Field label="E-Mail *">
-                  <input type="email" required value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} data-testid="contact-email-input" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
+                <Field id="contact-email" label="E-Mail *" error={fieldErrors.email}>
+                  <input id="contact-email" type="email" required value={form.email} onChange={(e) => updateField("email", e.target.value)} data-testid="contact-email-input" aria-invalid={!!fieldErrors.email} aria-describedby={fieldErrors.email ? "contact-email-error" : undefined} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
                 </Field>
               </div>
-              <Field label="Thema *">
-                <select required value={form.topic} onChange={(e) => setForm({ ...form, topic: e.target.value })} data-testid="contact-topic" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm">
+              <Field id="contact-topic" label="Thema *" error={fieldErrors.topic}>
+                <select id="contact-topic" required value={form.topic} onChange={(e) => updateField("topic", e.target.value)} data-testid="contact-topic" aria-invalid={!!fieldErrors.topic} aria-describedby={fieldErrors.topic ? "contact-topic-error" : undefined} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm">
                   {topics.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
                 </select>
               </Field>
-              <Field label="Betreff *">
-                <input required minLength={2} maxLength={200} value={form.subject} onChange={(e) => setForm({ ...form, subject: e.target.value })} data-testid="contact-subject" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
+              <Field id="contact-subject" label="Betreff *" error={fieldErrors.subject}>
+                <input id="contact-subject" required minLength={2} maxLength={200} value={form.subject} onChange={(e) => updateField("subject", e.target.value)} data-testid="contact-subject" aria-invalid={!!fieldErrors.subject} aria-describedby={fieldErrors.subject ? "contact-subject-error" : undefined} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
               </Field>
-              <Field label="Nachricht *">
-                <textarea required minLength={5} maxLength={4000} rows={6} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} data-testid="contact-message" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm resize-y" />
+              <Field id="contact-message" label="Nachricht *" error={fieldErrors.message}>
+                <textarea id="contact-message" required minLength={5} maxLength={4000} rows={6} value={form.message} onChange={(e) => updateField("message", e.target.value)} data-testid="contact-message" aria-invalid={!!fieldErrors.message} aria-describedby={fieldErrors.message ? "contact-message-error" : undefined} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm resize-y" />
               </Field>
               <label className="flex items-start gap-2 text-sm text-white/70">
-                <input type="checkbox" required checked={form.accept_privacy} onChange={(e) => setForm({ ...form, accept_privacy: e.target.checked })} data-testid="contact-privacy" className="mt-1 accent-[#29B6E8]" />
-                <span>Ich habe die <Link to="/privacy" className="text-[#29B6E8] hover:underline">Datenschutzhinweise</Link> gelesen und stimme der Speicherung meiner Angaben zur Bearbeitung der Anfrage zu.</span>
+                <input id="contact-privacy" type="checkbox" required checked={form.accept_privacy} onChange={(e) => updateField("accept_privacy", e.target.checked)} data-testid="contact-privacy" aria-invalid={!!fieldErrors.accept_privacy} aria-describedby={fieldErrors.accept_privacy ? "contact-privacy-error" : undefined} className="mt-1 accent-[#29B6E8]" />
+                <span>Ich habe die <Link to="/privacy" className="text-[#29B6E8] hover:underline">Datenschutzhinweise</Link> gelesen und stimme der Speicherung meiner Angaben zur Bearbeitung der Anfrage zu.{fieldErrors.accept_privacy && <span id="contact-privacy-error" role="alert" className="block mt-1 text-xs text-[#FF8A80]">{fieldErrors.accept_privacy}</span>}</span>
               </label>
+              {submitError && <AuthFormAlert id="contact-submit-error">{submitError}</AuthFormAlert>}
               <button type="submit" disabled={submitting} data-testid="contact-submit" className="inline-flex items-center gap-2 px-6 py-3 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm hover:bg-[#1E95C2] transition disabled:opacity-50">
                 <Send className="w-4 h-4" /> {submitting ? "Sende…" : "Nachricht senden"}
               </button>
@@ -142,11 +180,12 @@ export default function ContactPage() {
   );
 }
 
-function Field({ label, children }) {
+function Field({ id, label, error, children }) {
   return (
-    <label className="block">
+    <label htmlFor={id} className="block">
       <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">{label}</div>
       {children}
+      {error && <div id={`${id}-error`} role="alert" className="mt-1 text-xs text-[#FF8A80]">{error}</div>}
     </label>
   );
 }

--- a/frontend/src/pages/public/LoginPage.jsx
+++ b/frontend/src/pages/public/LoginPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 import { Logo } from "@/components/tls/Logo";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { AuthFormAlert, AuthPasswordField, AuthTextField } from "@/components/tls/AuthFormFields";
 import { toast } from "sonner";
 
@@ -18,7 +19,7 @@ export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [pw, setPw] = useState("");
   const [showPw, setShowPw] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
   const [err, setErr] = useState(null);
   const [fieldErrors, setFieldErrors] = useState({});
 
@@ -45,9 +46,13 @@ export default function LoginPage() {
     if (!validate()) return;
 
     setErr(null);
-    setLoading(true);
-    const res = await login(email.trim(), pw);
-    setLoading(false);
+    const attempt = await submitOnce(() => login(email.trim(), pw));
+    if (!attempt.started) return;
+    if (attempt.error) {
+      setErr("Login konnte nicht abgeschlossen werden. Bitte versuche es erneut.");
+      return;
+    }
+    const res = attempt.value;
 
     if (res.ok) {
       toast.success("Willkommen zurück!");

--- a/frontend/src/pages/public/MembershipApplyPage.jsx
+++ b/frontend/src/pages/public/MembershipApplyPage.jsx
@@ -10,6 +10,8 @@ import { PublicLayout } from "@/components/tls/PublicLayout";
 import { useAuth } from "@/context/AuthContext";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { toast } from "sonner";
 import { Crown, CheckCircle2, FileText, Mail } from "lucide-react";
 
@@ -38,9 +40,12 @@ export default function MembershipApplyPage() {
     accept_privacy: false,
     notes: "",
   });
-  const [submitting, setSubmitting] = useState(false);
+  const { submitting, submitOnce } = useSubmissionGuard();
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState("");
 
   const loadExisting = useCallback(() => {
+    if (user === undefined) return;
     if (!user) { nav("/login?next=/membership/apply"); return; }
     setLoading(true);
     return api.get("/membership/apply/me").then(({ data }) => { setExisting(data); setLoading(false); }).catch(() => setLoading(false));
@@ -48,17 +53,39 @@ export default function MembershipApplyPage() {
   useEffect(() => { loadExisting(); }, [loadExisting]);
   useApiInvalidation(loadExisting, ["membership"]);
 
+  const updateField = (field, value) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: null }));
+    setSubmitError("");
+  };
+
+  const validate = () => {
+    const errors = {};
+    if (form.motivation.trim().length < 20) errors.motivation = "Bitte beschreibe deine Motivation mit mindestens 20 Zeichen.";
+    if (!form.accept_statutes) errors.accept_statutes = "Bitte akzeptiere die Vereinsstatuten.";
+    if (!form.accept_privacy) errors.accept_privacy = "Bitte akzeptiere die Datenschutzerklärung.";
+    setFieldErrors(errors);
+    const first = ["motivation", "accept_statutes", "accept_privacy"].find((field) => errors[field]);
+    if (first) document.getElementById(`apply-${first.replace("accept_", "")}`)?.focus();
+    return Object.keys(errors).length === 0;
+  };
+
   const submit = async (e) => {
     e.preventDefault();
-    if (!form.accept_statutes || !form.accept_privacy) { toast.error("Bitte Statuten und Datenschutz akzeptieren."); return; }
-    if (form.motivation.length < 20) { toast.error("Motivation: mind. 20 Zeichen."); return; }
-    setSubmitting(true);
-    try {
-      const { data } = await api.post("/membership/apply", form);
-      setExisting(data);
+    if (!validate()) return;
+    const payload = { ...form, motivation: form.motivation.trim(), notes: form.notes.trim() || null };
+    setSubmitError("");
+    const attempt = await submitOnce(() => api.post("/membership/apply", payload));
+    if (!attempt.started) return;
+    if (!attempt.error) {
+      setExisting(attempt.value.data);
       toast.success("Bewerbung eingereicht! Wir melden uns per Mail.");
-    } catch (err) { toast.error(formatApiError(err.response?.data?.detail) || "Fehler"); }
-    setSubmitting(false);
+    } else {
+      const err = attempt.error;
+      const message = formatApiError(err.response?.data?.detail) || "Bewerbung konnte nicht gesendet werden.";
+      setSubmitError(message);
+      toast.error(message);
+    }
   };
 
   return (
@@ -77,28 +104,29 @@ export default function MembershipApplyPage() {
         ) : existing && existing.status === "rejected" ? (
           <StatusCard testId="apply-rejected" icon={FileText} color="#FF3B30" title="Bewerbung abgelehnt" body={existing.decision_note || "Du kannst zu einem späteren Zeitpunkt erneut versuchen."} />
         ) : (
-          <form onSubmit={submit} className="mt-8 space-y-5 border border-white/10 bg-[#121212] rounded-sm p-6" data-testid="apply-form">
-            <Field label="Beitragsart">
-              <select className="input" value={form.contribution_pref} onChange={(e) => setForm({ ...form, contribution_pref: e.target.value })} data-testid="apply-contribution">
+          <form onSubmit={submit} className="mt-8 space-y-5 border border-white/10 bg-[#121212] rounded-sm p-6" data-testid="apply-form" noValidate>
+            <Field id="apply-contribution" label="Beitragsart">
+              <select id="apply-contribution" className="input" value={form.contribution_pref} onChange={(e) => updateField("contribution_pref", e.target.value)} data-testid="apply-contribution">
                 {CONTRIB_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
               </select>
             </Field>
-            <Field label={`Motivation (${form.motivation.length}/2000)`}>
-              <textarea required minLength={20} maxLength={2000} rows={6} value={form.motivation} onChange={(e) => setForm({ ...form, motivation: e.target.value })} placeholder="Warum möchtest du Mitglied werden? Welche Spiele/Plattformen? Wie viel Zeit kannst du einbringen?" className="input" data-testid="apply-motivation" />
+            <Field id="apply-motivation" label={`Motivation (${form.motivation.length}/2000)`} error={fieldErrors.motivation}>
+              <textarea id="apply-motivation" required minLength={20} maxLength={2000} rows={6} value={form.motivation} onChange={(e) => updateField("motivation", e.target.value)} placeholder="Warum möchtest du Mitglied werden? Welche Spiele/Plattformen? Wie viel Zeit kannst du einbringen?" className="input" data-testid="apply-motivation" aria-invalid={!!fieldErrors.motivation} aria-describedby={fieldErrors.motivation ? "apply-motivation-error" : undefined} />
             </Field>
-            <Field label="Anmerkungen (optional)">
-              <textarea rows={2} value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} className="input" />
+            <Field id="apply-notes" label="Anmerkungen (optional)">
+              <textarea id="apply-notes" rows={2} maxLength={2000} value={form.notes} onChange={(e) => updateField("notes", e.target.value)} className="input" />
             </Field>
             <div className="space-y-2 pt-2 border-t border-white/5">
               <label className="flex items-start gap-2 cursor-pointer">
-                <input type="checkbox" required checked={form.accept_statutes} onChange={(e) => setForm({ ...form, accept_statutes: e.target.checked })} data-testid="apply-statutes" className="mt-1 accent-[#FFD700]" />
-                <span className="text-sm text-white/70">Ich habe die <a href="/imprint" className="text-[#29B6E8] underline">Vereinsstatuten</a> gelesen und akzeptiere sie.</span>
+                <input id="apply-statutes" type="checkbox" required checked={form.accept_statutes} onChange={(e) => updateField("accept_statutes", e.target.checked)} data-testid="apply-statutes" aria-invalid={!!fieldErrors.accept_statutes} aria-describedby={fieldErrors.accept_statutes ? "apply-statutes-error" : undefined} className="mt-1 accent-[#FFD700]" />
+                <span className="text-sm text-white/70">Ich habe die <a href="/imprint" className="text-[#29B6E8] underline">Vereinsstatuten</a> gelesen und akzeptiere sie.{fieldErrors.accept_statutes && <span id="apply-statutes-error" role="alert" className="block mt-1 text-xs text-[#FF8A80]">{fieldErrors.accept_statutes}</span>}</span>
               </label>
               <label className="flex items-start gap-2 cursor-pointer">
-                <input type="checkbox" required checked={form.accept_privacy} onChange={(e) => setForm({ ...form, accept_privacy: e.target.checked })} data-testid="apply-privacy" className="mt-1 accent-[#FFD700]" />
-                <span className="text-sm text-white/70">Ich akzeptiere die <a href="/privacy" className="text-[#29B6E8] underline">Datenschutzerklärung</a>.</span>
+                <input id="apply-privacy" type="checkbox" required checked={form.accept_privacy} onChange={(e) => updateField("accept_privacy", e.target.checked)} data-testid="apply-privacy" aria-invalid={!!fieldErrors.accept_privacy} aria-describedby={fieldErrors.accept_privacy ? "apply-privacy-error" : undefined} className="mt-1 accent-[#FFD700]" />
+                <span className="text-sm text-white/70">Ich akzeptiere die <a href="/privacy" className="text-[#29B6E8] underline">Datenschutzerklärung</a>.{fieldErrors.accept_privacy && <span id="apply-privacy-error" role="alert" className="block mt-1 text-xs text-[#FF8A80]">{fieldErrors.accept_privacy}</span>}</span>
               </label>
             </div>
+            {submitError && <AuthFormAlert id="apply-submit-error">{submitError}</AuthFormAlert>}
             <button type="submit" disabled={submitting} data-testid="apply-submit" className="w-full px-6 py-3 bg-[#FFD700] text-black font-bold uppercase tracking-wider rounded-sm inline-flex items-center justify-center gap-2 disabled:opacity-50">
               <Crown className="w-4 h-4" /> {submitting ? "Sende …" : "Bewerbung einreichen"}
             </button>
@@ -110,11 +138,12 @@ export default function MembershipApplyPage() {
   );
 }
 
-function Field({ label, children }) {
+function Field({ id, label, error, children }) {
   return (
-    <label className="block">
+    <label htmlFor={id} className="block">
       <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">{label}</div>
       {children}
+      {error && <div id={`${id}-error`} role="alert" className="mt-1 text-xs text-[#FF8A80]">{error}</div>}
     </label>
   );
 }

--- a/frontend/src/pages/public/PasswordRecoveryPage.jsx
+++ b/frontend/src/pages/public/PasswordRecoveryPage.jsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { api } from "@/lib/api";
+import { api, formatApiError } from "@/lib/api";
 import { Logo } from "@/components/tls/Logo";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { AuthFormAlert, AuthPasswordField, AuthTextField } from "@/components/tls/AuthFormFields";
 import { toast } from "sonner";
 
@@ -13,12 +14,14 @@ export function ForgotPasswordPage() {
 
   const [email, setEmail] = useState("");
   const [sent, setSent] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
   const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState("");
 
   const setEmailValue = (value) => {
     setEmail(value);
     setFieldErrors({});
+    setSubmitError("");
   };
 
   const validate = () => {
@@ -35,15 +38,18 @@ export function ForgotPasswordPage() {
     event.preventDefault();
     if (!validate()) return;
 
-    setLoading(true);
-    try {
-      await api.post("/auth/forgot-password", { email: email.trim() });
+    setSubmitError("");
+    const attempt = await submitOnce(() => api.post("/auth/forgot-password", { email: email.trim() }));
+    if (!attempt.started) return;
+    if (!attempt.error) {
       setSent(true);
       toast.success("Wenn die E-Mail existiert, wurde ein Link gesendet.");
-    } catch (err) {
-      toast.error(err.response?.data?.detail || "Anfrage fehlgeschlagen.");
+    } else {
+      const err = attempt.error;
+      const message = formatApiError(err.response?.data?.detail) || "Anfrage fehlgeschlagen.";
+      setSubmitError(message);
+      toast.error(message);
     }
-    setLoading(false);
   };
 
   return (
@@ -65,6 +71,7 @@ export function ForgotPasswordPage() {
             error={fieldErrors["forgot-email"]}
             testId="forgot-email"
           />
+          {submitError && <AuthFormAlert id="forgot-submit-error">{submitError}</AuthFormAlert>}
           <button disabled={loading} data-testid="forgot-submit" className="w-full py-3 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm hover:bg-[#1E95C2] disabled:opacity-50 transition">
             {loading ? "Sende ..." : "Link senden"}
           </button>
@@ -86,12 +93,14 @@ export function ResetPasswordPage() {
   const [confirm, setConfirm] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
   const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState("");
 
   const setField = (field, setter) => (value) => {
     setter(value);
     setFieldErrors((current) => ({ ...current, [field]: null }));
+    setSubmitError("");
   };
 
   const validate = () => {
@@ -111,15 +120,18 @@ export function ResetPasswordPage() {
     event.preventDefault();
     if (!validate()) return;
 
-    setLoading(true);
-    try {
-      await api.post("/auth/reset-password", { token, new_password: password });
+    setSubmitError("");
+    const attempt = await submitOnce(() => api.post("/auth/reset-password", { token, new_password: password }));
+    if (!attempt.started) return;
+    if (!attempt.error) {
       toast.success(isInvite ? "Account aktiviert. Du kannst dich jetzt einloggen." : "Passwort aktualisiert.");
       nav("/login");
-    } catch (err) {
-      toast.error(err.response?.data?.detail || "Link ungültig oder abgelaufen.");
+    } else {
+      const err = attempt.error;
+      const message = formatApiError(err.response?.data?.detail) || "Link ungültig oder abgelaufen.";
+      setSubmitError(message);
+      toast.error(message);
     }
-    setLoading(false);
   };
 
   return (
@@ -156,6 +168,7 @@ export function ResetPasswordPage() {
             error={fieldErrors.confirm}
             testId="reset-password-confirm"
           />
+          {submitError && <AuthFormAlert id="reset-submit-error">{submitError}</AuthFormAlert>}
           <button disabled={loading} data-testid="reset-submit" className="w-full py-3 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm hover:bg-[#1E95C2] disabled:opacity-50 transition">
             {loading ? "Speichere ..." : "Passwort speichern"}
           </button>

--- a/frontend/src/pages/public/RegisterPage.jsx
+++ b/frontend/src/pages/public/RegisterPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 import { Logo } from "@/components/tls/Logo";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import {
   AuthCheckboxField,
   AuthFormAlert,
@@ -49,7 +50,7 @@ export default function RegisterPage() {
   const [accept, setAccept] = useState(false);
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [newsletter, setNewsletter] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
   const [err, setErr] = useState(null);
   const [fieldErrors, setFieldErrors] = useState({});
 
@@ -93,7 +94,6 @@ export default function RegisterPage() {
     if (!validate()) return;
 
     setErr(null);
-    setLoading(true);
     const payload = {
       username: form.username.trim(),
       email: form.email.trim(),
@@ -105,8 +105,13 @@ export default function RegisterPage() {
       accept_terms: true,
       newsletter_consent: newsletter,
     };
-    const res = await register(payload);
-    setLoading(false);
+    const attempt = await submitOnce(() => register(payload));
+    if (!attempt.started) return;
+    if (attempt.error) {
+      setErr("Registrierung konnte nicht abgeschlossen werden. Bitte versuche es erneut.");
+      return;
+    }
+    const res = attempt.value;
 
     if (res.ok) {
       toast.success("Willkommen in der TLS Community!");


### PR DESCRIPTION
## Was geändert wurde

- zentralen atomaren Single-Flight-Guard für Kontakt, Mitgliedsantrag, Login, Registrierung sowie Passwort-Wiederherstellung und -Reset eingeführt
- feldnahe, barrierearme Validierung mit Fokusführung, `aria-invalid` und stabilen Fehlerzuständen ergänzt
- Erfolgsmeldungen dauerhaft sichtbar gemacht und API-Fehler zusätzlich zum Toast im Formular erhalten
- Mitgliedsantrag wartet nun auf den abgeschlossenen Auth-Bootstrap, statt während des Ladens fälschlich zum Login umzuleiten
- Kontakt- und Mitgliedsantragsdaten serverseitig getrimmt; reine Leerzeichen und überlange optionale Anmerkungen werden abgewiesen
- Doppel-Submit-, Validierungs-, Erfolgs- und Fehlerpfade als Browser- und Backend-Regressionen abgesichert

## Warum

Ein deaktivierter Submit-Button allein sperrt nicht synchron. Zwei Submit-Events im selben React-Renderzyklus konnten daher zwei Requests auslösen. Außerdem waren Validierungs- und API-Fehler in Kontakt und Mitgliedsantrag überwiegend nur als flüchtiger Toast sichtbar.

## Auswirkung

Die öffentlichen Kernformulare geben klare Feldhinweise, führen den Fokus zum ersten Fehler und senden auch bei nahezu gleichzeitigen Submit-Events höchstens einen Request. Die weiterführenden Event-, Team-, Turnier- und Matchaktionen bleiben bewusst ein eigener P0-Folgeblock, da dort fachliche Idempotenz und Konfliktlogik separat geprüft werden müssen.

## Validierung

- `python -m pytest -m "not live"`: 198 bestanden, 5 übersprungen
- `yarn audit:high`: grün
- `yarn build`: grün
- `yarn test --watchAll=false --passWithNoTests --coverage ...`: 10/10 grün
- `yarn test:e2e`: 42 bestanden, 8 zugangspflichtige Live-Admin-Tests übersprungen
- gezielt: 6/6 Backend-Formularvalidierungen und 6/6 Chromium-Kernformular-Flows
- `git diff --check` und Backend-Compile: grün

Teil von #95.