### PR TITLE
fix: guard public action requests

### DIFF
--- a/frontend/e2e/action-guards.spec.js
+++ b/frontend/e2e/action-guards.spec.js
@@ -1,0 +1,257 @@
+const { test, expect } = require("@playwright/test");
+
+async function acceptCookies(page) {
+  const button = page.getByRole("button", { name: /alle akzeptieren/i });
+  if (await button.count()) await button.click();
+}
+
+async function mockPublicChrome(page) {
+  await page.route("**/api/settings/public", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ club_name: "THE LION SQUAD", tagline: "eSports" }),
+  }));
+  await page.route("**/api/sponsors**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify([]),
+  }));
+}
+
+async function mockUser(page, user) {
+  await page.route("**/api/auth/me", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(user),
+  }));
+}
+
+async function dispatchDoubleSubmit(page, submitTestId) {
+  await page.evaluate((testId) => {
+    const submitter = document.querySelector(`[data-testid="${testId}"]`);
+    const form = submitter?.closest("form");
+    if (!form) throw new Error(`Form for ${testId} not found`);
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  }, submitTestId);
+}
+
+const user = {
+  id: "user-1",
+  username: "testplayer",
+  display_name: "Test Player",
+  role: "player",
+  user_type: "community_user",
+};
+
+test("event registration accepts only one simultaneous submission", async ({ page }) => {
+  await mockPublicChrome(page);
+  await mockUser(page, user);
+  let submissions = 0;
+  let ownRegistration = null;
+  await page.route("**/api/events/test-event", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      id: "event-1",
+      slug: "test-event",
+      name: "Testevent",
+      status: "registration_open",
+      public_phase: { state: "registration_open", label: "Anmeldung" },
+      has_registration: true,
+      allow_companions: false,
+      registration_summary: { registered_count: ownRegistration ? 1 : 0, reserved_seats: ownRegistration ? 1 : 0, companion_count: 0 },
+      own_registration: ownRegistration,
+      registrations: ownRegistration ? [ownRegistration] : [],
+      tournaments: [],
+      f1_challenges: [],
+    }),
+  }));
+  await page.route("**/api/events/event-1/registrations", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    ownRegistration = { id: "event-registration-1", user_id: user.id, display_name: user.display_name, status: "registered", seat_count: 1 };
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(ownRegistration) });
+  });
+
+  await page.goto("/events/test-event");
+  await acceptCookies(page);
+  await expect(page.getByTestId("event-register-submit")).toBeVisible();
+  await dispatchDoubleSubmit(page, "event-register-submit");
+
+  await expect(page.getByText("Angemeldet", { exact: true }).first()).toBeVisible();
+  expect(submissions).toBe(1);
+});
+
+test("team join accepts only one request and exposes the resulting state", async ({ page }) => {
+  await mockPublicChrome(page);
+  await mockUser(page, user);
+  let submissions = 0;
+  let joined = false;
+  await page.route("**/api/teams/team-1", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      id: "team-1",
+      name: "Guardians",
+      tag: "GRD",
+      description: "Testteam",
+      leader_id: "leader-1",
+      co_leader_ids: [],
+      member_ids: joined ? [user.id] : [],
+      members: [],
+      member_count: joined ? 1 : 0,
+      is_member: joined,
+      can_manage: false,
+    }),
+  }));
+  await page.route("**/api/teams/team-1/join", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    joined = true;
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/teams/team-1");
+  await acceptCookies(page);
+  await page.getByTestId("team-join-code").fill("JOIN123");
+  await dispatchDoubleSubmit(page, "team-join-submit");
+
+  await expect(page.getByTestId("team-leave")).toBeVisible();
+  expect(submissions).toBe(1);
+});
+
+test("tournament registration accepts only one simultaneous request", async ({ page }) => {
+  await mockPublicChrome(page);
+  await mockUser(page, user);
+  let submissions = 0;
+  let registrations = [];
+  const tournament = {
+    id: "tournament-1",
+    slug: "test-cup",
+    title: "Test Cup",
+    status: "registration_open",
+    registration_enabled: true,
+    participant_count: 0,
+    max_participants: 16,
+    team_mode: "solo",
+    event_mode: "online",
+    game: { id: "game-1", slug: "test-game", name: "Test Game", player_id_fields: [] },
+    public_phase: { state: "registration_open", label: "Anmeldung" },
+  };
+  await page.route("**/api/tournaments/test-cup", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ ...tournament, participant_count: registrations.length }),
+  }));
+  await page.route("**/api/tournaments/tournament-1/registrations", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(registrations),
+  }));
+  await page.route("**/api/teams/my", (route) => route.fulfill({ contentType: "application/json", body: "[]" }));
+  await page.route("**/api/tournaments/tournament-1/register", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    registrations = [{ id: "registration-1", user_id: user.id, display_name: user.display_name, status: "approved" }];
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(registrations[0]) });
+  });
+
+  await page.goto("/tournaments/test-cup");
+  await acceptCookies(page);
+  await expect(page.getByTestId("tournament-register-btn")).toBeVisible();
+  await page.evaluate(() => {
+    const button = document.querySelector('[data-testid="tournament-register-btn"]');
+    button.click();
+    button.click();
+  });
+
+  await expect(page.getByTestId("tournament-register-btn")).toHaveCount(0);
+  expect(submissions).toBe(1);
+});
+
+test("match action validation and API errors remain visible without duplicate requests", async ({ page }) => {
+  await mockPublicChrome(page);
+  await mockUser(page, user);
+  let submissions = 0;
+  const matchPage = {
+    collection: "matches",
+    matchday_label: "Runde 1",
+    match: { id: "match-1", match_key: "A1", status: "ready", schedule_status: "proposed", score_a: 0, score_b: 0 },
+    tournament: { id: "tournament-1", slug: "test-cup", title: "Test Cup" },
+    participants: [
+      { registration_id: "registration-1", display_name: "Alpha" },
+      { registration_id: "registration-2", display_name: "Bravo" },
+    ],
+    schedule_proposals: [],
+    can_act: true,
+    can_dispute: true,
+    can_forfeit: false,
+    can_propose_schedule: false,
+    can_manage_schedule: false,
+    can_player_report_result: false,
+    can_staff_submit_result: false,
+  };
+  await page.route("**/api/matches/match-1/page", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(matchPage),
+  }));
+  await page.route("**/api/matches/match-1/chat", (route) => route.fulfill({ contentType: "application/json", body: "[]" }));
+  await page.route("**/api/matches/match-1/dispute", async (route) => {
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({ status: 409, contentType: "application/json", body: JSON.stringify({ detail: "Klärfall bereits vorhanden" }) });
+  });
+
+  await page.goto("/matches/match-1");
+  await acceptCookies(page);
+  await dispatchDoubleSubmit(page, "match-dispute-btn");
+  await expect(page.locator("#match-action-error")).toContainText("Bitte Grund angeben");
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("match-dispute-input").fill("Das gemeldete Ergebnis ist falsch.");
+  await dispatchDoubleSubmit(page, "match-dispute-btn");
+  await expect(page.locator("#match-action-error")).toContainText("Klärfall bereits vorhanden");
+  expect(submissions).toBe(1);
+});
+
+test("fast-lap entry validates input and keeps one failed request visible", async ({ page }) => {
+  await mockPublicChrome(page);
+  await mockUser(page, { ...user, role: "tournament_admin" });
+  let submissions = 0;
+  const challenge = {
+    id: "challenge-1",
+    slug: "test-fastlap",
+    title: "Test Fast Lap",
+    status: "live",
+    can_manage_times: true,
+    tracks: [{ id: "track-1", name: "Teststrecke", country: "AT" }],
+    public_phase: { state: "live", label: "Live" },
+  };
+  await page.route("**/api/f1/challenges/test-fastlap", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(challenge),
+  }));
+  await page.route("**/api/f1/challenges/challenge-1/leaderboard**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ track: challenge.tracks[0], entries: [] }),
+  }));
+  await page.route("**/api/f1/challenges/challenge-1/assignable-users", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify([user]),
+  }));
+  await page.route("**/api/f1/challenges/challenge-1/times**", async (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ contentType: "application/json", body: "[]" });
+    }
+    submissions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    return route.fulfill({ status: 409, contentType: "application/json", body: JSON.stringify({ detail: "Zeit bereits erfasst" }) });
+  });
+
+  await page.goto("/fastlap/test-fastlap");
+  await acceptCookies(page);
+  await page.getByTestId("fastlap-user").selectOption(user.id);
+  await page.getByTestId("fastlap-time").fill("ungueltig");
+  await page.getByTestId("fastlap-submit").click();
+  await expect(page.locator("#fastlap-action-error")).toContainText("Ungültiges Zeitformat");
+  expect(submissions).toBe(0);
+
+  await page.getByTestId("fastlap-time").fill("1:24.587");
+  await dispatchDoubleSubmit(page, "fastlap-submit");
+  await expect(page.locator("#fastlap-action-error")).toContainText("Zeit bereits erfasst");
+  expect(submissions).toBe(1);
+});

--- a/frontend/src/pages/public/EventDetailPage.jsx
+++ b/frontend/src/pages/public/EventDetailPage.jsx
@@ -8,9 +8,11 @@ import { PhaseBadge } from "@/components/tls/PhaseBadge";
 import { RichContent } from "@/components/tls/RichContent";
 import { useCookieConsent } from "@/components/tls/CookieConsent";
 import { ExternalMediaNotice } from "@/components/tls/ExternalMediaNotice";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useCanonicalSlugRedirect } from "@/hooks/useCanonicalSlugRedirect";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { renderMarkdownLite } from "@/lib/markdownLite";
 import { seoTextPreview } from "@/lib/textPreview";
 import { formatTournamentDisplay } from "@/lib/tournamentLabels";
@@ -250,7 +252,8 @@ const EVENT_REGISTRATION_LABELS = {
 function EventRegistrationPanel({ event, user, accessToken = "", onChanged }) {
   const [companionCount, setCompanionCount] = useState(0);
   const [note, setNote] = useState("");
-  const [saving, setSaving] = useState(false);
+  const { submitting: saving, submitOnce } = useSubmissionGuard();
+  const [actionError, setActionError] = useState("");
   const summary = event.registration_summary || {};
   const own = event.own_registration;
   const activeOwn = own && !["cancelled", "no_show"].includes(own.status);
@@ -263,35 +266,38 @@ function EventRegistrationPanel({ event, user, accessToken = "", onChanged }) {
   useEffect(() => {
     setCompanionCount(0);
     setNote("");
+    setActionError("");
   }, [event.id]);
 
   const register = async (ev) => {
     ev.preventDefault();
-    setSaving(true);
-    try {
+    setActionError("");
+    const attempt = await submitOnce(async () => {
       await api.post(`/events/${event.id}/registrations`, {
         companion_count: Number(companionCount || 0),
-        note: note || null,
+        note: note.trim() || null,
       }, { params: accessToken ? { access: accessToken } : undefined });
       toast.success("Anmeldung gespeichert.");
       await onChanged();
-    } catch (err) {
-      toast.error(formatRequestError(err, "Anmeldung konnte nicht gespeichert werden."));
-    } finally {
-      setSaving(false);
+    });
+    if (attempt.started && attempt.error) {
+      const message = formatRequestError(attempt.error, "Anmeldung konnte nicht gespeichert werden.");
+      setActionError(message);
+      toast.error(message);
     }
   };
 
   const cancel = async () => {
-    setSaving(true);
-    try {
+    setActionError("");
+    const attempt = await submitOnce(async () => {
       await api.delete(`/events/${event.id}/registrations/me`);
       toast.success("Anmeldung storniert.");
       await onChanged();
-    } catch (err) {
-      toast.error(formatRequestError(err, "Anmeldung konnte nicht storniert werden."));
-    } finally {
-      setSaving(false);
+    });
+    if (attempt.started && attempt.error) {
+      const message = formatRequestError(attempt.error, "Anmeldung konnte nicht storniert werden.");
+      setActionError(message);
+      toast.error(message);
     }
   };
 
@@ -341,19 +347,20 @@ function EventRegistrationPanel({ event, user, accessToken = "", onChanged }) {
           {event.allow_companions && (
             <label className="block">
               <div className="text-[11px] uppercase tracking-widest text-white/50 font-bold mb-1.5">Begleitpersonen</div>
-              <input type="number" min="0" max={maxCompanions} value={companionCount} onChange={(ev) => setCompanionCount(ev.target.value)} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm" />
+              <input type="number" min="0" max={maxCompanions} value={companionCount} onChange={(ev) => { setCompanionCount(ev.target.value); setActionError(""); }} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm" />
               <div className="mt-1 text-xs text-white/40">Maximal {maxCompanions} pro Anmeldung.</div>
             </label>
           )}
           <label className="block">
             <div className="text-[11px] uppercase tracking-widest text-white/50 font-bold mb-1.5">Hinweis optional</div>
-            <textarea value={note} onChange={(ev) => setNote(ev.target.value)} rows={3} maxLength={500} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" placeholder="z.B. komme etwas später" />
+            <textarea value={note} onChange={(ev) => { setNote(ev.target.value); setActionError(""); }} rows={3} maxLength={500} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" placeholder="z.B. komme etwas später" />
           </label>
-          <button disabled={saving} className="inline-flex items-center gap-2 px-4 py-2 bg-[#9F7AEA] text-black text-xs uppercase tracking-wider font-bold rounded-sm disabled:opacity-50">
+          <button disabled={saving} data-testid="event-register-submit" className="inline-flex items-center gap-2 px-4 py-2 bg-[#9F7AEA] text-black text-xs uppercase tracking-wider font-bold rounded-sm disabled:opacity-50">
             <UserPlus className="w-3.5 h-3.5" /> {saving ? "Speichere..." : "Anmelden"}
           </button>
         </form>
       )}
+      {actionError && <div className="mt-4"><AuthFormAlert id="event-registration-error">{actionError}</AuthFormAlert></div>}
       {!!event.registrations?.length && (
         <div className="mt-6 border-t border-white/10 pt-4">
           <div className="text-[11px] uppercase tracking-widest font-bold text-white/45 mb-2">Angemeldet</div>

--- a/frontend/src/pages/public/F1DetailPage.jsx
+++ b/frontend/src/pages/public/F1DetailPage.jsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
 import { PhaseBadge } from "@/components/tls/PhaseBadge";
 import { PrizeList } from "@/components/tls/PrizeList";
 import { StreamEmbed } from "@/components/tls/StreamEmbed";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useCanonicalSlugRedirect } from "@/hooks/useCanonicalSlugRedirect";
 import { Award, Tv, Trophy, Flag, Calendar, Trash2, FileDown } from "lucide-react";
@@ -15,6 +16,7 @@ import { formatDateTime, getRegistrationState, hasOnlineRegistration } from "@/l
 import { renderMarkdownLite } from "@/lib/markdownLite";
 import { seoTextPreview } from "@/lib/textPreview";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { useConfirm } from "@/components/tls/ConfirmDialog";
 import { toast } from "sonner";
 
@@ -367,9 +369,14 @@ function InlineFastLapTimeEntry({ challenge, trackId, currentUser, onSaved }) {
   const [users, setUsers] = useState([]);
   const [times, setTimes] = useState([]);
   const [form, setForm] = useState({ user_id: "", time_str: "", penalty_seconds: 0, proof_url: "", admin_note: "", score_scope: "official" });
-  const [saving, setSaving] = useState(false);
-  const [deletingId, setDeletingId] = useState(null);
-  const set = (key, value) => setForm((current) => ({ ...current, [key]: value }));
+  const { submitting: saving, submitOnce } = useSubmissionGuard();
+  const [actionError, setActionError] = useState("");
+  const set = (key, value) => { setForm((current) => ({ ...current, [key]: value })); setActionError(""); };
+
+  const failAction = (message) => {
+    setActionError(message);
+    toast.error(message);
+  };
 
   useEffect(() => {
     if (!challenge?.id) return;
@@ -407,16 +414,16 @@ function InlineFastLapTimeEntry({ challenge, trackId, currentUser, onSaved }) {
     event.preventDefault();
     const ms = parseTimeStr(form.time_str);
     if (!ms) {
-      toast.error("Ungültiges Zeitformat. Beispiel: 1:24.587");
+      failAction("Ungültiges Zeitformat. Beispiel: 1:24.587");
       return;
     }
     const penalty = Number(form.penalty_seconds) || 0;
     if (penalty > 0 && (form.admin_note || "").trim().length < 5) {
-      toast.error("Bei Strafzeit ist eine Begründung Pflicht.");
+      failAction("Bei Strafzeit ist eine Begründung Pflicht.");
       return;
     }
-    setSaving(true);
-    try {
+    setActionError("");
+    const attempt = await submitOnce(async () => {
       await api.post(`/f1/challenges/${challenge.id}/times`, {
         user_id: form.user_id,
         track_id: trackId,
@@ -430,31 +437,29 @@ function InlineFastLapTimeEntry({ challenge, trackId, currentUser, onSaved }) {
       setForm((current) => ({ ...current, time_str: "", penalty_seconds: 0, proof_url: "", admin_note: "" }));
       await loadTimes();
       onSaved();
-    } catch (err) {
-      toast.error(formatRequestError(err, "Zeit konnte nicht eingetragen werden."));
-    } finally {
-      setSaving(false);
+    });
+    if (attempt.started && attempt.error) {
+      failAction(formatRequestError(attempt.error, "Zeit konnte nicht eingetragen werden."));
     }
   };
 
   const deleteTime = async (time) => {
-    const ok = await confirm({
-      title: "Zeit löschen?",
-      description: `${time.user?.display_name || time.user?.username || "Fahrer"} - ${time.time_str} wird aus der Challenge entfernt.`,
-      confirmLabel: "Zeit löschen",
-      tone: "danger",
-    });
-    if (!ok) return;
-    setDeletingId(time.id);
-    try {
+    setActionError("");
+    const attempt = await submitOnce(async () => {
+      const ok = await confirm({
+        title: "Zeit löschen?",
+        description: `${time.user?.display_name || time.user?.username || "Fahrer"} - ${time.time_str} wird aus der Challenge entfernt.`,
+        confirmLabel: "Zeit löschen",
+        tone: "danger",
+      });
+      if (!ok) return;
       await api.delete(`/f1/times/${time.id}`);
       toast.success("Zeit gelöscht.");
       await loadTimes();
       onSaved();
-    } catch (err) {
-      toast.error(formatRequestError(err, "Zeit konnte nicht gelöscht werden."));
-    } finally {
-      setDeletingId(null);
+    });
+    if (attempt.started && attempt.error) {
+      failAction(formatRequestError(attempt.error, "Zeit konnte nicht gelöscht werden."));
     }
   };
 
@@ -471,14 +476,14 @@ function InlineFastLapTimeEntry({ challenge, trackId, currentUser, onSaved }) {
         <div className="grid md:grid-cols-[minmax(12rem,1fr)_9rem_11rem_8rem_auto] gap-2 items-end">
           <label className="block">
             <span className="block text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1">Fahrer</span>
-            <select value={form.user_id} onChange={(e) => set("user_id", e.target.value)} required className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm">
+            <select value={form.user_id} onChange={(e) => set("user_id", e.target.value)} required data-testid="fastlap-user" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm">
               <option value="">- auswählen -</option>
               {users.map((item) => <option key={item.id} value={item.id}>{item.display_name || item.username || item.email}</option>)}
             </select>
           </label>
           <label className="block">
             <span className="block text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1">Zeit</span>
-            <input value={form.time_str} onChange={(e) => set("time_str", e.target.value)} required placeholder="1:24.587" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm font-display tabular-nums" />
+            <input value={form.time_str} onChange={(e) => set("time_str", e.target.value)} required placeholder="1:24.587" data-testid="fastlap-time" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm font-display tabular-nums" />
           </label>
           <label className="block">
             <span className="block text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1">Wertung</span>
@@ -489,15 +494,16 @@ function InlineFastLapTimeEntry({ challenge, trackId, currentUser, onSaved }) {
           </label>
           <label className="block">
             <span className="block text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1">Strafe</span>
-            <input type="number" step="0.1" value={form.penalty_seconds} onChange={(e) => set("penalty_seconds", e.target.value)} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm" />
+            <input type="number" step="0.1" value={form.penalty_seconds} onChange={(e) => set("penalty_seconds", e.target.value)} data-testid="fastlap-penalty" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm" />
           </label>
-          <button disabled={saving} className="px-4 py-2 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm text-sm disabled:opacity-50">Speichern</button>
+          <button disabled={saving} data-testid="fastlap-submit" className="px-4 py-2 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm text-sm disabled:opacity-50">Speichern</button>
         </div>
         <div className="mt-2 grid md:grid-cols-2 gap-2">
           <input value={form.proof_url} onChange={(e) => set("proof_url", e.target.value)} placeholder="Proof URL optional" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
           <input value={form.admin_note} onChange={(e) => set("admin_note", e.target.value)} placeholder={Number(form.penalty_seconds) > 0 ? "Begründung für Strafe" : "Notiz optional"} className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-sm" />
         </div>
         {forceReferenceScope && <div className="mt-2 text-[10px] text-[#FFD700] uppercase tracking-widest">Vereinsmitglied: nur Referenzzeit möglich.</div>}
+        {actionError && <div className="mt-3"><AuthFormAlert id="fastlap-action-error">{actionError}</AuthFormAlert></div>}
       </form>
 
       <div className="mt-4 border-t border-white/10 pt-3">
@@ -522,7 +528,7 @@ function InlineFastLapTimeEntry({ challenge, trackId, currentUser, onSaved }) {
                 <button
                   type="button"
                   onClick={() => deleteTime(time)}
-                  disabled={deletingId === time.id}
+                  disabled={saving}
                   className="p-1.5 text-white/42 hover:text-[#FF3B30] disabled:opacity-40"
                   title="Zeit löschen"
                 >

--- a/frontend/src/pages/public/MatchPage.jsx
+++ b/frontend/src/pages/public/MatchPage.jsx
@@ -5,10 +5,12 @@ import { toast } from "sonner";
 import { PublicLayout } from "@/components/tls/PublicLayout";
 import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
 import { MentionTextarea } from "@/components/tls/MentionTextarea";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { api, formatApiError } from "@/lib/api";
 import { useAuth } from "@/context/AuthContext";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 
 const scheduleLabels = {
   proposed: "Terminvorschlag offen",
@@ -76,7 +78,8 @@ export default function MatchPage() {
   const [forfeitReason, setForfeitReason] = useState("");
   const [forfeitWinnerId, setForfeitWinnerId] = useState("");
   const [v2Rows, setV2Rows] = useState([]);
-  const [busy, setBusy] = useState(false);
+  const { submitting: busy, submitOnce } = useSubmissionGuard();
+  const [actionError, setActionError] = useState("");
 
   const load = useCallback(async ({ preserveDrafts = true } = {}) => {
     const [{ data: page }, { data: messages }] = await Promise.all([
@@ -125,48 +128,50 @@ export default function MatchPage() {
     : "Matchseite mit Terminabstimmung, Matchchat und Ergebnisstatus.";
   useDocumentTitle(title, description, { robots: "noindex, follow" });
 
+  const failAction = (message) => {
+    setActionError(message);
+    toast.error(message);
+  };
+
+  const runAction = async (task, fallback) => {
+    setActionError("");
+    const attempt = await submitOnce(task);
+    if (!attempt.started || !attempt.error) return attempt.started;
+    failAction(formatApiError(attempt.error.response?.data?.detail) || fallback);
+    return false;
+  };
+
   const propose = async (e) => {
     e.preventDefault();
     const scheduled_at = fromLocalInput(proposalAt);
-    if (!scheduled_at) return toast.error("Bitte Datum und Uhrzeit wählen.");
-    setBusy(true);
-    try {
+    if (!scheduled_at) return failAction("Bitte Datum und Uhrzeit wählen.");
+    await runAction(async () => {
       await api.post(`/matches/${id}/schedule-proposals`, { scheduled_at, note: proposalNote || null });
       toast.success("Terminvorschlag gesendet.");
       setProposalNote("");
       await load();
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    } finally {
-      setBusy(false);
-    }
+    }, "Terminvorschlag konnte nicht gesendet werden.");
   };
 
   const decide = async (proposal, action) => {
     const payload = { action, note: decisionNote || null };
     if (action === "counter") {
       const scheduled_at = fromLocalInput(counterAt);
-      if (!scheduled_at) return toast.error("Bitte Datum und Uhrzeit für den Gegenvorschlag wählen.");
+      if (!scheduled_at) return failAction("Bitte Datum und Uhrzeit für den Gegenvorschlag wählen.");
       payload.scheduled_at = scheduled_at;
     }
-    setBusy(true);
-    try {
+    await runAction(async () => {
       await api.post(`/matches/${id}/schedule-proposals/${proposal.id}/decision`, payload);
       toast.success(action === "accept" ? "Termin bestätigt." : action === "counter" ? "Gegenvorschlag gesendet." : "Vorschlag abgelehnt.");
       setDecisionNote("");
       setCounterAt("");
       await load();
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    } finally {
-      setBusy(false);
-    }
+    }, "Terminentscheidung konnte nicht gespeichert werden.");
   };
 
   const submitLegacyResult = async (e) => {
     e.preventDefault();
-    setBusy(true);
-    try {
+    await runAction(async () => {
       const score_a = Math.max(0, Number.parseInt(scoreA || "0", 10) || 0);
       const score_b = Math.max(0, Number.parseInt(scoreB || "0", 10) || 0);
       if (data?.can_staff_submit_result) {
@@ -190,17 +195,12 @@ export default function MatchPage() {
       setProofUrl("");
       setReportNote("");
       await load({ preserveDrafts: false });
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    } finally {
-      setBusy(false);
-    }
+    }, "Ergebnis konnte nicht gespeichert werden.");
   };
 
   const submitV2Result = async (e) => {
     e.preventDefault();
-    setBusy(true);
-    try {
+    await runAction(async () => {
       await api.post(`/matches/${id}/result`, {
         proof_url: proofUrl.trim() || null,
         note: reportNote.trim() || null,
@@ -217,59 +217,43 @@ export default function MatchPage() {
       setProofUrl("");
       setReportNote("");
       await load({ preserveDrafts: false });
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    } finally {
-      setBusy(false);
-    }
+    }, "Heat-Ergebnis konnte nicht gespeichert werden.");
   };
 
   const submitDispute = async (e) => {
     e.preventDefault();
     const reason = disputeReason.trim();
-    if (!reason) return toast.error("Bitte Grund angeben.");
-    setBusy(true);
-    try {
+    if (!reason) return failAction("Bitte Grund angeben.");
+    await runAction(async () => {
       await api.post(`/matches/${id}/dispute`, { reason });
       toast.success("Klärfall gemeldet.");
       setDisputeReason("");
       await load({ preserveDrafts: false });
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    } finally {
-      setBusy(false);
-    }
+    }, "Klärfall konnte nicht gemeldet werden.");
   };
 
   const submitForfeit = async (e) => {
     e.preventDefault();
     const note = forfeitReason.trim();
-    if (!note || note.length < 5) return toast.error("Bitte Forfeit-Begründung mit mindestens 5 Zeichen angeben.");
-    if (!forfeitWinnerId) return toast.error("Bitte Gewinner auswählen.");
+    if (!note || note.length < 5) return failAction("Bitte Forfeit-Begründung mit mindestens 5 Zeichen angeben.");
+    if (!forfeitWinnerId) return failAction("Bitte Gewinner auswählen.");
     if (!window.confirm("Forfeit wirklich speichern? Diese Staff-Aktion wertet das Match als Forfeit.")) return;
-    setBusy(true);
-    try {
+    await runAction(async () => {
       await api.post(`/matches/${id}/forfeit`, { winner_id: forfeitWinnerId, note });
       toast.success("Forfeit gespeichert.");
       setForfeitReason("");
       await load({ preserveDrafts: false });
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    } finally {
-      setBusy(false);
-    }
+    }, "Forfeit konnte nicht gespeichert werden.");
   };
 
   const sendMessage = async (e) => {
     e.preventDefault();
     if (!message.trim()) return;
-    try {
+    await runAction(async () => {
       const { data: saved } = await api.post(`/matches/${id}/chat`, { message: message.trim() });
       setChat((rows) => [...rows, saved]);
       setMessage("");
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail));
-    }
+    }, "Nachricht konnte nicht gesendet werden.");
   };
 
   if (!data) {
@@ -333,6 +317,8 @@ export default function MatchPage() {
             )}
           </div>
         </div>
+
+        {actionError && <div className="mt-5"><AuthFormAlert id="match-action-error">{actionError}</AuthFormAlert></div>}
 
         <div className="mt-8 border border-[#29B6E8]/35 bg-[#0F1D23] rounded-sm p-5" data-testid="match-result-card">
           <div className="flex items-start justify-between gap-4 flex-wrap">
@@ -504,8 +490,8 @@ export default function MatchPage() {
                       </div>
                       {canManageSchedule && p.status === "pending" && (
                         <div className="flex gap-1 shrink-0">
-                          <button type="button" onClick={() => decide(p, "accept")} className="p-2 border border-[#00D26A]/40 text-[#00D26A] rounded-sm"><Check className="w-3.5 h-3.5" /></button>
-                          <button type="button" onClick={() => decide(p, "decline")} className="p-2 border border-[#FF3B30]/40 text-[#FF3B30] rounded-sm"><X className="w-3.5 h-3.5" /></button>
+                          <button type="button" disabled={busy} onClick={() => decide(p, "accept")} className="p-2 border border-[#00D26A]/40 text-[#00D26A] rounded-sm disabled:opacity-50"><Check className="w-3.5 h-3.5" /></button>
+                          <button type="button" disabled={busy} onClick={() => decide(p, "decline")} className="p-2 border border-[#FF3B30]/40 text-[#FF3B30] rounded-sm disabled:opacity-50"><X className="w-3.5 h-3.5" /></button>
                         </div>
                       )}
                     </div>
@@ -513,7 +499,7 @@ export default function MatchPage() {
                       <div className="mt-3 grid md:grid-cols-[1fr_1fr_auto] gap-2 items-end">
                         <input type="datetime-local" value={counterAt} onChange={(e) => setCounterAt(e.target.value)} className="input" />
                         <input value={decisionNote} onChange={(e) => setDecisionNote(e.target.value)} className="input" placeholder="Antwort / Grund" />
-                        <button type="button" onClick={() => decide(p, "counter")} className="px-3 py-2 border border-[#29B6E8]/50 text-[#29B6E8] rounded-sm text-[10px] uppercase tracking-wider font-bold">Gegenvorschlag</button>
+                        <button type="button" disabled={busy} onClick={() => decide(p, "counter")} className="px-3 py-2 border border-[#29B6E8]/50 text-[#29B6E8] rounded-sm text-[10px] uppercase tracking-wider font-bold disabled:opacity-50">Gegenvorschlag</button>
                       </div>
                     )}
                   </div>
@@ -551,7 +537,7 @@ export default function MatchPage() {
                     textareaClassName="input w-full min-h-[4.5rem] resize-y"
                     placeholder="Nachricht schreiben, @leitung oder @username markieren"
                   />
-                  <button className="px-3 py-2 bg-[#29B6E8] text-black rounded-sm"><Send className="w-4 h-4" /></button>
+                  <button disabled={busy || !message.trim()} className="px-3 py-2 bg-[#29B6E8] text-black rounded-sm disabled:opacity-50"><Send className="w-4 h-4" /></button>
                 </div>
               </form>
             ) : (

--- a/frontend/src/pages/public/TeamsPage.jsx
+++ b/frontend/src/pages/public/TeamsPage.jsx
@@ -8,8 +8,10 @@ import { ImageUpload } from "@/components/tls/ImageUpload";
 import { MentionTextarea } from "@/components/tls/MentionTextarea";
 import { MentionText } from "@/components/tls/MentionText";
 import { useConfirm } from "@/components/tls/ConfirmDialog";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { toast } from "sonner";
 import { Copy, Edit, MessageSquare, Plus, Search, Send, Shield, Trash2, Users, UserPlus } from "lucide-react";
 
@@ -107,6 +109,8 @@ function TeamDetail({ id }) {
   const [team, setTeam] = useState(null);
   const [editing, setEditing] = useState(null);
   const [joinCode, setJoinCode] = useState("");
+  const { submitting: mutating, submitOnce } = useSubmissionGuard();
+  const [actionError, setActionError] = useState("");
   const confirm = useConfirm();
 
   const load = useCallback(async () => {
@@ -123,70 +127,80 @@ function TeamDetail({ id }) {
   const isMember = !!user && (team.is_member || team.member_ids?.includes(user.id));
   const canEdit = !!user && (team.can_manage || team.leader_id === user.id || team.co_leader_ids?.includes(user.id) || isAdmin);
 
+  const runAction = async (task, fallback) => {
+    setActionError("");
+    const attempt = await submitOnce(task);
+    if (!attempt.started || !attempt.error) return attempt.started;
+    const message = formatRequestError(attempt.error, fallback);
+    setActionError(message);
+    toast.error(message);
+    return false;
+  };
+
   const join = async (e) => {
     e.preventDefault();
-    try {
+    await runAction(async () => {
       await api.post(`/teams/${team.id}/join`, { join_code: joinCode.trim() });
       toast.success("Du bist dem Team beigetreten.");
       setJoinCode("");
-      load();
-    } catch (err) { toast.error(formatRequestError(err, "Team-Beitritt fehlgeschlagen.")); }
+      await load();
+    }, "Team-Beitritt fehlgeschlagen.");
   };
 
   const leave = async () => {
-    try {
+    await runAction(async () => {
       await api.post(`/teams/${team.id}/leave`);
       toast.success("Team verlassen.");
-      load();
-    } catch (err) { toast.error(formatRequestError(err, "Team konnte nicht verlassen werden.")); }
+      await load();
+    }, "Team konnte nicht verlassen werden.");
   };
 
   const remove = async () => {
-    if (!await confirm({
-      title: "Team endgültig löschen?",
-      description: "Das Team wird inklusive Verwaltung und Mitgliedschaften entfernt.",
-      confirmLabel: "Endgültig löschen",
-    })) return;
-    try {
+    await runAction(async () => {
+      if (!await confirm({
+        title: "Team endgültig löschen?",
+        description: "Das Team wird inklusive Verwaltung und Mitgliedschaften entfernt.",
+        confirmLabel: "Endgültig löschen",
+      })) return;
       await api.delete(`/teams/${team.id}`);
       toast.success("Team gelöscht.");
       nav("/teams");
-    } catch (err) { toast.error(formatRequestError(err, "Team konnte nicht gelöscht werden.")); }
+    }, "Team konnte nicht gelöscht werden.");
   };
 
   const kickMember = async (m) => {
-    if (!await confirm({
-      title: "Mitglied entfernen?",
-      description: `${m.display_name || m.username} wirklich aus dem Team entfernen?`,
-      confirmLabel: "Entfernen",
-    })) return;
-    try {
+    await runAction(async () => {
+      if (!await confirm({
+        title: "Mitglied entfernen?",
+        description: `${m.display_name || m.username} wirklich aus dem Team entfernen?`,
+        confirmLabel: "Entfernen",
+      })) return;
       await api.delete(`/teams/${team.id}/members/${m.id}`);
       toast.success(`${m.display_name || m.username} entfernt.`);
-      load();
-    } catch (err) { toast.error(formatRequestError(err, "Mitglied konnte nicht entfernt werden.")); }
+      await load();
+    }, "Mitglied konnte nicht entfernt werden.");
   };
 
   const setRole = async (m, role) => {
-    try {
+    await runAction(async () => {
       await api.post(`/teams/${team.id}/members/${m.id}/role`, { role });
       toast.success(role === "co_leader" ? "Zum Co-Leader befördert." : "Co-Leader-Rolle entzogen.");
-      load();
-    } catch (err) { toast.error(formatRequestError(err, "Rolle konnte nicht geändert werden.")); }
+      await load();
+    }, "Rolle konnte nicht geändert werden.");
   };
 
   const transferLead = async (m) => {
-    if (!await confirm({
-      title: "Leadership übertragen?",
-      description: `Leadership an ${m.display_name || m.username} übergeben? Du wirst automatisch Co-Leader.`,
-      confirmLabel: "Übertragen",
-      tone: "info",
-    })) return;
-    try {
+    await runAction(async () => {
+      if (!await confirm({
+        title: "Leadership übertragen?",
+        description: `Leadership an ${m.display_name || m.username} übergeben? Du wirst automatisch Co-Leader.`,
+        confirmLabel: "Übertragen",
+        tone: "info",
+      })) return;
       await api.post(`/teams/${team.id}/transfer-leader`, { new_leader_id: m.id });
       toast.success("Leadership übertragen.");
-      load();
-    } catch (err) { toast.error(formatRequestError(err, "Leadership konnte nicht übertragen werden.")); }
+      await load();
+    }, "Leadership konnte nicht übertragen werden.");
   };
 
   const copyJoin = async () => {
@@ -216,8 +230,8 @@ function TeamDetail({ id }) {
             </div>
             {canEdit && (
               <div className="flex gap-2 flex-wrap">
-                <button onClick={() => setEditing(team)} data-testid="team-edit-open" className="px-4 py-2 border border-[#29B6E8]/50 text-[#29B6E8] rounded-sm text-xs uppercase tracking-wider font-bold inline-flex items-center gap-2"><Edit className="w-3.5 h-3.5" /> Bearbeiten</button>
-                <button onClick={remove} data-testid="team-delete" className="px-4 py-2 border border-[#FF3B30]/50 text-[#FF3B30] rounded-sm text-xs uppercase tracking-wider font-bold inline-flex items-center gap-2"><Trash2 className="w-3.5 h-3.5" /> Löschen</button>
+                <button onClick={() => setEditing(team)} disabled={mutating} data-testid="team-edit-open" className="px-4 py-2 border border-[#29B6E8]/50 text-[#29B6E8] rounded-sm text-xs uppercase tracking-wider font-bold inline-flex items-center gap-2 disabled:opacity-50"><Edit className="w-3.5 h-3.5" /> Bearbeiten</button>
+                <button onClick={remove} disabled={mutating} data-testid="team-delete" className="px-4 py-2 border border-[#FF3B30]/50 text-[#FF3B30] rounded-sm text-xs uppercase tracking-wider font-bold inline-flex items-center gap-2 disabled:opacity-50"><Trash2 className="w-3.5 h-3.5" /> Löschen</button>
               </div>
             )}
           </div>
@@ -257,22 +271,22 @@ function TeamDetail({ id }) {
                   {(showKick || showRole || showTransfer) && (
                     <div className="flex flex-wrap gap-1.5 pt-2 border-t border-white/5">
                       {showRole && !isCo && (
-                        <button onClick={(e) => { e.preventDefault(); setRole(m, "co_leader"); }}
+                        <button disabled={mutating} onClick={(e) => { e.preventDefault(); setRole(m, "co_leader"); }}
                           data-testid={`team-promote-${m.id}`}
                           className="px-2 py-1 text-[10px] font-bold uppercase tracking-wider border border-[#29B6E8]/40 text-[#29B6E8] hover:bg-[#29B6E8]/10 rounded-sm">↑ Co-Leader</button>
                       )}
                       {showRole && isCo && (
-                        <button onClick={(e) => { e.preventDefault(); setRole(m, "member"); }}
+                        <button disabled={mutating} onClick={(e) => { e.preventDefault(); setRole(m, "member"); }}
                           data-testid={`team-demote-${m.id}`}
                           className="px-2 py-1 text-[10px] font-bold uppercase tracking-wider border border-white/15 text-white/60 hover:bg-white/5 rounded-sm">↓ Mitglied</button>
                       )}
                       {showTransfer && (
-                        <button onClick={(e) => { e.preventDefault(); transferLead(m); }}
+                        <button disabled={mutating} onClick={(e) => { e.preventDefault(); transferLead(m); }}
                           data-testid={`team-transfer-${m.id}`}
                           className="px-2 py-1 text-[10px] font-bold uppercase tracking-wider border border-[#FFD700]/40 text-[#FFD700] hover:bg-[#FFD700]/10 rounded-sm">★ Leader machen</button>
                       )}
                       {showKick && (
-                        <button onClick={(e) => { e.preventDefault(); kickMember(m); }}
+                        <button disabled={mutating} onClick={(e) => { e.preventDefault(); kickMember(m); }}
                           data-testid={`team-kick-${m.id}`}
                           className="ml-auto px-2 py-1 text-[10px] font-bold uppercase tracking-wider border border-[#FF3B30]/40 text-[#FF3B30] hover:bg-[#FF3B30]/10 rounded-sm">Entfernen</button>
                       )}
@@ -286,6 +300,7 @@ function TeamDetail({ id }) {
           {(isMember || canEdit) && <TeamChat team={team} user={user} />}
         </div>
         <aside className="space-y-4">
+          {actionError && <AuthFormAlert id="team-action-error">{actionError}</AuthFormAlert>}
           {canEdit && (
             <div className="border border-[#FFD700]/25 bg-[#FFD700]/5 rounded-sm p-4">
               <div className="text-[11px] uppercase tracking-widest text-[#FFD700] font-bold">Join-Code</div>
@@ -299,12 +314,12 @@ function TeamDetail({ id }) {
           {user && !isMember && (
             <form onSubmit={join} className="border border-white/10 bg-[#121212] rounded-sm p-4 space-y-3">
               <div className="text-[11px] uppercase tracking-widest text-[#29B6E8] font-bold">Team beitreten</div>
-              <input value={joinCode} onChange={(e) => setJoinCode(e.target.value)} placeholder="Join-Code" required data-testid="team-join-code" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm" />
-              <button data-testid="team-join-submit" className="w-full px-4 py-2 bg-[#29B6E8] text-black rounded-sm text-xs uppercase tracking-wider font-bold inline-flex justify-center items-center gap-2"><UserPlus className="w-3.5 h-3.5" /> Beitreten</button>
+              <input value={joinCode} onChange={(e) => { setJoinCode(e.target.value); setActionError(""); }} placeholder="Join-Code" required data-testid="team-join-code" className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm" />
+              <button disabled={mutating} data-testid="team-join-submit" className="w-full px-4 py-2 bg-[#29B6E8] text-black rounded-sm text-xs uppercase tracking-wider font-bold inline-flex justify-center items-center gap-2 disabled:opacity-50"><UserPlus className="w-3.5 h-3.5" /> {mutating ? "Prüfe…" : "Beitreten"}</button>
             </form>
           )}
           {user && isMember && team.leader_id !== user.id && (
-            <button onClick={leave} data-testid="team-leave" className="w-full px-4 py-2 border border-white/15 text-white/70 rounded-sm text-xs uppercase tracking-wider font-bold">Team verlassen</button>
+            <button onClick={leave} disabled={mutating} data-testid="team-leave" className="w-full px-4 py-2 border border-white/15 text-white/70 rounded-sm text-xs uppercase tracking-wider font-bold disabled:opacity-50">Team verlassen</button>
           )}
           {team.discord_link && <a href={team.discord_link} target="_blank" rel="noreferrer" className="block px-4 py-3 border border-white/10 rounded-sm text-center text-sm font-bold uppercase tracking-wider hover:border-[#29B6E8]/60 hover:text-[#29B6E8]">Discord</a>}
         </aside>
@@ -317,7 +332,8 @@ function TeamDetail({ id }) {
 function TeamChat({ team, user }) {
   const [messages, setMessages] = useState([]);
   const [text, setText] = useState("");
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
+  const [sendError, setSendError] = useState("");
   const scrollRef = useRef(null);
 
   const load = useCallback(async () => {
@@ -343,16 +359,17 @@ function TeamChat({ team, user }) {
 
   const send = async () => {
     const message = text.trim();
-    if (!message || loading) return;
-    setLoading(true);
-    try {
+    if (!message) return;
+    setSendError("");
+    const attempt = await submitOnce(async () => {
       const { data } = await api.post(`/teams/${team.id}/chat`, { message });
       setMessages((rows) => [...rows, data]);
       setText("");
-    } catch (err) {
-      toast.error(formatRequestError(err, "Nachricht konnte nicht gesendet werden."));
-    } finally {
-      setLoading(false);
+    });
+    if (attempt.started && attempt.error) {
+      const messageText = formatRequestError(attempt.error, "Nachricht konnte nicht gesendet werden.");
+      setSendError(messageText);
+      toast.error(messageText);
     }
   };
 
@@ -382,7 +399,7 @@ function TeamChat({ team, user }) {
         <div className="border-t border-white/10 p-3 flex gap-2">
           <MentionTextarea
             value={text}
-            onValueChange={setText}
+            onValueChange={(value) => { setText(value); setSendError(""); }}
             scope="team"
             scopeId={team.id}
             onKeyDown={(e) => {
@@ -401,6 +418,7 @@ function TeamChat({ team, user }) {
             <Send className="w-3.5 h-3.5" /> Senden
           </button>
         </div>
+        {sendError && <div className="border-t border-white/10 p-3"><AuthFormAlert id="team-chat-error">{sendError}</AuthFormAlert></div>}
       </div>
     </section>
   );
@@ -410,6 +428,8 @@ function InviteMemberPanel({ team }) {
   const [query, setQuery] = useState("");
   const [candidates, setCandidates] = useState([]);
   const [loading, setLoading] = useState(false);
+  const { submitting: inviting, submitOnce } = useSubmissionGuard();
+  const [inviteError, setInviteError] = useState("");
 
   useEffect(() => {
     const needle = query.trim();
@@ -432,12 +452,16 @@ function InviteMemberPanel({ team }) {
   }, [query, team.id]);
 
   const invite = async (user) => {
-    try {
+    setInviteError("");
+    const attempt = await submitOnce(async () => {
       await api.post(`/teams/${team.id}/invites`, { user_id: user.id });
       toast.success(`${user.display_name || user.username} eingeladen.`);
       setCandidates((rows) => rows.map((row) => row.id === user.id ? { ...row, has_pending_invite: true } : row));
-    } catch (err) {
-      toast.error(formatRequestError(err, "Einladung konnte nicht gesendet werden."));
+    });
+    if (attempt.started && attempt.error) {
+      const message = formatRequestError(attempt.error, "Einladung konnte nicht gesendet werden.");
+      setInviteError(message);
+      toast.error(message);
     }
   };
 
@@ -451,7 +475,7 @@ function InviteMemberPanel({ team }) {
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/35" />
         <input
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => { setQuery(e.target.value); setInviteError(""); }}
           placeholder="Username suchen"
           className="w-full bg-[#0A0A0A] border border-white/10 pl-9 pr-3 py-2 rounded-sm text-sm"
         />
@@ -466,7 +490,7 @@ function InviteMemberPanel({ team }) {
             </div>
             <button
               type="button"
-              disabled={candidate.has_pending_invite}
+              disabled={candidate.has_pending_invite || inviting}
               onClick={() => invite(candidate)}
               className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 border border-[#29B6E8]/40 text-[#29B6E8] rounded-sm text-[10px] uppercase tracking-wider font-bold disabled:opacity-45 disabled:pointer-events-none"
             >
@@ -475,6 +499,7 @@ function InviteMemberPanel({ team }) {
           </div>
         ))}
         {query.trim().length >= 2 && !loading && candidates.length === 0 && <div className="text-xs text-white/35">Keine passenden Benutzer gefunden.</div>}
+        {inviteError && <AuthFormAlert id="team-invite-error">{inviteError}</AuthFormAlert>}
       </div>
     </div>
   );
@@ -483,27 +508,32 @@ function InviteMemberPanel({ team }) {
 function TeamModal({ team, onClose, onSaved }) {
   const isNew = !team?.id;
   const [form, setForm] = useState({ ...emptyTeam, ...team });
-  const [saving, setSaving] = useState(false);
-  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+  const { submitting: saving, submitOnce } = useSubmissionGuard();
+  const [submitError, setSubmitError] = useState("");
+  const set = (k, v) => { setForm((f) => ({ ...f, [k]: v })); setSubmitError(""); };
 
   const submit = async (e) => {
     e.preventDefault();
-    setSaving(true);
-    try {
-      const payload = {
+    const payload = {
         name: form.name.trim(),
         tag: form.tag.trim().toUpperCase(),
         description: form.description || null,
         logo_url: form.logo_url || null,
         banner_url: form.banner_url || null,
         discord_link: form.discord_link || null,
-      };
+    };
+    setSubmitError("");
+    const attempt = await submitOnce(async () => {
       if (isNew) await api.post("/teams", payload);
       else await api.patch(`/teams/${team.id}`, payload);
       toast.success(isNew ? "Team erstellt." : "Team gespeichert.");
       onSaved();
-    } catch (err) { toast.error(formatRequestError(err, isNew ? "Team konnte nicht erstellt werden." : "Team konnte nicht gespeichert werden.", { name: form.name })); }
-    setSaving(false);
+    });
+    if (attempt.started && attempt.error) {
+      const message = formatRequestError(attempt.error, isNew ? "Team konnte nicht erstellt werden." : "Team konnte nicht gespeichert werden.", { name: form.name });
+      setSubmitError(message);
+      toast.error(message);
+    }
   };
 
   return (
@@ -522,7 +552,8 @@ function TeamModal({ team, onClose, onSaved }) {
           <Field label="Discord-Link"><Input value={form.discord_link || ""} onChange={(v) => set("discord_link", v)} placeholder="https://discord.gg/..." /></Field>
         </div>
         <div className="flex justify-end gap-2 p-5 border-t border-white/10">
-          <button type="button" onClick={onClose} className="px-4 py-2 border border-white/10 text-white/60 rounded-sm text-xs uppercase tracking-wider font-bold">Abbrechen</button>
+          {submitError && <div className="mr-auto"><AuthFormAlert id="team-submit-error">{submitError}</AuthFormAlert></div>}
+          <button type="button" onClick={onClose} disabled={saving} className="px-4 py-2 border border-white/10 text-white/60 rounded-sm text-xs uppercase tracking-wider font-bold disabled:opacity-50">Abbrechen</button>
           <button disabled={saving} data-testid="team-save" className="px-5 py-2 bg-[#29B6E8] text-black rounded-sm text-xs uppercase tracking-wider font-bold disabled:opacity-50">{saving ? "Speichere…" : "Speichern"}</button>
         </div>
       </form>

--- a/frontend/src/pages/public/TournamentDetailPage.jsx
+++ b/frontend/src/pages/public/TournamentDetailPage.jsx
@@ -7,7 +7,9 @@ import { PublicLoadingState } from "@/components/tls/PublicLoadingState";
 import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
 import { StatusBadge } from "@/components/tls/StatusBadge";
 import { PhaseBadge } from "@/components/tls/PhaseBadge";
+import { AuthFormAlert } from "@/components/tls/AuthFormFields";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { toast } from "sonner";
 import { Calendar, Users, Trophy, MapPin, Gamepad2, Radio, Zap, X, Flag, MessageSquare, Send } from "lucide-react";
 import { PrizeList } from "@/components/tls/PrizeList";
@@ -34,7 +36,8 @@ export default function TournamentDetailPage() {
   const [standings, setStandings] = useState([]);
   const [myReg, setMyReg] = useState(null);
   const [myTeams, setMyTeams] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
+  const [actionError, setActionError] = useState("");
   const [registerModal, setRegisterModal] = useState(false);
   const confirm = useConfirm();
   const seoDescription = seoTextPreview(t?.description || t?.rules, "eSports Turnier von THE LION SQUAD mit Anmeldung, Check-in, Bracket und Rangliste.");
@@ -77,10 +80,19 @@ export default function TournamentDetailPage() {
 
   useApiInvalidation(load, ["tournaments"]);
 
+  const runAction = async (task, fallback) => {
+    setActionError("");
+    const attempt = await submitOnce(task);
+    if (!attempt.started || !attempt.error) return attempt.started;
+    const message = formatApiError(attempt.error.response?.data?.detail) || fallback;
+    setActionError(message);
+    toast.error(message);
+    return false;
+  };
+
   const submitRegistration = async ({ playerIds = {}, teamId = null } = {}) => {
     if (!user) { nav(`/login?next=${encodeURIComponent(`/tournaments/${slug}${accessToken ? `?access=${accessToken}` : ""}`)}`); return; }
-    setLoading(true);
-    try {
+    await runAction(async () => {
       await api.post(`/tournaments/${t.id}/register`, {
         team_id: teamId,
         ingame_name: user.display_name || user.username,
@@ -90,10 +102,8 @@ export default function TournamentDetailPage() {
       }, { params: accessToken ? { access: accessToken } : undefined });
       toast.success("Erfolgreich angemeldet!");
       setRegisterModal(false);
-      load();
-    } catch (e) {
-      toast.error(formatApiError(e.response?.data?.detail));
-    } finally { setLoading(false); }
+      await load();
+    }, "Anmeldung konnte nicht gespeichert werden.");
   };
 
   const handleRegister = async () => {
@@ -107,32 +117,27 @@ export default function TournamentDetailPage() {
   };
 
   const handleCheckin = async () => {
-    try {
+    await runAction(async () => {
       await api.post(`/tournaments/${t.id}/checkin`);
       toast.success("Check-in erfolgt.");
-      load();
-    } catch (e) { toast.error(formatApiError(e.response?.data?.detail)); }
+      await load();
+    }, "Check-in konnte nicht gespeichert werden.");
   };
 
   const handleUnregister = async () => {
     if (!myReg) return;
-    const ok = await confirm({
-      title: "Vom Turnier abmelden?",
-      description: "Deine Anmeldung wird entfernt und dein Platz wird im Vorschau-Turnierbaum wieder frei.",
-      confirmLabel: "Abmelden",
-      tone: "danger",
-    });
-    if (!ok) return;
-    setLoading(true);
-    try {
+    await runAction(async () => {
+      const ok = await confirm({
+        title: "Vom Turnier abmelden?",
+        description: "Deine Anmeldung wird entfernt und dein Platz wird im Vorschau-Turnierbaum wieder frei.",
+        confirmLabel: "Abmelden",
+        tone: "danger",
+      });
+      if (!ok) return;
       await api.delete(`/tournaments/${t.id}/registrations/${myReg.id}`);
       toast.success("Du bist vom Turnier abgemeldet.");
-      load();
-    } catch (e) {
-      toast.error(formatApiError(e.response?.data?.detail) || "Abmeldung fehlgeschlagen.");
-    } finally {
-      setLoading(false);
-    }
+      await load();
+    }, "Abmeldung fehlgeschlagen.");
   };
 
   if (!t) return <PublicLayout><PublicLoadingState label="Lade Turnier" /></PublicLayout>;
@@ -224,7 +229,7 @@ export default function TournamentDetailPage() {
               </button>
             )}
             {canCheckIn && myReg.status === "approved" && t.status === "check_in" && (
-              <button onClick={handleCheckin} data-testid="tournament-checkin-btn" className="px-6 py-3 bg-[#FFD700] text-black font-bold uppercase tracking-wider rounded-sm hover:bg-[#EAC200] transition">
+              <button onClick={handleCheckin} disabled={loading} data-testid="tournament-checkin-btn" className="px-6 py-3 bg-[#FFD700] text-black font-bold uppercase tracking-wider rounded-sm hover:bg-[#EAC200] disabled:opacity-50 transition">
                 Check-in
               </button>
             )}
@@ -265,6 +270,7 @@ export default function TournamentDetailPage() {
               </a>
             )}
           </div>
+          {!registerModal && actionError && <div className="mt-4 max-w-3xl"><AuthFormAlert id="tournament-action-error">{actionError}</AuthFormAlert></div>}
         </div>
       </div>
 
@@ -342,6 +348,7 @@ export default function TournamentDetailPage() {
           user={user}
           myTeams={myTeams}
           loading={loading}
+          error={actionError}
           onClose={() => setRegisterModal(false)}
           onSubmit={submitRegistration}
         />
@@ -353,8 +360,9 @@ export default function TournamentDetailPage() {
 function TournamentChat({ tournament, user }) {
   const [messages, setMessages] = useState([]);
   const [text, setText] = useState("");
-  const [loading, setLoading] = useState(false);
+  const { submitting: loading, submitOnce } = useSubmissionGuard();
   const [blocked, setBlocked] = useState("");
+  const [sendError, setSendError] = useState("");
   const scrollRef = useRef(null);
 
   const load = useCallback(async () => {
@@ -385,16 +393,17 @@ function TournamentChat({ tournament, user }) {
     event.preventDefault();
     const message = text.trim();
     if (!message) return;
-    setLoading(true);
-    try {
+    setSendError("");
+    const attempt = await submitOnce(async () => {
       const { data } = await api.post(`/tournaments/${tournament.id}/chat`, { message });
       setMessages((rows) => [...rows, data]);
       setText("");
       setBlocked("");
-    } catch (err) {
-      toast.error(formatApiError(err.response?.data?.detail) || "Nachricht konnte nicht gesendet werden.");
-    } finally {
-      setLoading(false);
+    });
+    if (attempt.started && attempt.error) {
+      const messageText = formatApiError(attempt.error.response?.data?.detail) || "Nachricht konnte nicht gesendet werden.";
+      setSendError(messageText);
+      toast.error(messageText);
     }
   };
 
@@ -432,7 +441,7 @@ function TournamentChat({ tournament, user }) {
             <form onSubmit={send} className="border-t border-white/10 p-3 flex gap-2">
               <MentionTextarea
                 value={text}
-                onValueChange={setText}
+                onValueChange={(value) => { setText(value); setSendError(""); }}
                 scope="tournament"
                 scopeId={tournament.id}
                 onKeyDown={(event) => {
@@ -451,6 +460,7 @@ function TournamentChat({ tournament, user }) {
                 <Send className="w-3.5 h-3.5" /> Senden
               </button>
             </form>
+            {sendError && <div className="border-t border-white/10 p-3"><AuthFormAlert id="tournament-chat-error">{sendError}</AuthFormAlert></div>}
           </>
         )}
       </div>
@@ -480,7 +490,7 @@ function PodiumCard({ row }) {
   );
 }
 
-function RegistrationModal({ tournament, user, myTeams = [], loading, onClose, onSubmit }) {
+function RegistrationModal({ tournament, user, myTeams = [], loading, error, onClose, onSubmit }) {
   const game = tournament.game || {};
   const fields = game.effective_player_id_fields || game.player_id_fields || [];
   const sourceSlug = game.identity_game_slug || game.slug;
@@ -539,6 +549,7 @@ function RegistrationModal({ tournament, user, myTeams = [], loading, onClose, o
             />
           </label>
         ))}
+        {error && <AuthFormAlert id="tournament-registration-error">{error}</AuthFormAlert>}
         <div className="flex justify-end gap-2 pt-2">
           <button type="button" onClick={onClose} className="px-4 py-2 border border-white/15 text-white/70 rounded-sm text-xs uppercase tracking-wider font-bold">Abbrechen</button>
           <button disabled={loading || (needsTeam && !teamId)} className="px-5 py-2 bg-[#29B6E8] text-black rounded-sm text-xs uppercase tracking-wider font-bold disabled:opacity-50">


### PR DESCRIPTION
## Zusammenfassung

- schützt Event-, Team-, Turnier-, Match- und Fast-Lap-Aktionen atomar vor Doppelklicks und parallelen Browser-Requests
- hält Buttons während laufender Mutationen gesperrt und zeigt Validierungs-/API-Fehler stabil sowie zugänglich an
- führt Bestätigungsdialoge innerhalb der Single-Flight-Sperre aus
- ergänzt Desktop- und Mobile-Regressionsfälle für die zentralen öffentlichen Aktionen

## Prüfung

- `yarn build`
- Frontend-Unit-Tests: 10 bestanden
- neue Action-Guard-E2E-Tests: 10 bestanden
- vollständige Browser-Suite: 52 bestanden, 8 Live-Admin-Tests erwartungsgemäß übersprungen
- `yarn audit:high`
- Backend-Tests: 198 bestanden
- `python -m compileall -q backend`
- `git diff --check`

## Abgrenzung

Dieser PR schließt den clientseitigen Formular-/Doppelversand-Schutz in #95 ab. Die separate Prüfung echter serverseitiger Idempotenz bei gleichzeitig eintreffenden Requests (insbesondere Turnier- und Ergebnisaktionen) bleibt bewusst offen und wird in einem eigenen Schritt behandelt.