### PR TITLE
fix: serialize tournament mutations

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -52,12 +52,14 @@ async def init_indexes():
     await db.tournaments.create_index("id", unique=True)
     await db.tournaments.create_index("slug", unique=True)
     await db.tournaments.create_index("slug_history")
+    await db.tournaments.create_index("creation_key", unique=True, sparse=True)
     await db.tournaments.create_index("status")
     await db.tournaments.create_index("game_id")
     await db.tournaments.create_index("event_id")
     # Registrations
     await db.tournament_registrations.create_index("id", unique=True)
     await db.tournament_registrations.create_index([("tournament_id", 1), ("user_id", 1)])
+    await db.tournament_registrations.create_index("identity_key", unique=True, sparse=True)
     # Matches
     await db.matches.create_index("id", unique=True)
     await db.matches.create_index("tournament_id")
@@ -117,6 +119,10 @@ async def init_indexes():
     # Audit
     await db.audit_logs.create_index("id", unique=True)
     await db.audit_logs.create_index("created_at")
+    # Cross-worker mutation leases.  These protect multi-document tournament
+    # operations when multiple API workers receive the same action at once.
+    await db.mutation_locks.create_index("resource", unique=True)
+    await db.mutation_locks.create_index("expires_at", expireAfterSeconds=0)
     # Auth helpers
     await db.password_reset_tokens.create_index("expires_at", expireAfterSeconds=0)
     await db.login_attempts.create_index("identifier")
@@ -148,6 +154,7 @@ async def init_indexes():
     await db.tournament_staff_assignments.create_index("user_id")
     await db.tournament_stages.create_index("id", unique=True)
     await db.tournament_stages.create_index([("tournament_id", 1), ("number", 1)])
+    await db.tournament_stages.create_index("creation_key", unique=True, sparse=True)
     await db.matches_v2.create_index("id", unique=True)
     await db.matches_v2.create_index([("tournament_id", 1), ("stage_id", 1)])
     await db.matches_v2.create_index([("stage_id", 1), ("match_key", 1)])

--- a/backend/routes/match_routes.py
+++ b/backend/routes/match_routes.py
@@ -28,11 +28,13 @@ from match_rules import loser_for_winner, match_allows_draw, validate_winner_id
 from services.match_notifications import notify_match_result_confirmed
 from services.match_overview import operational_match_overviews, own_match_overviews
 from services.match_planning import ensure_station_slot_available, ensure_tournament_accepts_results
-from services.match_v2_results import MatchV2ResultError, build_v2_result_application
+from services.match_v2_results import MatchV2ResultError
+from services.mutation_lock import MutationLockBusy, mutation_lock, tournament_write_resource
 from services.station_runtime import release_station_for_match
 from services.rate_limit import enforce_rate_limit
 from services.station_labels import attach_station_info
 from services.user_notifications import create_user_notification
+from services.v2_result_submission import submit_v2_result
 
 router = APIRouter(prefix="/api/matches", tags=["matches"])
 STAFF_ROLES = {"moderator", "tournament_admin", "club_admin", "superadmin"}
@@ -217,6 +219,15 @@ async def _find_match_any(match_id: str) -> tuple[dict, str]:
     raise HTTPException(status_code=404, detail="Match nicht gefunden")
 
 
+async def _serialized_match_write(match_id: str):
+    match, _collection = await _find_match_any(match_id)
+    try:
+        async with mutation_lock(get_db(), tournament_write_resource(match["tournament_id"])):
+            yield
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
+
+
 def _registration_ids_for_match(match: dict) -> list[str]:
     if match.get("slots"):
         return [
@@ -356,7 +367,9 @@ async def _notify_match_chat_message(
     message: dict,
 ) -> None:
     tournament = await db.tournaments.find_one({"id": match.get("tournament_id")}, {"_id": 0}) or {}
-    stage = await db.tournament_stages.find_one({"id": match.get("stage_id")}, {"_id": 0}) if match.get("stage_id") else None
+    stage = await db.tournament_stages.find_one(
+        {"id": match.get("stage_id")}, {"_id": 0, "creation_key": 0}
+    ) if match.get("stage_id") else None
     policy = _match_policy(match, collection, tournament, stage)
     handles = {handle.lower() for handle in MENTION_RE.findall(message.get("message") or "")}
     staff_requested = bool(handles & STAFF_MENTION_HANDLES)
@@ -583,8 +596,12 @@ async def _match_page_payload(match: dict, collection: str, user: dict | None = 
     db = get_db()
     match = await _refresh_schedule_escalation(match, collection)
     await attach_station_info(db, [match])
-    tournament = await db.tournaments.find_one({"id": match.get("tournament_id")}, {"_id": 0})
-    stage = await db.tournament_stages.find_one({"id": match.get("stage_id")}, {"_id": 0})
+    tournament = await db.tournaments.find_one(
+        {"id": match.get("tournament_id")}, {"_id": 0, "creation_key": 0}
+    )
+    stage = await db.tournament_stages.find_one(
+        {"id": match.get("stage_id")}, {"_id": 0, "creation_key": 0}
+    )
     proposals = await db.match_schedule_proposals.find(
         {"match_id": match["id"]},
         {"_id": 0},
@@ -658,7 +675,8 @@ async def list_schedule_proposals(match_id: str, user: dict | None = Depends(get
 
 @router.post("/{match_id}/schedule-proposals")
 async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCreate,
-                                   me: dict = Depends(get_current_user)):
+                                   me: dict = Depends(get_current_user),
+                                   _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
     match, collection = await _find_match_any(match_id)
     acting_reg = await _acting_registration_for_match(match, me)
@@ -670,6 +688,17 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
     if not await _can_act_for_match(match, me):
         raise HTTPException(status_code=403, detail="Nur Teilnehmer, Team-Captains oder Turnierleitung duerfen Termine vorschlagen")
     now_iso = now_utc().isoformat()
+    normalized_note = (body.note or "").strip() or None
+    existing = await db.match_schedule_proposals.find_one({
+        "match_id": match_id,
+        "actor_user_id": me["id"],
+        "scheduled_at": body.scheduled_at.isoformat(),
+        "note": normalized_note,
+        "status": "pending",
+        "kind": "proposal",
+    }, {"_id": 0, "match_collection": 0})
+    if existing:
+        return {**existing, "idempotent_replay": True}
     doc = {
         "id": new_id(),
         "match_id": match_id,
@@ -679,7 +708,7 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
         "actor_user_id": me["id"],
         "actor_registration_id": acting_reg.get("id") if acting_reg else None,
         "scheduled_at": body.scheduled_at.isoformat(),
-        "note": (body.note or "").strip() or None,
+        "note": normalized_note,
         "status": "pending",
         "kind": "proposal",
         "created_at": now_iso,
@@ -693,12 +722,14 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
     }})
     doc.pop("_id", None)
     doc.pop("match_collection", None)
+    doc["idempotent_replay"] = False
     return doc
 
 
 @router.post("/{match_id}/schedule-proposals/{proposal_id}/decision")
 async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchScheduleProposalDecision,
-                                   me: dict = Depends(get_current_user)):
+                                   me: dict = Depends(get_current_user),
+                                   _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
     match, collection = await _find_match_any(match_id)
     proposal = await db.match_schedule_proposals.find_one({"id": proposal_id, "match_id": match_id}, {"_id": 0})
@@ -720,12 +751,34 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
     ):
         raise HTTPException(status_code=400, detail="Der eigene Vorschlag muss von der Gegenseite bestaetigt werden")
     now_iso = now_utc().isoformat()
+    normalized_note = (body.note or "").strip() or None
+    completed_action = {"accept": "accepted", "decline": "declined", "counter": "countered"}[body.action]
+    if (
+        proposal.get("status") == completed_action
+        and proposal.get("decision_user_id") == me["id"]
+        and proposal.get("decision_note") == normalized_note
+    ):
+        if completed_action == "countered" and body.scheduled_at:
+            existing_counter = await db.match_schedule_proposals.find_one({
+                "parent_proposal_id": proposal_id,
+                "actor_user_id": me["id"],
+                "scheduled_at": body.scheduled_at.isoformat(),
+                "note": normalized_note,
+            }, {"_id": 0, "match_collection": 0})
+            if existing_counter:
+                return {**existing_counter, "idempotent_replay": True}
+        response = {"ok": True, "status": completed_action, "idempotent_replay": True}
+        if completed_action == "accepted":
+            response["scheduled_at"] = proposal.get("scheduled_at")
+        return response
+    if proposal.get("status") != "pending":
+        raise HTTPException(status_code=409, detail="Über diesen Terminvorschlag wurde bereits entschieden")
     if body.action == "accept":
         scheduled_at = proposal.get("scheduled_at")
         await db.match_schedule_proposals.update_one({"id": proposal_id}, {"$set": {
             "status": "accepted",
             "decision_user_id": me["id"],
-            "decision_note": (body.note or "").strip() or None,
+            "decision_note": normalized_note,
             "updated_at": now_iso,
         }})
         await db[collection].update_one({"id": match_id}, {"$set": {
@@ -734,22 +787,22 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
             "status": "scheduled" if match.get("status") in {"pending", "ready", "preview"} else match.get("status"),
             "updated_at": now_iso,
         }})
-        return {"ok": True, "status": "accepted", "scheduled_at": scheduled_at}
+        return {"ok": True, "status": "accepted", "scheduled_at": scheduled_at, "idempotent_replay": False}
     if body.action == "decline":
         await db.match_schedule_proposals.update_one({"id": proposal_id}, {"$set": {
             "status": "declined",
             "decision_user_id": me["id"],
-            "decision_note": (body.note or "").strip() or None,
+            "decision_note": normalized_note,
             "updated_at": now_iso,
         }})
         await db[collection].update_one({"id": match_id}, {"$set": {"schedule_status": "declined", "updated_at": now_iso}})
-        return {"ok": True, "status": "declined"}
+        return {"ok": True, "status": "declined", "idempotent_replay": False}
     if not body.scheduled_at:
         raise HTTPException(status_code=400, detail="Gegenvorschlag braucht Datum und Uhrzeit")
     await db.match_schedule_proposals.update_one({"id": proposal_id}, {"$set": {
         "status": "countered",
         "decision_user_id": me["id"],
-        "decision_note": (body.note or "").strip() or None,
+        "decision_note": normalized_note,
         "updated_at": now_iso,
     }})
     counter = {
@@ -761,7 +814,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
         "actor_user_id": me["id"],
         "actor_registration_id": acting_reg.get("id") if acting_reg else None,
         "scheduled_at": body.scheduled_at.isoformat(),
-        "note": (body.note or "").strip() or None,
+        "note": normalized_note,
         "status": "pending",
         "kind": "counter",
         "parent_proposal_id": proposal_id,
@@ -776,6 +829,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
     }})
     counter.pop("_id", None)
     counter.pop("match_collection", None)
+    counter["idempotent_replay"] = False
     return counter
 
 
@@ -851,72 +905,28 @@ async def submit_match_result(match_id: str, body: MatchV2ResultSubmit,
     await _ensure_match_tournament_unlocked(db, match)
     await ensure_tournament_accepts_results(db, match["tournament_id"])
     await _require_result_permission(me, match)
-    stage_matches = await db.matches_v2.find(
-        {"stage_id": match["stage_id"]},
-        {"_id": 0},
-    ).to_list(3000)
-    now_iso = now_utc().isoformat()
     try:
-        application = build_v2_result_application(
-            match,
-            stage_matches,
-            [entry.model_dump() for entry in body.results],
-            actor_id=me["id"],
-            now_iso=now_iso,
-            proof_url=body.proof_url,
-            note=body.note,
-            force=force,
-        )
+        async with mutation_lock(db, tournament_write_resource(match["tournament_id"])):
+            match, collection = await _find_match_any(match_id)
+            if collection != "matches_v2":
+                raise HTTPException(status_code=400, detail="Dieses Ergebnisformular ist für Mehrspieler-Heats vorgesehen")
+            await _ensure_match_tournament_unlocked(db, match)
+            await ensure_tournament_accepts_results(db, match["tournament_id"])
+            await _require_result_permission(me, match)
+            return await submit_v2_result(
+                db,
+                match,
+                [entry.model_dump() for entry in body.results],
+                actor_id=me["id"],
+                proof_url=body.proof_url,
+                note=body.note,
+                force=force,
+                audit_action="match.result.submit",
+            )
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
     except MatchV2ResultError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc))
-
-    await db.matches_v2.update_one({"id": match_id}, {"$set": application["match_set"]})
-    for target_id, update in application["target_sets"].items():
-        await db.matches_v2.update_one({"id": target_id}, {"$set": update})
-
-    report = {
-        "id": new_id(),
-        "match_id": match_id,
-        "tournament_id": match["tournament_id"],
-        "stage_id": match["stage_id"],
-        "reporter_user_id": me["id"],
-        "source": "staff",
-        "results": application["results"],
-        "proof_url": body.proof_url,
-        "note": body.note,
-        "force": force,
-        "created_at": now_iso,
-    }
-    await db.match_reports_v2.insert_one(report)
-    await db.audit_logs.insert_one({
-        "id": new_id(),
-        "action": "match.result.submit",
-        "target_id": match["tournament_id"],
-        "actor_id": me["id"],
-        "data": {
-            "match_id": match_id,
-            "stage_id": match["stage_id"],
-            "match_key": match.get("match_key"),
-            "advanced_matches": list(application["target_sets"].keys()),
-            "force": force,
-        },
-        "created_at": now_iso,
-    })
-    updated = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
-    try:
-        await notify_match_result_confirmed(db, updated, "matches_v2", force=force)
-    except Exception:
-        pass
-    try:
-        await release_station_for_match(db, updated, "matches_v2")
-    except Exception:
-        pass
-    return {
-        "ok": True,
-        "match": updated,
-        "advanced_match_ids": list(application["target_sets"].keys()),
-        "report_id": report["id"],
-    }
 
 
 @router.get("/{match_id}")
@@ -940,7 +950,8 @@ async def get_match(match_id: str, user: dict | None = Depends(get_optional_user
 
 @router.put("/{match_id}")
 @router.patch("/{match_id}")
-async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_current_user)):
+async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_current_user),
+                       _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
     m = await db.matches.find_one({"id": match_id})
     if not m:
@@ -980,6 +991,10 @@ async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_
     await ensure_station_slot_available(db, m, updates, "matches")
     if not final_winner and "winner_id" in updates:
         updates["loser_id"] = None
+    if updates and all(m.get(key) == value for key, value in updates.items()):
+        m.pop("_id", None)
+        m["idempotent_replay"] = True
+        return m
     updates["updated_at"] = now_utc().isoformat()
     await db.matches.update_one({"id": match_id}, {"$set": updates})
     m = await db.matches.find_one({"id": match_id})
@@ -1006,7 +1021,11 @@ async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_
             },
         })
     # If completed, advance bracket
-    if m.get("status") == "completed" and m.get("winner_id"):
+    if (
+        m.get("status") == "completed"
+        and m.get("winner_id")
+        and current_result_signature != previous_result_signature
+    ):
         all_matches = await db.matches.find({"tournament_id": m["tournament_id"]}).to_list(2000)
         updated_matches = advance_match_winner(m, all_matches)
         for um in updated_matches:
@@ -1055,11 +1074,13 @@ async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_
             except Exception:
                 pass
     m.pop("_id", None)
+    m["idempotent_replay"] = False
     return m
 
 
 @router.post("/{match_id}/report")
-async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends(get_current_user)):
+async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends(get_current_user),
+                       _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
     m = await db.matches.find_one({"id": match_id})
     if not m:
@@ -1077,6 +1098,20 @@ async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends
         {"id": {"$in": reg_ids}, "user_id": me["id"]})
     if not my_reg:
         raise HTTPException(status_code=403, detail="Nicht Teilnehmer dieses Matches")
+    report_signature = {
+        "registration_id": my_reg["id"],
+        "score_a": body.score_a,
+        "score_b": body.score_b,
+        "screenshot_url": body.screenshot_url,
+        "note": body.note,
+    }
+    if any(
+        all(report.get(key) == value for key, value in report_signature.items())
+        for report in m.get("reports") or []
+    ):
+        m.pop("_id", None)
+        m["idempotent_replay"] = True
+        return m
     report = {
         "id": new_id(),
         "user_id": me["id"],
@@ -1125,11 +1160,13 @@ async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends
             except Exception:
                 pass
     m = await db.matches.find_one({"id": match_id}, {"_id": 0})
+    m["idempotent_replay"] = False
     return m
 
 
 @router.post("/{match_id}/dispute")
-async def dispute(match_id: str, body: MatchDispute, me: dict = Depends(get_current_user)):
+async def dispute(match_id: str, body: MatchDispute, me: dict = Depends(get_current_user),
+                  _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
     m = await db.matches.find_one({"id": match_id})
     if not m:
@@ -1137,8 +1174,16 @@ async def dispute(match_id: str, body: MatchDispute, me: dict = Depends(get_curr
     await _ensure_match_tournament_unlocked(db, m)
     if not _is_staff(me) and not await _user_registration_for_match(m, me):
         raise HTTPException(status_code=403, detail="Nicht Teilnehmer dieses Matches")
+    reason = body.reason.strip()
+    if any(
+        item.get("user_id") == me["id"] and (item.get("reason") or "").strip() == reason
+        for item in m.get("disputes") or []
+    ):
+        m.pop("_id", None)
+        m["idempotent_replay"] = True
+        return m
     await db.matches.update_one({"id": match_id}, {
-        "$push": {"disputes": {"user_id": me["id"], "reason": body.reason,
+        "$push": {"disputes": {"user_id": me["id"], "reason": reason,
                                  "at": now_utc().isoformat()}},
         "$set": {"status": "disputed", "updated_at": now_utc().isoformat()},
     })
@@ -1152,11 +1197,14 @@ async def dispute(match_id: str, body: MatchDispute, me: dict = Depends(get_curr
         await on_dispute_opened(me["id"], match_id=match_id)
     except Exception:
         pass
+    m["idempotent_replay"] = False
     return m
 
 
 @router.post("/{match_id}/forfeit")
-async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user)):
+async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user),
+                  force: bool = False,
+                  _mutation: None = Depends(_serialized_match_write)):
     """Admin forfeit - winner_id is the surviving participant.
 
     P0 — Penalty Transparency: a justification note (≥5 chars) is mandatory and
@@ -1178,6 +1226,16 @@ async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user
     winner_id = body.get("winner_id")
     validate_winner_id(m, winner_id)
     loser_id = loser_for_winner(m, winner_id)
+    if (
+        m.get("status") == "forfeit"
+        and m.get("winner_id") == winner_id
+        and m.get("admin_decision_note") == note
+    ):
+        m.pop("_id", None)
+        m["idempotent_replay"] = True
+        return m
+    if m.get("status") == "forfeit" and not force:
+        raise HTTPException(status_code=409, detail="Forfeit ist bereits gesetzt. Abweichende Korrektur braucht force=true.")
     await db.matches.update_one({"id": match_id}, {"$set": {
         "winner_id": winner_id, "loser_id": loser_id,
         "status": "forfeit",
@@ -1204,6 +1262,7 @@ async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user
     except Exception:
         pass
     m.pop("_id", None)
+    m["idempotent_replay"] = False
     # Phase B v4.1: forfeit ⇒ no_show for the loser
     try:
         from badges import trigger_negative_incident

--- a/backend/routes/match_v2_routes.py
+++ b/backend/routes/match_v2_routes.py
@@ -13,11 +13,11 @@ from models import (
     new_id,
     now_utc,
 )
-from services.match_v2_results import MatchV2ResultError, build_v2_result_application
-from services.match_notifications import notify_match_result_confirmed
+from services.match_v2_results import MatchV2ResultError
 from services.match_planning import ensure_station_slot_available, ensure_tournament_accepts_results
+from services.mutation_lock import MutationLockBusy, mutation_lock, tournament_write_resource
 from services.rate_limit import enforce_rate_limit
-from services.station_runtime import release_station_for_match
+from services.v2_result_submission import submit_v2_result
 from services.tournament_permissions import (
     CHECKIN_STAFF_ROLES,
     READ_STAFF_ROLES,
@@ -185,7 +185,9 @@ async def _assert_match_visible(match: dict, user: dict | None) -> None:
     if await _can_read_match(user, match):
         return
     db = get_db()
-    tournament = await db.tournaments.find_one({"id": match.get("tournament_id")}, {"_id": 0})
+    tournament = await db.tournaments.find_one(
+        {"id": match.get("tournament_id")}, {"_id": 0, "creation_key": 0}
+    )
     if not tournament:
         raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
     if tournament.get("status") == "draft" or tournament.get("is_public") is False:
@@ -244,7 +246,9 @@ async def _match_page_payload(match: dict, user: dict | None = None) -> dict:
     db = get_db()
     match = await _refresh_schedule_escalation(match)
     tournament = await db.tournaments.find_one({"id": match.get("tournament_id")}, {"_id": 0})
-    stage = await db.tournament_stages.find_one({"id": match.get("stage_id")}, {"_id": 0})
+    stage = await db.tournament_stages.find_one(
+        {"id": match.get("stage_id")}, {"_id": 0, "creation_key": 0}
+    )
     regs = await _registrations_for_match(match)
     reg_by_id = {r["id"]: r for r in regs}
     user_ids = list({r.get("user_id") for r in regs if r.get("user_id")})
@@ -302,6 +306,18 @@ async def _match_page_payload(match: dict, user: dict | None = None) -> dict:
     }
 
 
+async def _serialized_match_v2_write(match_id: str):
+    db = get_db()
+    match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
+    if not match:
+        raise HTTPException(status_code=404, detail="Match nicht gefunden")
+    try:
+        async with mutation_lock(db, tournament_write_resource(match["tournament_id"])):
+            yield
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
+
+
 @router.get("/{match_id}")
 async def get_match_v2(match_id: str, user: dict | None = Depends(get_optional_user)):
     db = get_db()
@@ -335,7 +351,8 @@ async def list_schedule_proposals(match_id: str, user: dict | None = Depends(get
 
 @router.post("/{match_id}/schedule-proposals")
 async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCreate,
-                                   me: dict = Depends(get_current_user)):
+                                   me: dict = Depends(get_current_user),
+                                   _mutation: None = Depends(_serialized_match_v2_write)):
     db = get_db()
     match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
     if not match:
@@ -350,6 +367,17 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
         raise HTTPException(status_code=403, detail="Nur Teilnehmer, Team-Captains oder Turnierleitung duerfen Termine vorschlagen")
     acting_reg = await _acting_registration_for_match(match, me)
     now_iso = now_utc().isoformat()
+    normalized_note = (body.note or "").strip() or None
+    existing = await db.match_schedule_proposals.find_one({
+        "match_id": match_id,
+        "actor_user_id": me["id"],
+        "scheduled_at": body.scheduled_at.isoformat(),
+        "note": normalized_note,
+        "status": "pending",
+        "kind": "proposal",
+    }, {"_id": 0})
+    if existing:
+        return {**existing, "idempotent_replay": True}
     doc = {
         "id": new_id(),
         "match_id": match_id,
@@ -358,7 +386,7 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
         "actor_user_id": me["id"],
         "actor_registration_id": acting_reg.get("id") if acting_reg else None,
         "scheduled_at": body.scheduled_at.isoformat(),
-        "note": (body.note or "").strip() or None,
+        "note": normalized_note,
         "status": "pending",
         "kind": "proposal",
         "created_at": now_iso,
@@ -371,12 +399,14 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
         "updated_at": now_iso,
     }})
     doc.pop("_id", None)
+    doc["idempotent_replay"] = False
     return doc
 
 
 @router.post("/{match_id}/schedule-proposals/{proposal_id}/decision")
 async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchScheduleProposalDecision,
-                                   me: dict = Depends(get_current_user)):
+                                   me: dict = Depends(get_current_user),
+                                   _mutation: None = Depends(_serialized_match_v2_write)):
     db = get_db()
     match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
     proposal = await db.match_schedule_proposals.find_one({"id": proposal_id, "match_id": match_id}, {"_id": 0})
@@ -393,12 +423,34 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
     if acting_reg and proposal.get("actor_registration_id") == acting_reg.get("id") and body.action in {"accept", "decline"}:
         raise HTTPException(status_code=400, detail="Der eigene Vorschlag muss von der Gegenseite bestaetigt werden")
     now_iso = now_utc().isoformat()
+    normalized_note = (body.note or "").strip() or None
+    completed_action = {"accept": "accepted", "decline": "declined", "counter": "countered"}[body.action]
+    if (
+        proposal.get("status") == completed_action
+        and proposal.get("decision_user_id") == me["id"]
+        and proposal.get("decision_note") == normalized_note
+    ):
+        if completed_action == "countered" and body.scheduled_at:
+            existing_counter = await db.match_schedule_proposals.find_one({
+                "parent_proposal_id": proposal_id,
+                "actor_user_id": me["id"],
+                "scheduled_at": body.scheduled_at.isoformat(),
+                "note": normalized_note,
+            }, {"_id": 0})
+            if existing_counter:
+                return {**existing_counter, "idempotent_replay": True}
+        response = {"ok": True, "status": completed_action, "idempotent_replay": True}
+        if completed_action == "accepted":
+            response["scheduled_at"] = proposal.get("scheduled_at")
+        return response
+    if proposal.get("status") != "pending":
+        raise HTTPException(status_code=409, detail="Über diesen Terminvorschlag wurde bereits entschieden")
     if body.action == "accept":
         scheduled_at = proposal.get("scheduled_at")
         await db.match_schedule_proposals.update_one({"id": proposal_id}, {"$set": {
             "status": "accepted",
             "decision_user_id": me["id"],
-            "decision_note": (body.note or "").strip() or None,
+            "decision_note": normalized_note,
             "updated_at": now_iso,
         }})
         await db.matches_v2.update_one({"id": match_id}, {"$set": {
@@ -407,22 +459,22 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
             "status": "scheduled" if match.get("status") in {"pending", "ready", "preview"} else match.get("status"),
             "updated_at": now_iso,
         }})
-        return {"ok": True, "status": "accepted", "scheduled_at": scheduled_at}
+        return {"ok": True, "status": "accepted", "scheduled_at": scheduled_at, "idempotent_replay": False}
     if body.action == "decline":
         await db.match_schedule_proposals.update_one({"id": proposal_id}, {"$set": {
             "status": "declined",
             "decision_user_id": me["id"],
-            "decision_note": (body.note or "").strip() or None,
+            "decision_note": normalized_note,
             "updated_at": now_iso,
         }})
         await db.matches_v2.update_one({"id": match_id}, {"$set": {"schedule_status": "declined", "updated_at": now_iso}})
-        return {"ok": True, "status": "declined"}
+        return {"ok": True, "status": "declined", "idempotent_replay": False}
     if not body.scheduled_at:
         raise HTTPException(status_code=400, detail="Gegenvorschlag braucht Datum und Uhrzeit")
     await db.match_schedule_proposals.update_one({"id": proposal_id}, {"$set": {
         "status": "countered",
         "decision_user_id": me["id"],
-        "decision_note": (body.note or "").strip() or None,
+        "decision_note": normalized_note,
         "updated_at": now_iso,
     }})
     counter = {
@@ -433,7 +485,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
         "actor_user_id": me["id"],
         "actor_registration_id": acting_reg.get("id") if acting_reg else None,
         "scheduled_at": body.scheduled_at.isoformat(),
-        "note": (body.note or "").strip() or None,
+        "note": normalized_note,
         "status": "pending",
         "kind": "counter",
         "parent_proposal_id": proposal_id,
@@ -443,6 +495,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
     await db.match_schedule_proposals.insert_one(counter)
     await db.matches_v2.update_one({"id": match_id}, {"$set": {"schedule_status": "proposed", "updated_at": now_iso}})
     counter.pop("_id", None)
+    counter["idempotent_replay"] = False
     return counter
 
 
@@ -506,7 +559,8 @@ async def post_match_chat(match_id: str, body: MatchChatCreate, request: Request
 @router.patch("/{match_id}")
 @router.put("/{match_id}")
 async def update_match_v2(match_id: str, body: MatchV2Update,
-                          me: dict = Depends(get_current_user)):
+                          me: dict = Depends(get_current_user),
+                          _mutation: None = Depends(_serialized_match_v2_write)):
     db = get_db()
     match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
     if not match:
@@ -521,10 +575,12 @@ async def update_match_v2(match_id: str, body: MatchV2Update,
     if updates.get("scheduled_at") and match.get("status") in {"pending", "ready", "preview"} and "status" not in updates:
         updates["status"] = "scheduled"
     await ensure_station_slot_available(db, match, updates, "matches_v2")
+    if updates and all(match.get(key) == value for key, value in updates.items()):
+        return {**match, "idempotent_replay": True}
     updates["updated_at"] = now_utc().isoformat()
     await db.matches_v2.update_one({"id": match_id}, {"$set": updates})
     updated = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
-    return updated
+    return {**updated, "idempotent_replay": False}
 
 
 @router.post("/{match_id}/result")
@@ -538,69 +594,25 @@ async def submit_match_v2_result(match_id: str, body: MatchV2ResultSubmit,
     await _ensure_match_tournament_unlocked(db, match)
     await ensure_tournament_accepts_results(db, match["tournament_id"])
     await _require_v2_result_permission(me, match)
-    stage_matches = await db.matches_v2.find(
-        {"stage_id": match["stage_id"]},
-        {"_id": 0},
-    ).to_list(3000)
-    now_iso = now_utc().isoformat()
     try:
-        application = build_v2_result_application(
-            match,
-            stage_matches,
-            [entry.model_dump() for entry in body.results],
-            actor_id=me["id"],
-            now_iso=now_iso,
-            proof_url=body.proof_url,
-            note=body.note,
-            force=force,
-        )
+        async with mutation_lock(db, tournament_write_resource(match["tournament_id"])):
+            match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
+            if not match:
+                raise HTTPException(status_code=404, detail="Match nicht gefunden")
+            await _ensure_match_tournament_unlocked(db, match)
+            await ensure_tournament_accepts_results(db, match["tournament_id"])
+            await _require_v2_result_permission(me, match)
+            return await submit_v2_result(
+                db,
+                match,
+                [entry.model_dump() for entry in body.results],
+                actor_id=me["id"],
+                proof_url=body.proof_url,
+                note=body.note,
+                force=force,
+                audit_action="match_v2.result.submit",
+            )
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
     except MatchV2ResultError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc))
-
-    await db.matches_v2.update_one({"id": match_id}, {"$set": application["match_set"]})
-    for target_id, update in application["target_sets"].items():
-        await db.matches_v2.update_one({"id": target_id}, {"$set": update})
-
-    report = {
-        "id": new_id(),
-        "match_id": match_id,
-        "tournament_id": match["tournament_id"],
-        "stage_id": match["stage_id"],
-        "reporter_user_id": me["id"],
-        "source": "staff",
-        "results": application["results"],
-        "proof_url": body.proof_url,
-        "note": body.note,
-        "force": force,
-        "created_at": now_iso,
-    }
-    await db.match_reports_v2.insert_one(report)
-    await db.audit_logs.insert_one({
-        "id": new_id(),
-        "action": "match_v2.result.submit",
-        "target_id": match["tournament_id"],
-        "actor_id": me["id"],
-        "data": {
-            "match_id": match_id,
-            "stage_id": match["stage_id"],
-            "match_key": match.get("match_key"),
-            "advanced_matches": list(application["target_sets"].keys()),
-            "force": force,
-        },
-        "created_at": now_iso,
-    })
-    updated = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
-    try:
-        await notify_match_result_confirmed(db, updated, "matches_v2", force=force)
-    except Exception:
-        pass
-    try:
-        await release_station_for_match(db, updated, "matches_v2")
-    except Exception:
-        pass
-    return {
-        "ok": True,
-        "match": updated,
-        "advanced_match_ids": list(application["target_sets"].keys()),
-        "report_id": report["id"],
-    }

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -1,6 +1,8 @@
 """Tournament + bracket routes."""
 import csv
+import hashlib
 import io
+import json
 import re
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import RedirectResponse, StreamingResponse
@@ -9,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 import math
 from urllib.parse import quote, urlencode
 from pydantic import BaseModel, Field
+from pymongo.errors import DuplicateKeyError
 from database import get_db
 from auth import get_current_user, require_admin, get_optional_user
 from services.visibility import user_can_see
@@ -32,6 +35,7 @@ from services.match_v2_results import (
     build_v2_result_application,
     public_recalculation_error,
 )
+from services.mutation_lock import MutationLockBusy, mutation_lock, tournament_write_resource
 from services.slug_utils import apply_slug_history, find_by_slug_or_history, slug_source_for_update, unique_slug
 from models import (
     TournamentCreate, TournamentUpdate, RegistrationCreate, RegistrationUpdate,
@@ -674,7 +678,7 @@ async def _get_visible_tournament(tid: str, user: dict | None) -> dict:
 
 def _public_registration(reg: dict, user: dict | None, is_staff: bool) -> dict:
     if is_staff:
-        return reg
+        return {key: value for key, value in reg.items() if key not in {"_id", "identity_key"}}
     is_self = bool(user and reg.get("user_id") == user.get("id"))
     out = {
         "id": reg.get("id"),
@@ -1435,6 +1439,7 @@ async def _apply_checked_in_badges(user_id: str, tid: str) -> None:
 
 async def _enrich_tournament(t: dict, user: dict | None = None) -> dict:
     db = get_db()
+    t.pop("creation_key", None)
     t["public_phase"] = derive_public_phase(t, "tournament")
     if t.get("game_id"):
         g = await db.games.find_one({"id": t["game_id"]}, {"_id": 0})
@@ -1455,6 +1460,17 @@ async def _resolve_tid(slug_or_id: str) -> str:
     if not t:
         raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
     return t["id"]
+
+
+async def _serialized_tournament_write(tid: str):
+    """Serialize critical writes for one canonical tournament across workers."""
+    db = get_db()
+    resolved_tid = await _resolve_tid(tid)
+    try:
+        async with mutation_lock(db, tournament_write_resource(resolved_tid)):
+            yield resolved_tid
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
 
 
 @router.get("")
@@ -1641,35 +1657,59 @@ async def post_tournament_chat(tid: str, body: TournamentChatCreate, me: dict = 
 @router.post("")
 async def create_tournament(body: TournamentCreate, me: dict = Depends(require_admin())):
     db = get_db()
-    # Validate game
-    if not await db.games.find_one({"id": body.game_id}):
-        raise HTTPException(status_code=400, detail="Spiel nicht gefunden")
-    doc = body.model_dump()
-    doc["slug"] = await unique_slug(db.tournaments, doc.get("slug") or doc.get("title"), fallback="turnier")
-    doc["format_label"] = (doc.get("format_label") or "").strip() or None
-    if doc.get("format") != "single_elim":
-        doc["bronze_match"] = False
-    # ISO-serialize datetimes
-    for k in ["registration_open_from", "registration_open_until", "check_in_from",
-              "check_in_until", "start_date", "end_date"]:
-        doc[k] = _iso(doc.get(k))
-    doc["id"] = new_id()
-    # Allow scheduling directly (announced) — fall back to draft.
-    if not doc.get("status"):
-        doc["status"] = "draft"
-    doc["created_at"] = now_utc().isoformat()
-    doc["updated_at"] = now_utc().isoformat()
-    doc["created_by"] = me["id"]
-    await db.tournaments.insert_one(doc)
-    auto_preview = await _create_initial_bracket_preview(db, doc, me.get("id"))
-    doc.pop("_id", None)
-    doc["auto_generated_bracket"] = auto_preview
-    return doc
+    canonical_body = body.model_dump(mode="json")
+    creation_digest = hashlib.sha256(
+        json.dumps(canonical_body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    creation_key = f"{me['id']}:{creation_digest}"
+    try:
+        async with mutation_lock(db, "tournament:create"):
+            existing = await db.tournaments.find_one({"creation_key": creation_key}, {"_id": 0})
+            if existing:
+                existing.pop("creation_key", None)
+                return {**existing, "auto_generated_bracket": None, "idempotent_replay": True}
+            # Validate game
+            if not await db.games.find_one({"id": body.game_id}):
+                raise HTTPException(status_code=400, detail="Spiel nicht gefunden")
+            doc = body.model_dump()
+            doc["creation_key"] = creation_key
+            doc["slug"] = await unique_slug(db.tournaments, doc.get("slug") or doc.get("title"), fallback="turnier")
+            doc["format_label"] = (doc.get("format_label") or "").strip() or None
+            if doc.get("format") != "single_elim":
+                doc["bronze_match"] = False
+            # ISO-serialize datetimes
+            for k in ["registration_open_from", "registration_open_until", "check_in_from",
+                      "check_in_until", "start_date", "end_date"]:
+                doc[k] = _iso(doc.get(k))
+            doc["id"] = new_id()
+            # Allow scheduling directly (announced) — fall back to draft.
+            if not doc.get("status"):
+                doc["status"] = "draft"
+            doc["created_at"] = now_utc().isoformat()
+            doc["updated_at"] = now_utc().isoformat()
+            doc["created_by"] = me["id"]
+            try:
+                await db.tournaments.insert_one(doc)
+            except DuplicateKeyError:
+                existing = await db.tournaments.find_one({"creation_key": creation_key}, {"_id": 0})
+                if not existing:
+                    raise HTTPException(status_code=409, detail="Turnier konnte wegen einer parallelen Erstellung nicht angelegt werden")
+                existing.pop("creation_key", None)
+                return {**existing, "auto_generated_bracket": None, "idempotent_replay": True}
+            auto_preview = await _create_initial_bracket_preview(db, doc, me.get("id"))
+            doc.pop("_id", None)
+            doc.pop("creation_key", None)
+            doc["auto_generated_bracket"] = auto_preview
+            doc["idempotent_replay"] = False
+            return doc
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turniererstellung wird bereits verarbeitet. Bitte erneut versuchen.")
 
 
 @router.put("/{tid}")
 @router.patch("/{tid}")
-async def update_tournament(tid: str, body: TournamentUpdate, me: dict = Depends(require_admin())):
+async def update_tournament(tid: str, body: TournamentUpdate, me: dict = Depends(require_admin()),
+                            _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     if body.game_id and not await db.games.find_one({"id": body.game_id}, {"id": 1}):
@@ -1708,14 +1748,20 @@ async def update_tournament(tid: str, body: TournamentUpdate, me: dict = Depends
     updates["updated_at"] = now_utc().isoformat()
     await db.tournaments.update_one({"id": tid}, {"$set": updates})
     t = await db.tournaments.find_one({"id": tid}, {"_id": 0})
+    t.pop("creation_key", None)
     return t
 
 
 @router.post("/{tid}/lock")
-async def lock_tournament(tid: str, me: dict = Depends(require_admin())):
+async def lock_tournament(tid: str, me: dict = Depends(require_admin()),
+                          _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
-    tournament = await _ensure_tournament_unlocked(db, tid)
+    tournament = await db.tournaments.find_one({"id": tid}, {"_id": 0})
+    if not tournament:
+        raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
+    if tournament.get("locked_at"):
+        return {"ok": True, "locked_at": tournament["locked_at"], "idempotent_replay": True}
     if tournament.get("status") not in LOCKABLE_TOURNAMENT_STATUSES:
         raise HTTPException(status_code=400, detail="Nur beendete, veröffentlichte, archivierte oder abgesagte Turniere können gesperrt werden.")
     now = now_utc().isoformat()
@@ -1724,27 +1770,31 @@ async def lock_tournament(tid: str, me: dict = Depends(require_admin())):
         {"$set": {"locked_at": now, "locked_by": me.get("id"), "updated_at": now}},
     )
     await _audit_tournament_action(db, "tournament.lock", me.get("id"), tid, {"status": tournament.get("status")})
-    return {"ok": True, "locked_at": now}
+    return {"ok": True, "locked_at": now, "idempotent_replay": False}
 
 
 @router.post("/{tid}/unlock")
-async def unlock_tournament(tid: str, me: dict = Depends(require_admin())):
+async def unlock_tournament(tid: str, me: dict = Depends(require_admin()),
+                            _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     tournament = await db.tournaments.find_one({"id": tid}, {"_id": 0})
     if not tournament:
         raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
+    if not tournament.get("locked_at"):
+        return {"ok": True, "idempotent_replay": True}
     now = now_utc().isoformat()
     await db.tournaments.update_one(
         {"id": tid},
         {"$unset": {"locked_at": "", "locked_by": ""}, "$set": {"updated_at": now}},
     )
     await _audit_tournament_action(db, "tournament.unlock", me.get("id"), tid, {"previous_locked_at": tournament.get("locked_at")})
-    return {"ok": True}
+    return {"ok": True, "idempotent_replay": False}
 
 
 @router.delete("/{tid}")
-async def delete_tournament(tid: str, me: dict = Depends(require_admin())):
+async def delete_tournament(tid: str, me: dict = Depends(require_admin()),
+                            _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     v2_match_ids = await db.matches_v2.distinct("id", {"tournament_id": tid})
@@ -1828,6 +1878,94 @@ async def list_assignable_tournament_users(tid: str, q: str | None = None, limit
     return users
 
 
+async def _create_self_registration(db, tid: str, tournament: dict, body: RegistrationCreate,
+                                    me: dict, register_access: dict | None) -> dict:
+    existing = await db.tournament_registrations.find_one(
+        {"tournament_id": tid, "user_id": me["id"]},
+        {"_id": 0},
+    )
+    if existing:
+        existing.pop("identity_key", None)
+        return {**existing, "auto_bracket_update": None, "idempotent_replay": True}
+    team = await _validate_registration_actor(db, tournament, body, me)
+    if team:
+        existing_team = await db.tournament_registrations.find_one(
+            {"tournament_id": tid, "team_id": team["id"]},
+            {"_id": 0},
+        )
+        if existing_team:
+            existing_team.pop("identity_key", None)
+            return {**existing_team, "auto_bracket_update": None, "idempotent_replay": True}
+    game = await db.games.find_one({"id": tournament.get("game_id")}, {"_id": 0}) if tournament.get("game_id") else None
+    game = await _enrich_game_identity(db, game)
+    submitted_ids = body.player_ids or {}
+    profile_ids = me.get("game_ids") or {}
+    source_slug = game.get("identity_game_slug") if game else None
+    profile_source_ids = (profile_ids.get(source_slug) if source_slug else {}) or {}
+    profile_game_ids = (profile_ids.get(game.get("slug")) if game else {}) or {}
+    player_ids = {**profile_source_ids, **profile_game_ids, **submitted_ids}
+    missing = [
+        field.get("label") or field.get("key")
+        for field in _required_game_fields(game)
+        if not str(player_ids.get(field.get("key"), "")).strip()
+    ]
+    if missing:
+        raise HTTPException(status_code=400, detail=f"Für dieses Turnier fehlen Pflicht-IDs: {', '.join(missing)}")
+    # Count approved
+    count = await db.tournament_registrations.count_documents(
+        {"tournament_id": tid, "status": {"$in": ["pending", "approved", "checked_in"]}})
+    reg = {
+        "id": new_id(),
+        "identity_key": f"{tid}:team:{team['id']}" if team else f"{tid}:user:{me['id']}",
+        "tournament_id": tid,
+        "user_id": me["id"],
+        "team_id": team.get("id") if team else None,
+        "status": "approved",  # auto-approve by default; admin can flip to manual flow
+        "ingame_name": body.ingame_name or (team.get("name") if team else None) or me.get("display_name") or me.get("username"),
+        "discord": body.discord or me.get("discord_name"),
+        "platform_id": body.platform_id,
+        "player_ids": player_ids,
+        "notes": body.notes,
+        "accepted_rules": body.accept_rules,
+        "accepted_privacy": body.accept_privacy,
+        "seed": None,
+        "display_name": (f"[{team.get('tag')}] {team.get('name')}" if team and team.get("tag") else (team.get("name") if team else None)) or me.get("display_name") or me.get("username"),
+        "registration_type": "team" if team else "solo",
+        "registered_by": me["id"],
+        "created_at": now_utc().isoformat(),
+        "updated_at": now_utc().isoformat(),
+    }
+    if count >= tournament.get("max_participants", 32):
+        reg["status"] = "waitlist"
+    try:
+        await db.tournament_registrations.insert_one(reg)
+    except DuplicateKeyError:
+        existing = await db.tournament_registrations.find_one(
+            {"identity_key": reg["identity_key"]},
+            {"_id": 0},
+        )
+        if existing:
+            existing.pop("identity_key", None)
+            return {**existing, "auto_bracket_update": None, "idempotent_replay": True}
+        raise
+    auto_bracket_update = None
+    if reg["status"] in {"approved", "checked_in"}:
+        auto_bracket_update = await _refresh_tournament_previews_after_registration(db, tournament, me.get("id"))
+    reg.pop("_id", None)
+    reg.pop("identity_key", None)
+    reg["auto_bracket_update"] = auto_bracket_update
+    reg["idempotent_replay"] = False
+    # Badge trigger
+    try:
+        from badges import on_tournament_registered
+        await on_tournament_registered(me["id"], tid)
+    except Exception:
+        pass
+    if register_access:
+        await record_access_link_use(db, register_access, me)
+    return reg
+
+
 @router.post("/{tid}/register")
 async def register_for_tournament(tid: str, body: RegistrationCreate,
                                    access: str | None = None,
@@ -1853,73 +1991,25 @@ async def register_for_tournament(tid: str, body: RegistrationCreate,
         raise HTTPException(status_code=400, detail=registration_error)
     if t.get("block_club_member_registration") and await _is_active_club_member(db, me):
         raise HTTPException(status_code=403, detail="Dieses Turnier ist für externe Teilnehmer vorgesehen. Vereinsmitglieder können sich hier nicht selbst anmelden.")
-    existing = await db.tournament_registrations.find_one({"tournament_id": tid, "user_id": me["id"]})
-    if existing:
-        raise HTTPException(status_code=409, detail="Bereits angemeldet")
-    team = await _validate_registration_actor(db, t, body, me)
-    game = await db.games.find_one({"id": t.get("game_id")}, {"_id": 0}) if t.get("game_id") else None
-    game = await _enrich_game_identity(db, game)
-    submitted_ids = body.player_ids or {}
-    profile_ids = me.get("game_ids") or {}
-    source_slug = game.get("identity_game_slug") if game else None
-    profile_source_ids = (profile_ids.get(source_slug) if source_slug else {}) or {}
-    profile_game_ids = (profile_ids.get(game.get("slug")) if game else {}) or {}
-    player_ids = {**profile_source_ids, **profile_game_ids, **submitted_ids}
-    missing = [
-        field.get("label") or field.get("key")
-        for field in _required_game_fields(game)
-        if not str(player_ids.get(field.get("key"), "")).strip()
-    ]
-    if missing:
-        raise HTTPException(status_code=400, detail=f"Für dieses Turnier fehlen Pflicht-IDs: {', '.join(missing)}")
-    # Count approved
-    count = await db.tournament_registrations.count_documents(
-        {"tournament_id": tid, "status": {"$in": ["pending", "approved", "checked_in"]}})
-    status = "pending" if count >= t.get("max_participants", 32) else "approved"
-    if status == "pending" and count >= t.get("max_participants", 32):
-        status = "waitlist"
-    reg = {
-        "id": new_id(),
-        "tournament_id": tid,
-        "user_id": me["id"],
-        "team_id": team.get("id") if team else None,
-        "status": "approved",  # auto-approve by default; admin can flip to manual flow
-        "ingame_name": body.ingame_name or (team.get("name") if team else None) or me.get("display_name") or me.get("username"),
-        "discord": body.discord or me.get("discord_name"),
-        "platform_id": body.platform_id,
-        "player_ids": player_ids,
-        "notes": body.notes,
-        "accepted_rules": body.accept_rules,
-        "accepted_privacy": body.accept_privacy,
-        "seed": None,
-        "display_name": (f"[{team.get('tag')}] {team.get('name')}" if team and team.get("tag") else (team.get("name") if team else None)) or me.get("display_name") or me.get("username"),
-        "registration_type": "team" if team else "solo",
-        "registered_by": me["id"],
-        "created_at": now_utc().isoformat(),
-        "updated_at": now_utc().isoformat(),
-    }
-    if count >= t.get("max_participants", 32):
-        reg["status"] = "waitlist"
-    await db.tournament_registrations.insert_one(reg)
-    auto_bracket_update = None
-    if reg["status"] in {"approved", "checked_in"}:
-        auto_bracket_update = await _refresh_tournament_previews_after_registration(db, t, me.get("id"))
-    reg.pop("_id", None)
-    reg["auto_bracket_update"] = auto_bracket_update
-    # Badge trigger
     try:
-        from badges import on_tournament_registered
-        await on_tournament_registered(me["id"], tid)
-    except Exception:
-        pass
-    if register_access:
-        await record_access_link_use(db, register_access, me)
-    return reg
+        async with mutation_lock(db, tournament_write_resource(tid)):
+            current = await db.tournaments.find_one({"id": tid}, {"_id": 0})
+            if not current:
+                raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
+            if _is_tournament_locked(current):
+                raise HTTPException(status_code=423, detail=TOURNAMENT_MUTATION_LOCKED_DETAIL)
+            current_error = _registration_error(current)
+            if current_error and not register_access:
+                raise HTTPException(status_code=400, detail=current_error)
+            return await _create_self_registration(db, tid, current, body, me, register_access)
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
 
 
 @router.post("/{tid}/registrations")
 async def admin_create_registration(tid: str, body: RegistrationAdminCreate,
-                                    me: dict = Depends(get_current_user)):
+                                    me: dict = Depends(get_current_user),
+                                    _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     tournament = await _ensure_tournament_unlocked(db, tid)
@@ -1931,17 +2021,33 @@ async def admin_create_registration(tid: str, body: RegistrationAdminCreate,
         user = await db.users.find_one({"id": payload["user_id"]}, {"_id": 0, "password_hash": 0})
         if not user:
             raise HTTPException(status_code=404, detail="Nutzer nicht gefunden")
-        existing = await db.tournament_registrations.find_one({"tournament_id": tid, "user_id": payload["user_id"]}, {"id": 1})
+        existing = await db.tournament_registrations.find_one(
+            {"tournament_id": tid, "user_id": payload["user_id"]},
+            {"_id": 0, "identity_key": 0},
+        )
         if existing:
-            raise HTTPException(status_code=409, detail="Dieser Nutzer ist bereits angemeldet")
+            return {
+                "registration": existing,
+                "replacement": None,
+                "auto_bracket_update": None,
+                "idempotent_replay": True,
+            }
     team = None
     if payload.get("team_id"):
         team = await db.teams.find_one({"id": payload["team_id"]}, {"_id": 0})
         if not team:
             raise HTTPException(status_code=404, detail="Team nicht gefunden")
-        existing_team = await db.tournament_registrations.find_one({"tournament_id": tid, "team_id": payload["team_id"]}, {"id": 1})
+        existing_team = await db.tournament_registrations.find_one(
+            {"tournament_id": tid, "team_id": payload["team_id"]},
+            {"_id": 0, "identity_key": 0},
+        )
         if existing_team:
-            raise HTTPException(status_code=409, detail="Dieses Team ist bereits angemeldet")
+            return {
+                "registration": existing_team,
+                "replacement": None,
+                "auto_bracket_update": None,
+                "idempotent_replay": True,
+            }
     if _is_team_tournament(tournament) and not team:
         raise HTTPException(status_code=400, detail="Dieses Turnier erwartet eine Team-Anmeldung")
     if not _is_team_tournament(tournament) and team:
@@ -2000,7 +2106,14 @@ async def admin_create_registration(tid: str, body: RegistrationAdminCreate,
         "created_at": now_utc().isoformat(),
         "updated_at": now_utc().isoformat(),
     }
-    await db.tournament_registrations.insert_one(reg)
+    if reg.get("team_id"):
+        reg["identity_key"] = f"{tid}:team:{reg['team_id']}"
+    elif reg.get("user_id"):
+        reg["identity_key"] = f"{tid}:user:{reg['user_id']}"
+    try:
+        await db.tournament_registrations.insert_one(reg)
+    except DuplicateKeyError:
+        raise HTTPException(status_code=409, detail="Dieser Nutzer oder dieses Team ist bereits angemeldet")
 
     replacement = None
     if old_reg_id:
@@ -2021,28 +2134,38 @@ async def admin_create_registration(tid: str, body: RegistrationAdminCreate,
         {"registration_id": reg["id"], "user_id": reg.get("user_id"), "is_guest": reg["is_guest"], "replace_registration_id": old_reg_id},
     )
     reg.pop("_id", None)
-    return {"registration": reg, "replacement": replacement, "auto_bracket_update": auto_bracket_update}
+    reg.pop("identity_key", None)
+    return {
+        "registration": reg,
+        "replacement": replacement,
+        "auto_bracket_update": auto_bracket_update,
+        "idempotent_replay": False,
+    }
 
 
 @router.put("/{tid}/registrations/{reg_id}")
 @router.patch("/{tid}/registrations/{reg_id}")
 async def update_registration(tid: str, reg_id: str, body: RegistrationUpdate,
-                               me: dict = Depends(get_current_user)):
+                               me: dict = Depends(get_current_user),
+                               _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
     await require_tournament_staff_permission(me, tid, PARTICIPANT_STAFF_ROLES)
     updates = {k: v for k, v in body.model_dump(exclude_unset=True).items() if v is not None}
-    updates["updated_at"] = now_utc().isoformat()
-    await db.tournament_registrations.update_one({"id": reg_id, "tournament_id": tid}, {"$set": updates})
     reg = await db.tournament_registrations.find_one({"id": reg_id, "tournament_id": tid}, {"_id": 0})
     if not reg:
         raise HTTPException(status_code=404, detail="Anmeldung nicht gefunden")
+    if updates and all(reg.get(key) == value for key, value in updates.items()):
+        return {**reg, "idempotent_replay": True}
+    updates["updated_at"] = now_utc().isoformat()
+    await db.tournament_registrations.update_one({"id": reg_id, "tournament_id": tid}, {"$set": updates})
+    reg = await db.tournament_registrations.find_one({"id": reg_id, "tournament_id": tid}, {"_id": 0})
     if updates.get("status") in {"approved", "checked_in", "rejected", "waitlist", "no_show"}:
         tournament = await db.tournaments.find_one({"id": tid}, {"_id": 0})
         if tournament:
             reg["auto_bracket_update"] = await _refresh_tournament_previews_after_registration(db, tournament, me.get("id"))
-    return reg
+    return {**reg, "idempotent_replay": False}
 
 
 @router.post("/{tid}/registrations/{reg_id}/checkin")
@@ -2058,35 +2181,42 @@ async def staff_set_registration_checkin(tid: str, reg_id: str, body: dict,
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
     await require_tournament_staff_permission(me, tid, CHECKIN_STAFF_ROLES)
-    reg = await db.tournament_registrations.find_one({"id": reg_id, "tournament_id": tid}, {"_id": 0})
-    if not reg:
-        raise HTTPException(status_code=404, detail="Anmeldung nicht gefunden")
     status = body.get("status")
     if status not in REGISTRATION_CHECKIN_STATUSES:
         raise HTTPException(status_code=400, detail="Ungültiger Check-in-Status")
-    if reg.get("status") in ("rejected", "waitlist") and status == "checked_in":
-        raise HTTPException(status_code=400, detail="Diese Anmeldung kann nicht eingecheckt werden")
+    try:
+        async with mutation_lock(db, tournament_write_resource(tid)):
+            reg = await db.tournament_registrations.find_one({"id": reg_id, "tournament_id": tid}, {"_id": 0})
+            if not reg:
+                raise HTTPException(status_code=404, detail="Anmeldung nicht gefunden")
+            if reg.get("status") == status:
+                return {**reg, "idempotent_replay": True}
+            if reg.get("status") in ("rejected", "waitlist") and status == "checked_in":
+                raise HTTPException(status_code=400, detail="Diese Anmeldung kann nicht eingecheckt werden")
 
-    await db.tournament_registrations.update_one(
-        {"id": reg_id},
-        {"$set": {"status": status, "updated_at": now_utc().isoformat()}},
-    )
-    if status == "checked_in" and reg.get("user_id"):
-        await _apply_late_checkin_hooks(db, tid, reg["user_id"])
-        await _apply_checked_in_badges(reg["user_id"], tid)
-    await _audit_tournament_action(
-        db,
-        "tournament.registration.checkin_status",
-        me.get("id"),
-        tid,
-        {"registration_id": reg_id, "from_status": reg.get("status"), "to_status": status},
-    )
-    updated = await db.tournament_registrations.find_one({"id": reg_id}, {"_id": 0})
-    return updated
+            await db.tournament_registrations.update_one(
+                {"id": reg_id},
+                {"$set": {"status": status, "updated_at": now_utc().isoformat()}},
+            )
+            if status == "checked_in" and reg.get("user_id"):
+                await _apply_late_checkin_hooks(db, tid, reg["user_id"])
+                await _apply_checked_in_badges(reg["user_id"], tid)
+            await _audit_tournament_action(
+                db,
+                "tournament.registration.checkin_status",
+                me.get("id"),
+                tid,
+                {"registration_id": reg_id, "from_status": reg.get("status"), "to_status": status},
+            )
+            updated = await db.tournament_registrations.find_one({"id": reg_id}, {"_id": 0})
+            return {**updated, "idempotent_replay": False}
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
 
 
 @router.delete("/{tid}/registrations/{reg_id}")
-async def delete_registration(tid: str, reg_id: str, me: dict = Depends(get_current_user)):
+async def delete_registration(tid: str, reg_id: str, me: dict = Depends(get_current_user),
+                              _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
@@ -2180,7 +2310,8 @@ async def list_tournament_staff(tid: str, me: dict = Depends(get_current_user)):
 
 @router.post("/{tid}/staff")
 async def create_tournament_staff(tid: str, body: TournamentStaffAssignmentCreate,
-                                  me: dict = Depends(require_admin())):
+                                  me: dict = Depends(require_admin()),
+                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     if not await db.users.find_one({"id": body.user_id}, {"id": 1}):
@@ -2195,7 +2326,9 @@ async def create_tournament_staff(tid: str, body: TournamentStaffAssignmentCreat
         "scope_id": scope_id,
     })
     if existing:
-        raise HTTPException(status_code=409, detail="Diese Zuweisung existiert bereits")
+        existing.pop("_id", None)
+        enriched = (await _enrich_staff_assignments([existing]))[0]
+        return {**enriched, "idempotent_replay": True}
     doc = _normalize_team_settings(body.model_dump())
     doc["id"] = new_id()
     doc["tournament_id"] = tid
@@ -2213,13 +2346,15 @@ async def create_tournament_staff(tid: str, body: TournamentStaffAssignmentCreat
         {"assignment_id": doc["id"], "user_id": doc["user_id"], "role": doc["role"], "scope": doc["scope"], "scope_id": doc.get("scope_id")},
     )
     doc.pop("_id", None)
-    return (await _enrich_staff_assignments([doc]))[0]
+    enriched = (await _enrich_staff_assignments([doc]))[0]
+    return {**enriched, "idempotent_replay": False}
 
 
 @router.patch("/{tid}/staff/{assignment_id}")
 @router.put("/{tid}/staff/{assignment_id}")
 async def update_tournament_staff(tid: str, assignment_id: str, body: TournamentStaffAssignmentUpdate,
-                                  me: dict = Depends(require_admin())):
+                                  me: dict = Depends(require_admin()),
+                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     current = await db.tournament_staff_assignments.find_one({"id": assignment_id, "tournament_id": tid}, {"_id": 0})
@@ -2254,7 +2389,8 @@ async def update_tournament_staff(tid: str, assignment_id: str, body: Tournament
 
 
 @router.delete("/{tid}/staff/{assignment_id}")
-async def delete_tournament_staff(tid: str, assignment_id: str, me: dict = Depends(require_admin())):
+async def delete_tournament_staff(tid: str, assignment_id: str, me: dict = Depends(require_admin()),
+                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     current = await db.tournament_staff_assignments.find_one({"id": assignment_id, "tournament_id": tid}, {"_id": 0})
@@ -2281,17 +2417,28 @@ async def list_tournament_stages(tid: str, user=Depends(get_optional_user)):
         {"tournament_id": tid},
         {"_id": 0},
     ).sort("number", 1).to_list(200)
+    for stage in stages:
+        stage.pop("creation_key", None)
     return stages
 
 
 @router.post("/{tid}/stages")
 async def create_tournament_stage(tid: str, body: TournamentStageCreate,
-                                  me: dict = Depends(get_current_user)):
+                                  me: dict = Depends(get_current_user),
+                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
     await require_tournament_staff_permission(me, tid, STRUCTURE_STAFF_ROLES)
     doc = body.model_dump()
+    creation_digest = hashlib.sha256(
+        json.dumps(body.model_dump(mode="json"), sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    creation_key = f"{tid}:{me['id']}:{creation_digest}"
+    existing_creation = await db.tournament_stages.find_one({"creation_key": creation_key}, {"_id": 0})
+    if existing_creation:
+        existing_creation.pop("creation_key", None)
+        return {**existing_creation, "idempotent_replay": True}
     if doc.get("number") is None:
         last = await db.tournament_stages.find(
             {"tournament_id": tid},
@@ -2305,6 +2452,7 @@ async def create_tournament_stage(tid: str, body: TournamentStageCreate,
     if duplicate:
         raise HTTPException(status_code=409, detail="Stage-Nummer existiert bereits")
     doc["id"] = new_id()
+    doc["creation_key"] = creation_key
     doc["tournament_id"] = tid
     doc["created_at"] = now_utc().isoformat()
     doc["updated_at"] = doc["created_at"]
@@ -2318,13 +2466,15 @@ async def create_tournament_stage(tid: str, body: TournamentStageCreate,
         {"stage_id": doc["id"], "stage_type": doc["stage_type"], "match_type": doc["match_type"]},
     )
     doc.pop("_id", None)
-    return doc
+    doc.pop("creation_key", None)
+    return {**doc, "idempotent_replay": False}
 
 
 @router.patch("/{tid}/stages/{stage_id}")
 @router.put("/{tid}/stages/{stage_id}")
 async def update_tournament_stage(tid: str, stage_id: str, body: TournamentStageUpdate,
-                                  me: dict = Depends(get_current_user)):
+                                  me: dict = Depends(get_current_user),
+                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
@@ -2350,11 +2500,13 @@ async def update_tournament_stage(tid: str, stage_id: str, body: TournamentStage
         {"stage_id": stage_id, "updates": {k: v for k, v in updates.items() if k != "updated_at"}},
     )
     updated = await db.tournament_stages.find_one({"id": stage_id}, {"_id": 0})
+    updated.pop("creation_key", None)
     return updated
 
 
 @router.delete("/{tid}/stages/{stage_id}")
-async def delete_tournament_stage(tid: str, stage_id: str, me: dict = Depends(get_current_user)):
+async def delete_tournament_stage(tid: str, stage_id: str, me: dict = Depends(get_current_user),
+                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
@@ -2392,7 +2544,8 @@ async def list_tournament_matches_v2(tid: str, stage_id: str | None = None,
 
 @router.post("/{tid}/matches-v2/recalculate-advancement")
 async def recalculate_tournament_matches_v2_advancement(tid: str, stage_id: str | None = None,
-                                                        me: dict = Depends(get_current_user)):
+                                                        me: dict = Depends(get_current_user),
+                                                        _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await require_tournament_staff_permission(me, tid, RESULT_STAFF_ROLES)
@@ -2466,7 +2619,8 @@ async def recalculate_tournament_matches_v2_advancement(tid: str, stage_id: str 
 @router.post("/{tid}/stages/{stage_id}/generate")
 async def generate_tournament_stage_matches(tid: str, stage_id: str, force: bool = False,
                                             preview: bool = False,
-                                            me: dict = Depends(get_current_user)):
+                                            me: dict = Depends(get_current_user),
+                                            _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
@@ -2527,25 +2681,19 @@ async def generate_tournament_stage_matches(tid: str, stage_id: str, force: bool
     return {"ok": True, "stage_id": stage_id, "match_count": len(matches), "preview": preview}
 
 
-@router.post("/{tid}/checkin")
-async def checkin_self(tid: str, me: dict = Depends(get_current_user)):
-    db = get_db()
-    tid = await _resolve_tid(tid)
-    tournament = await _ensure_tournament_unlocked(db, tid)
-    if (tournament.get("event_mode") or "online") == "local":
-        raise HTTPException(status_code=403, detail="Bei Vor-Ort-Turnieren macht die Turnierleitung den Check-in.")
-    reg = await db.tournament_registrations.find_one({"tournament_id": tid, "user_id": me["id"]})
+async def _find_self_registration(db, tid: str, user_id: str) -> dict | None:
+    reg = await db.tournament_registrations.find_one({"tournament_id": tid, "user_id": user_id})
     if not reg:
         team_ids = [
             row.get("team_id")
-            for row in await db.team_members.find({"user_id": me["id"]}, {"_id": 0, "team_id": 1}).to_list(100)
+            for row in await db.team_members.find({"user_id": user_id}, {"_id": 0, "team_id": 1}).to_list(100)
             if row.get("team_id")
         ]
         if team_ids:
             teams = await db.teams.find(
                 {
                     "id": {"$in": team_ids},
-                    "$or": [{"leader_id": me["id"]}, {"co_leader_ids": me["id"]}],
+                    "$or": [{"leader_id": user_id}, {"co_leader_ids": user_id}],
                 },
                 {"_id": 0, "id": 1},
             ).to_list(100)
@@ -2555,29 +2703,47 @@ async def checkin_self(tid: str, me: dict = Depends(get_current_user)):
                     "tournament_id": tid,
                     "team_id": {"$in": manageable_team_ids},
                 })
-    if not reg:
-        raise HTTPException(status_code=404, detail="Keine Anmeldung gefunden")
-    if reg["status"] not in ("approved", "checked_in"):
-        raise HTTPException(status_code=400, detail="Nicht check-in-fähig")
-    await db.tournament_registrations.update_one(
-        {"id": reg["id"]}, {"$set": {"status": "checked_in", "updated_at": now_utc().isoformat()}})
-    # Phase B v4.1: late check-in detection (check-in after start_date) → neg_late_checkin
-    await _apply_late_checkin_hooks(db, tid, me["id"])
-    await _apply_checked_in_badges(me["id"], tid)
-    await _audit_tournament_action(
-        db,
-        "tournament.registration.self_checkin",
-        me.get("id"),
-        tid,
-        {"registration_id": reg["id"], "from_status": reg.get("status"), "to_status": "checked_in"},
-    )
-    return {"ok": True}
+    return reg
+
+
+@router.post("/{tid}/checkin")
+async def checkin_self(tid: str, me: dict = Depends(get_current_user)):
+    db = get_db()
+    tid = await _resolve_tid(tid)
+    tournament = await _ensure_tournament_unlocked(db, tid)
+    if (tournament.get("event_mode") or "online") == "local":
+        raise HTTPException(status_code=403, detail="Bei Vor-Ort-Turnieren macht die Turnierleitung den Check-in.")
+    try:
+        async with mutation_lock(db, tournament_write_resource(tid)):
+            reg = await _find_self_registration(db, tid, me["id"])
+            if not reg:
+                raise HTTPException(status_code=404, detail="Keine Anmeldung gefunden")
+            if reg["status"] == "checked_in":
+                return {"ok": True, "idempotent_replay": True}
+            if reg["status"] != "approved":
+                raise HTTPException(status_code=400, detail="Nicht check-in-fähig")
+            await db.tournament_registrations.update_one(
+                {"id": reg["id"]}, {"$set": {"status": "checked_in", "updated_at": now_utc().isoformat()}})
+            # Phase B v4.1: late check-in detection (check-in after start_date) → neg_late_checkin
+            await _apply_late_checkin_hooks(db, tid, me["id"])
+            await _apply_checked_in_badges(me["id"], tid)
+            await _audit_tournament_action(
+                db,
+                "tournament.registration.self_checkin",
+                me.get("id"),
+                tid,
+                {"registration_id": reg["id"], "from_status": reg.get("status"), "to_status": "checked_in"},
+            )
+            return {"ok": True, "idempotent_replay": False}
+    except MutationLockBusy:
+        raise HTTPException(status_code=409, detail="Eine Turnieraktion wird bereits verarbeitet. Bitte erneut versuchen.")
 
 
 # --- Bracket generation ---
 @router.post("/{tid}/generate-bracket")
 async def generate(tid: str, preview: bool = False, force: bool = False,
-                   me: dict = Depends(get_current_user)):
+                   me: dict = Depends(get_current_user),
+                   _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     t = await _ensure_tournament_unlocked(db, tid)
@@ -2588,7 +2754,8 @@ async def generate(tid: str, preview: bool = False, force: bool = False,
 @router.post("/{tid}/bracket/from-format")
 async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBracketStructurePayload | None = None,
                                                  preview: bool = True, force: bool = False,
-                                                 me: dict = Depends(get_current_user)):
+                                                 me: dict = Depends(get_current_user),
+                                                 _mutation_tid: str = Depends(_serialized_tournament_write)):
     """Use the tournament structure as the single source of truth and rebuild the bracket preview."""
     db = get_db()
     tid = await _resolve_tid(tid)
@@ -2687,7 +2854,8 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
 
 
 @router.post("/{tid}/reset-bracket")
-async def reset_bracket(tid: str, force: bool = False, me: dict = Depends(get_current_user)):
+async def reset_bracket(tid: str, force: bool = False, me: dict = Depends(get_current_user),
+                        _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     t = await _ensure_tournament_unlocked(db, tid)
@@ -2699,6 +2867,8 @@ async def reset_bracket(tid: str, force: bool = False, me: dict = Depends(get_cu
         )
     match_count = await db.matches.count_documents({"tournament_id": tid})
     v2_match_ids = await db.matches_v2.distinct("id", {"tournament_id": tid})
+    if match_count == 0 and not v2_match_ids and t.get("status") == "draft":
+        return {"ok": True, "idempotent_replay": True}
     await db.matches.delete_many({"tournament_id": tid})
     await db.matches_v2.delete_many({"tournament_id": tid})
     if v2_match_ids:
@@ -2711,11 +2881,12 @@ async def reset_bracket(tid: str, force: bool = False, me: dict = Depends(get_cu
         tid,
         {"previous_status": t.get("status"), "match_count": match_count, "v2_match_count": len(v2_match_ids), "force": force},
     )
-    return {"ok": True}
+    return {"ok": True, "idempotent_replay": False}
 
 
 @router.post("/{tid}/status")
-async def set_status(tid: str, body: dict, me: dict = Depends(get_current_user)):
+async def set_status(tid: str, body: dict, me: dict = Depends(get_current_user),
+                     _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     await _ensure_tournament_unlocked(db, tid)
@@ -2897,7 +3068,12 @@ async def set_status(tid: str, body: dict, me: dict = Depends(get_current_user))
             )
         except Exception:
             pass
-    return {"ok": True, "auto_generated_bracket": auto_generated_bracket, "planning": planning}
+    return {
+        "ok": True,
+        "auto_generated_bracket": auto_generated_bracket,
+        "planning": planning,
+        "idempotent_replay": prev == status,
+    }
 
 
 @router.get("/{tid}/planning-check")
@@ -3139,7 +3315,8 @@ async def standings(tid: str, access: str | None = None, user=Depends(get_option
 
 # ---------- Swiss / Groups specific ----------
 @router.post("/{tid}/swiss/next-round")
-async def swiss_next_round(tid: str, me: dict = Depends(require_admin())):
+async def swiss_next_round(tid: str, me: dict = Depends(require_admin()),
+                           _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     t = await db.tournaments.find_one({"id": tid})
@@ -3164,7 +3341,8 @@ async def swiss_next_round(tid: str, me: dict = Depends(require_admin())):
 
 
 @router.post("/{tid}/groups/generate")
-async def groups_generate(tid: str, body: dict, me: dict = Depends(require_admin())):
+async def groups_generate(tid: str, body: dict, me: dict = Depends(require_admin()),
+                          _mutation_tid: str = Depends(_serialized_tournament_write)):
     db = get_db()
     tid = await _resolve_tid(tid)
     t = await db.tournaments.find_one({"id": tid})

--- a/backend/services/match_notifications.py
+++ b/backend/services/match_notifications.py
@@ -81,6 +81,13 @@ async def notify_match_result_confirmed(db, match: dict, collection_name: str = 
         "collection": collection_name,
         "force": bool(force),
     }
+    result_token = (
+        (match.get("result_meta") or {}).get("report_id")
+        or match.get("admin_decision_at")
+        or match.get("updated_at")
+    )
+    if result_token:
+        meta["dedupe_key"] = f"match-result:{match.get('id')}:{result_token}"
     sent = 0
     for user_id in user_ids:
         await create_user_notification(

--- a/backend/services/match_v2_results.py
+++ b/backend/services/match_v2_results.py
@@ -179,6 +179,33 @@ def normalize_v2_results(match: dict, raw_results: list[dict]) -> list[dict]:
     return sorted(normalized, key=lambda item: item["rank"])
 
 
+def is_v2_result_replay(
+    match: dict,
+    raw_results: list[dict],
+    *,
+    proof_url: str | None = None,
+    note: str | None = None,
+) -> bool:
+    """Return whether a completed match already contains this exact result.
+
+    This comparison is intentionally independent of the actor and ``force``:
+    permissions are checked by the route first, while an exact retry must not
+    create another report, audit entry, notification, or advancement update.
+    """
+    if match.get("status") != "completed":
+        return False
+    try:
+        normalized = normalize_v2_results(match, raw_results)
+    except MatchV2ResultError:
+        return False
+    meta = match.get("result_meta") or {}
+    return (
+        normalized == (match.get("results") or [])
+        and ((proof_url or "").strip() or None) == meta.get("proof_url")
+        and ((note or "").strip() or None) == meta.get("note")
+    )
+
+
 def _target_lookup(stage_matches: list[dict]) -> tuple[dict[str, dict], dict[str, dict]]:
     by_id = {match["id"]: match for match in stage_matches if match.get("id")}
     by_key = {match["match_key"]: match for match in stage_matches if match.get("match_key")}

--- a/backend/services/mutation_lock.py
+++ b/backend/services/mutation_lock.py
@@ -8,7 +8,7 @@ always releases only the token owned by the current operation.
 from __future__ import annotations
 
 import asyncio
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from time import monotonic
 from uuid import uuid4
@@ -102,6 +102,5 @@ async def mutation_lock(
     finally:
         if renewal_task:
             renewal_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await renewal_task
+            await asyncio.gather(renewal_task, return_exceptions=True)
         await db.mutation_locks.delete_one({"resource": resource, "owner": owner})

--- a/backend/services/mutation_lock.py
+++ b/backend/services/mutation_lock.py
@@ -1,0 +1,107 @@
+"""Short MongoDB-backed leases for cross-worker write serialization.
+
+The API can run behind a reverse proxy with multiple workers, so an in-process
+``asyncio.Lock`` cannot protect multi-document tournament mutations.  This
+lease uses a unique MongoDB resource key, permits takeover after expiry, and
+always releases only the token owned by the current operation.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, suppress
+from datetime import datetime, timedelta, timezone
+from time import monotonic
+from uuid import uuid4
+
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+
+class MutationLockBusy(RuntimeError):
+    """Raised when another worker still owns the requested mutation lease."""
+
+
+def tournament_write_resource(tournament_id: str) -> str:
+    return f"tournament:{tournament_id}:write"
+
+
+@asynccontextmanager
+async def mutation_lock(
+    db,
+    resource: str,
+    *,
+    wait_seconds: float = 2.0,
+    lease_seconds: float = 30.0,
+    retry_seconds: float = 0.05,
+):
+    """Acquire a renewable-by-expiry MongoDB lease for one mutation resource.
+
+    Waiting briefly lets an immediate retry observe the first request's final
+    state and return an idempotent response.  The lease itself is deliberately
+    finite so a crashed worker cannot leave a permanent write lock behind.
+    """
+    if not resource or not resource.strip():
+        raise ValueError("resource must not be empty")
+    if lease_seconds <= 0:
+        raise ValueError("lease_seconds must be positive")
+
+    owner = str(uuid4())
+    deadline = monotonic() + max(0.0, wait_seconds)
+    acquired = False
+    renewal_task = None
+
+    while not acquired:
+        now = datetime.now(timezone.utc)
+        expires_at = now + timedelta(seconds=lease_seconds)
+        try:
+            document = await db.mutation_locks.find_one_and_update(
+                {
+                    "resource": resource,
+                    "$or": [
+                        {"expires_at": {"$lte": now}},
+                        {"owner": owner},
+                    ],
+                },
+                {
+                    "$set": {
+                        "resource": resource,
+                        "owner": owner,
+                        "acquired_at": now,
+                        "expires_at": expires_at,
+                    }
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+            acquired = bool(document and document.get("owner") == owner)
+        except DuplicateKeyError:
+            acquired = False
+
+        if acquired:
+            break
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise MutationLockBusy(resource)
+        await asyncio.sleep(min(max(0.001, retry_seconds), remaining))
+
+    try:
+        async def renew_lease():
+            interval = max(0.01, lease_seconds / 3)
+            while True:
+                await asyncio.sleep(interval)
+                renewed_at = datetime.now(timezone.utc)
+                result = await db.mutation_locks.update_one(
+                    {"resource": resource, "owner": owner},
+                    {"$set": {"expires_at": renewed_at + timedelta(seconds=lease_seconds)}},
+                )
+                if getattr(result, "matched_count", 0) != 1:
+                    return
+
+        renewal_task = asyncio.create_task(renew_lease())
+        yield owner
+    finally:
+        if renewal_task:
+            renewal_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await renewal_task
+        await db.mutation_locks.delete_one({"resource": resource, "owner": owner})

--- a/backend/services/v2_result_submission.py
+++ b/backend/services/v2_result_submission.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 
 from models import now_utc
 from services.match_notifications import notify_match_result_confirmed
 from services.match_v2_results import build_v2_result_application, is_v2_result_replay, normalize_v2_results
 from services.station_runtime import release_station_for_match
+
+
+logger = logging.getLogger("tls.match_results")
 
 
 def _submission_identity(
@@ -68,12 +72,20 @@ async def _upsert_result_audit(
 async def _finish_result_side_effects(db, match: dict, force: bool) -> None:
     try:
         await notify_match_result_confirmed(db, match, "matches_v2", force=force)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "Result notification failed for match=%s type=%s",
+            match.get("id"),
+            type(exc).__name__,
+        )
     try:
         await release_station_for_match(db, match, "matches_v2")
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "Station release failed for match=%s type=%s",
+            match.get("id"),
+            type(exc).__name__,
+        )
 
 
 async def submit_v2_result(

--- a/backend/services/v2_result_submission.py
+++ b/backend/services/v2_result_submission.py
@@ -1,0 +1,179 @@
+"""Single implementation for idempotent v2 match-result persistence."""
+from __future__ import annotations
+
+import hashlib
+import json
+
+from models import now_utc
+from services.match_notifications import notify_match_result_confirmed
+from services.match_v2_results import build_v2_result_application, is_v2_result_replay, normalize_v2_results
+from services.station_runtime import release_station_for_match
+
+
+def _submission_identity(
+    match: dict,
+    raw_results: list[dict],
+    proof_url: str | None,
+    note: str | None,
+    force: bool,
+) -> tuple[str, list[dict]]:
+    normalized = normalize_v2_results(match, raw_results)
+    parent_report_id = (match.get("result_meta") or {}).get("report_id")
+    payload = {
+        "match_id": match["id"],
+        "parent_report_id": parent_report_id,
+        "results": normalized,
+        "proof_url": (proof_url or "").strip() or None,
+        "note": (note or "").strip() or None,
+        "force": bool(force),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return f"v2-result-{digest}", normalized
+
+
+async def _upsert_result_audit(
+    db,
+    *,
+    audit_action: str,
+    match: dict,
+    actor_id: str,
+    report_id: str,
+    advanced_match_ids: list[str],
+    force: bool,
+    created_at: str,
+) -> None:
+    await db.audit_logs.update_one(
+        {"id": f"audit-{report_id}"},
+        {"$setOnInsert": {
+            "id": f"audit-{report_id}",
+            "action": audit_action,
+            "target_id": match["tournament_id"],
+            "actor_id": actor_id,
+            "data": {
+                "match_id": match["id"],
+                "stage_id": match["stage_id"],
+                "match_key": match.get("match_key"),
+                "advanced_matches": advanced_match_ids,
+                "force": force,
+                "report_id": report_id,
+            },
+            "created_at": created_at,
+        }},
+        upsert=True,
+    )
+
+
+async def _finish_result_side_effects(db, match: dict, force: bool) -> None:
+    try:
+        await notify_match_result_confirmed(db, match, "matches_v2", force=force)
+    except Exception:
+        pass
+    try:
+        await release_station_for_match(db, match, "matches_v2")
+    except Exception:
+        pass
+
+
+async def submit_v2_result(
+    db,
+    match: dict,
+    raw_results: list[dict],
+    *,
+    actor_id: str,
+    proof_url: str | None,
+    note: str | None,
+    force: bool,
+    audit_action: str,
+) -> dict:
+    """Persist one v2 result while the caller owns the tournament write lease."""
+    if is_v2_result_replay(match, raw_results, proof_url=proof_url, note=note):
+        meta = match.get("result_meta") or {}
+        report_id = meta.get("report_id")
+        advanced_match_ids = meta.get("advanced_match_ids") or []
+        if report_id:
+            await _upsert_result_audit(
+                db,
+                audit_action=audit_action,
+                match=match,
+                actor_id=match.get("completed_by") or actor_id,
+                report_id=report_id,
+                advanced_match_ids=advanced_match_ids,
+                force=bool(meta.get("force")),
+                created_at=meta.get("confirmed_at") or match.get("completed_at") or now_utc().isoformat(),
+            )
+            await _finish_result_side_effects(db, match, bool(meta.get("force")))
+        return {
+            "ok": True,
+            "match": match,
+            "advanced_match_ids": advanced_match_ids,
+            "report_id": report_id,
+            "idempotent_replay": True,
+        }
+
+    stage_matches = await db.matches_v2.find(
+        {"stage_id": match["stage_id"]},
+        {"_id": 0},
+    ).to_list(3000)
+    now_iso = now_utc().isoformat()
+    report_id, normalized_results = _submission_identity(match, raw_results, proof_url, note, force)
+    application = build_v2_result_application(
+        match,
+        stage_matches,
+        normalized_results,
+        actor_id=actor_id,
+        now_iso=now_iso,
+        proof_url=proof_url,
+        note=note,
+        force=force,
+    )
+    advanced_match_ids = list(application["target_sets"].keys())
+    application["match_set"]["result_meta"].update({
+        "report_id": report_id,
+        "advanced_match_ids": advanced_match_ids,
+    })
+
+    await db.match_reports_v2.update_one(
+        {"id": report_id},
+        {"$setOnInsert": {
+            "id": report_id,
+            "match_id": match["id"],
+            "tournament_id": match["tournament_id"],
+            "stage_id": match["stage_id"],
+            "reporter_user_id": actor_id,
+            "source": "staff",
+            "results": application["results"],
+            "proof_url": (proof_url or "").strip() or None,
+            "note": (note or "").strip() or None,
+            "force": force,
+            "created_at": now_iso,
+        }},
+        upsert=True,
+    )
+    # Downstream writes are safe to repeat.  Commit the source match last so a
+    # retry after interruption will resume rather than mistaking partial work
+    # for a completed replay.
+    for target_id, update in application["target_sets"].items():
+        await db.matches_v2.update_one({"id": target_id}, {"$set": update})
+    await db.matches_v2.update_one({"id": match["id"]}, {"$set": application["match_set"]})
+
+    await _upsert_result_audit(
+        db,
+        audit_action=audit_action,
+        match=match,
+        actor_id=actor_id,
+        report_id=report_id,
+        advanced_match_ids=advanced_match_ids,
+        force=force,
+        created_at=now_iso,
+    )
+    updated = await db.matches_v2.find_one({"id": match["id"]}, {"_id": 0})
+    await _finish_result_side_effects(db, updated, force)
+    return {
+        "ok": True,
+        "match": updated,
+        "advanced_match_ids": advanced_match_ids,
+        "report_id": report_id,
+        "idempotent_replay": False,
+    }

--- a/backend/tests/test_match_idempotency_unit.py
+++ b/backend/tests/test_match_idempotency_unit.py
@@ -1,0 +1,235 @@
+import asyncio
+from copy import deepcopy
+from datetime import datetime, timezone
+import pathlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from models import MatchDispute, MatchScheduleProposalCreate, MatchScoreReport, MatchUpdate, MatchV2Update
+import routes.match_routes as match_routes
+import routes.match_v2_routes as match_v2_routes
+
+
+class _MutableMatchCollection:
+    def __init__(self, document):
+        self.document = deepcopy(document)
+        self.update_count = 0
+
+    async def find_one(self, _query, _projection=None):
+        return deepcopy(self.document)
+
+    async def update_one(self, _query, update):
+        self.update_count += 1
+        self.document.update(deepcopy(update.get("$set") or {}))
+
+
+def test_dispute_exact_replay_skips_write_audit_and_badge(monkeypatch):
+    match = {
+        "id": "match-1",
+        "tournament_id": "t1",
+        "status": "disputed",
+        "disputes": [{"user_id": "user-1", "reason": "Falsches Ergebnis"}],
+    }
+    matches = _MutableMatchCollection(match)
+    db = SimpleNamespace(matches=matches)
+    audit = AsyncMock()
+
+    monkeypatch.setattr(match_routes, "get_db", lambda: db)
+    monkeypatch.setattr(match_routes, "_ensure_match_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(match_routes, "_user_registration_for_match", AsyncMock(return_value={"id": "reg-1"}))
+    monkeypatch.setattr(match_routes, "_audit_match_action", audit)
+
+    result = asyncio.run(match_routes.dispute(
+        "match-1",
+        MatchDispute(reason="  Falsches Ergebnis  "),
+        {"id": "user-1", "role": "player"},
+    ))
+
+    assert result["idempotent_replay"] is True
+    assert matches.update_count == 0
+    audit.assert_not_awaited()
+
+
+def test_forfeit_exact_replay_skips_advancement_and_notifications(monkeypatch):
+    match = {
+        "id": "match-1",
+        "tournament_id": "t1",
+        "participant_a_id": "reg-a",
+        "participant_b_id": "reg-b",
+        "winner_id": "reg-a",
+        "loser_id": "reg-b",
+        "status": "forfeit",
+        "admin_decision_note": "Nicht erschienen",
+    }
+    matches = _MutableMatchCollection(match)
+    db = SimpleNamespace(matches=matches)
+    advance = Mock(side_effect=AssertionError("replay must not advance again"))
+    notify = AsyncMock()
+
+    monkeypatch.setattr(match_routes, "get_db", lambda: db)
+    monkeypatch.setattr(match_routes, "_ensure_match_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(match_routes, "ensure_tournament_accepts_results", AsyncMock())
+    monkeypatch.setattr(match_routes, "_require_result_permission", AsyncMock())
+    monkeypatch.setattr(match_routes, "advance_match_winner", advance)
+    monkeypatch.setattr(match_routes, "notify_match_result_confirmed", notify)
+
+    result = asyncio.run(match_routes.forfeit(
+        "match-1",
+        {"winner_id": "reg-a", "note": " Nicht erschienen "},
+        {"id": "admin-1", "role": "tournament_admin"},
+    ))
+
+    assert result["idempotent_replay"] is True
+    assert matches.update_count == 0
+    advance.assert_not_called()
+    notify.assert_not_awaited()
+
+
+def test_non_result_update_on_completed_match_does_not_repeat_completion_hooks(monkeypatch):
+    match = {
+        "id": "match-1",
+        "tournament_id": "t1",
+        "participant_a_id": "reg-a",
+        "participant_b_id": "reg-b",
+        "winner_id": "reg-a",
+        "loser_id": "reg-b",
+        "score_a": 2,
+        "score_b": 0,
+        "status": "completed",
+        "admin_note": None,
+    }
+    matches = _MutableMatchCollection(match)
+    db = SimpleNamespace(matches=matches)
+    advance = Mock(side_effect=AssertionError("non-result update must not advance again"))
+    audit = AsyncMock()
+
+    monkeypatch.setattr(match_routes, "get_db", lambda: db)
+    monkeypatch.setattr(match_routes, "_ensure_match_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(match_routes, "has_match_result_permission", AsyncMock(return_value=True))
+    monkeypatch.setattr(match_routes, "ensure_tournament_accepts_results", AsyncMock())
+    monkeypatch.setattr(match_routes, "ensure_station_slot_available", AsyncMock())
+    monkeypatch.setattr(match_routes, "advance_match_winner", advance)
+    monkeypatch.setattr(match_routes, "_audit_match_action", audit)
+
+    result = asyncio.run(match_routes.update_match(
+        "match-1",
+        MatchUpdate(admin_note="Nur eine Notiz"),
+        {"id": "admin-1", "role": "tournament_admin"},
+    ))
+
+    assert result["admin_note"] == "Nur eine Notiz"
+    assert result["idempotent_replay"] is False
+    assert matches.update_count == 1
+    advance.assert_not_called()
+    audit.assert_not_awaited()
+
+
+def test_score_report_exact_replay_skips_second_report_and_audit(monkeypatch):
+    report = {
+        "id": "report-1",
+        "registration_id": "reg-a",
+        "user_id": "user-1",
+        "score_a": 2,
+        "score_b": 1,
+        "screenshot_url": "https://example.test/proof",
+        "note": "final",
+    }
+    match = {
+        "id": "match-1",
+        "tournament_id": "t1",
+        "participant_a_id": "reg-a",
+        "participant_b_id": "reg-b",
+        "status": "waiting_result",
+        "reports": [report],
+    }
+    matches = _MutableMatchCollection(match)
+    db = SimpleNamespace(
+        matches=matches,
+        tournaments=SimpleNamespace(find_one=AsyncMock(return_value={})),
+        tournament_stages=SimpleNamespace(find_one=AsyncMock()),
+        tournament_registrations=SimpleNamespace(find_one=AsyncMock(return_value={"id": "reg-a"})),
+    )
+    audit = AsyncMock()
+
+    monkeypatch.setattr(match_routes, "get_db", lambda: db)
+    monkeypatch.setattr(match_routes, "_ensure_match_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(match_routes, "ensure_tournament_accepts_results", AsyncMock())
+    monkeypatch.setattr(match_routes, "_audit_match_action", audit)
+
+    result = asyncio.run(match_routes.report_score(
+        "match-1",
+        MatchScoreReport(
+            score_a=2,
+            score_b=1,
+            screenshot_url="https://example.test/proof",
+            note="final",
+        ),
+        {"id": "user-1", "role": "player"},
+    ))
+
+    assert result["idempotent_replay"] is True
+    assert matches.update_count == 0
+    audit.assert_not_awaited()
+
+
+def test_schedule_proposal_exact_replay_reuses_pending_record(monkeypatch):
+    scheduled_at = datetime(2026, 8, 20, 18, 0, tzinfo=timezone.utc)
+    existing = {
+        "id": "proposal-1",
+        "match_id": "match-1",
+        "actor_user_id": "user-1",
+        "scheduled_at": scheduled_at.isoformat(),
+        "note": "passt",
+        "status": "pending",
+        "kind": "proposal",
+    }
+    proposals = SimpleNamespace(find_one=AsyncMock(return_value=existing), insert_one=AsyncMock())
+    db = SimpleNamespace(
+        match_schedule_proposals=proposals,
+        tournaments=SimpleNamespace(find_one=AsyncMock(return_value={"event_mode": "online"})),
+        tournament_stages=SimpleNamespace(find_one=AsyncMock()),
+    )
+    match = {"id": "match-1", "tournament_id": "t1", "status": "ready"}
+
+    monkeypatch.setattr(match_routes, "get_db", lambda: db)
+    monkeypatch.setattr(match_routes, "_find_match_any", AsyncMock(return_value=(match, "matches")))
+    monkeypatch.setattr(match_routes, "_acting_registration_for_match", AsyncMock(return_value={"id": "reg-a"}))
+    monkeypatch.setattr(match_routes, "_can_act_for_match", AsyncMock(return_value=True))
+
+    result = asyncio.run(match_routes.create_schedule_proposal(
+        "match-1",
+        MatchScheduleProposalCreate(scheduled_at=scheduled_at, note=" passt "),
+        {"id": "user-1", "role": "player"},
+    ))
+
+    assert result["id"] == "proposal-1"
+    assert result["idempotent_replay"] is True
+    proposals.insert_one.assert_not_awaited()
+
+
+def test_v2_match_update_exact_replay_skips_write(monkeypatch):
+    match = {
+        "id": "match-v2",
+        "tournament_id": "t1",
+        "status": "ready",
+        "admin_note": "bestehend",
+    }
+    matches = _MutableMatchCollection(match)
+    db = SimpleNamespace(matches_v2=matches)
+
+    monkeypatch.setattr(match_v2_routes, "get_db", lambda: db)
+    monkeypatch.setattr(match_v2_routes, "_ensure_match_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(match_v2_routes, "require_tournament_staff_permission", AsyncMock())
+    monkeypatch.setattr(match_v2_routes, "ensure_station_slot_available", AsyncMock())
+
+    result = asyncio.run(match_v2_routes.update_match_v2(
+        "match-v2",
+        MatchV2Update(admin_note="bestehend"),
+        {"id": "admin-1", "role": "tournament_admin"},
+    ))
+
+    assert result["idempotent_replay"] is True
+    assert matches.update_count == 0

--- a/backend/tests/test_match_v2_results_unit.py
+++ b/backend/tests/test_match_v2_results_unit.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from services.match_v2_results import (
     MatchV2ResultError,
     build_v2_result_application,
+    is_v2_result_replay,
     normalize_v2_results,
     public_recalculation_error,
 )
@@ -134,6 +135,45 @@ def test_v2_result_application_fills_advancement_slots():
     assert application["target_sets"]["m-b"]["slots"][1]["registration_id"] == "r1"
     assert application["target_sets"]["m-l"]["slots"][0]["registration_id"] == "r4"
     assert application["target_sets"]["m-l"]["slots"][1]["registration_id"] == "r3"
+
+
+def test_completed_v2_result_detects_exact_idempotent_replay():
+    source = _source_match()
+    application = build_v2_result_application(
+        source,
+        [source, _target("m-b", "B"), _target("m-l", "L")],
+        RESULTS,
+        actor_id="admin",
+        now_iso="2026-05-08T12:00:00+00:00",
+        proof_url=" https://example.test/proof ",
+        note=" final ",
+    )
+    completed = {**source, **application["match_set"]}
+
+    assert is_v2_result_replay(
+        completed,
+        RESULTS,
+        proof_url="https://example.test/proof",
+        note="final",
+    )
+
+
+def test_completed_v2_result_replay_requires_same_payload_and_metadata():
+    source = _source_match()
+    application = build_v2_result_application(
+        source,
+        [source, _target("m-b", "B"), _target("m-l", "L")],
+        RESULTS,
+        actor_id="admin",
+        now_iso="2026-05-08T12:00:00+00:00",
+        note="final",
+    )
+    completed = {**source, **application["match_set"]}
+    changed = [dict(entry) for entry in RESULTS]
+    changed[0]["score"] = 999
+
+    assert not is_v2_result_replay(completed, changed, note="final")
+    assert not is_v2_result_replay(completed, RESULTS, note="korrigiert")
 
 
 def test_l_flow_rank_is_loser_index_after_qualifiers():

--- a/backend/tests/test_mutation_lock_unit.py
+++ b/backend/tests/test_mutation_lock_unit.py
@@ -1,0 +1,144 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+import pathlib
+import sys
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.mutation_lock import MutationLockBusy, mutation_lock, tournament_write_resource
+
+
+class _FakeMutationLocks:
+    def __init__(self, document=None):
+        self.document = document
+        self._atomic = asyncio.Lock()
+
+    async def find_one_and_update(self, query, update, **_kwargs):
+        async with self._atomic:
+            current = self.document
+            now = query["$or"][0]["expires_at"]["$lte"]
+            owner = query["$or"][1]["owner"]
+            can_take = (
+                current is None
+                or current.get("expires_at") <= now
+                or current.get("owner") == owner
+            )
+            if not can_take:
+                raise DuplicateKeyError("resource already leased")
+            self.document = dict(update["$set"])
+            return dict(self.document)
+
+    async def delete_one(self, query):
+        async with self._atomic:
+            if self.document and all(self.document.get(key) == value for key, value in query.items()):
+                self.document = None
+
+    async def update_one(self, query, update):
+        async with self._atomic:
+            matched = bool(
+                self.document
+                and all(self.document.get(key) == value for key, value in query.items())
+            )
+            if matched:
+                self.document.update(update["$set"])
+            return type("Result", (), {"matched_count": int(matched)})()
+
+
+class _FakeDb:
+    def __init__(self, document=None):
+        self.mutation_locks = _FakeMutationLocks(document)
+
+
+def test_tournament_write_resource_is_stable_and_scoped():
+    assert tournament_write_resource("turnier-1") == "tournament:turnier-1:write"
+
+
+def test_mutation_lock_rejects_parallel_owner_without_waiting():
+    async def scenario():
+        db = _FakeDb()
+        async with mutation_lock(db, "resource-1", wait_seconds=0):
+            with pytest.raises(MutationLockBusy):
+                async with mutation_lock(db, "resource-1", wait_seconds=0):
+                    pass
+        assert db.mutation_locks.document is None
+
+    asyncio.run(scenario())
+
+
+def test_mutation_lock_waiter_acquires_after_release():
+    async def scenario():
+        db = _FakeDb()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        order = []
+
+        async def first_owner():
+            async with mutation_lock(db, "resource-1", wait_seconds=0):
+                order.append("first")
+                entered.set()
+                await release.wait()
+
+        async def second_owner():
+            await entered.wait()
+            async with mutation_lock(db, "resource-1", wait_seconds=0.5, retry_seconds=0.001):
+                order.append("second")
+
+        first_task = asyncio.create_task(first_owner())
+        second_task = asyncio.create_task(second_owner())
+        await entered.wait()
+        await asyncio.sleep(0.01)
+        assert order == ["first"]
+        release.set()
+        await asyncio.gather(first_task, second_task)
+        assert order == ["first", "second"]
+        assert db.mutation_locks.document is None
+
+    asyncio.run(scenario())
+
+
+def test_mutation_lock_takes_over_expired_lease():
+    async def scenario():
+        db = _FakeDb({
+            "resource": "resource-1",
+            "owner": "dead-worker",
+            "expires_at": datetime.now(timezone.utc) - timedelta(seconds=1),
+        })
+        async with mutation_lock(db, "resource-1", wait_seconds=0) as owner:
+            assert owner != "dead-worker"
+            assert db.mutation_locks.document["owner"] == owner
+        assert db.mutation_locks.document is None
+
+    asyncio.run(scenario())
+
+
+def test_mutation_lock_renews_lease_while_work_is_running():
+    async def scenario():
+        db = _FakeDb()
+        async with mutation_lock(
+            db,
+            "resource-1",
+            wait_seconds=0,
+            lease_seconds=0.03,
+        ):
+            first_expiry = db.mutation_locks.document["expires_at"]
+            await asyncio.sleep(0.02)
+            assert db.mutation_locks.document["expires_at"] > first_expiry
+        assert db.mutation_locks.document is None
+
+    asyncio.run(scenario())
+
+
+def test_mutation_lock_validates_arguments():
+    async def scenario():
+        db = _FakeDb()
+        with pytest.raises(ValueError, match="resource"):
+            async with mutation_lock(db, ""):
+                pass
+        with pytest.raises(ValueError, match="lease_seconds"):
+            async with mutation_lock(db, "resource-1", lease_seconds=0):
+                pass
+
+    asyncio.run(scenario())

--- a/backend/tests/test_tournament_operations_unit.py
+++ b/backend/tests/test_tournament_operations_unit.py
@@ -1,5 +1,6 @@
 """Regression tests for Package 4 tournament start and station safety."""
 import asyncio
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -12,6 +13,7 @@ from routes.station_routes import (
     _match_has_minimum_participants,
 )
 from services.match_reminder import _uses_actual_start_notifications
+from models import RegistrationUpdate, TournamentCreate, TournamentStageCreate
 
 
 def _legacy_match(**updates):
@@ -147,3 +149,245 @@ def test_manual_live_start_does_not_change_status_before_hard_preflight(monkeypa
     assert error.value.status_code == 409
     assert error.value.detail["force_allowed"] is False
     tournaments.update_one.assert_not_awaited()
+
+
+def test_self_registration_exact_retry_returns_existing_record_without_insert():
+    existing = {"id": "reg-1", "tournament_id": "t1", "user_id": "user-1", "status": "approved"}
+    registrations = SimpleNamespace(
+        find_one=AsyncMock(return_value=existing),
+        insert_one=AsyncMock(),
+    )
+    db = SimpleNamespace(tournament_registrations=registrations)
+
+    result = asyncio.run(tournament_routes._create_self_registration(
+        db,
+        "t1",
+        {"id": "t1"},
+        object(),
+        {"id": "user-1"},
+        None,
+    ))
+
+    assert result["id"] == "reg-1"
+    assert result["idempotent_replay"] is True
+    assert result["auto_bracket_update"] is None
+    registrations.insert_one.assert_not_awaited()
+
+
+def test_team_registration_retry_by_another_manager_reuses_team_record(monkeypatch):
+    existing_team = {"id": "reg-team", "tournament_id": "t1", "team_id": "team-1", "status": "approved"}
+    registrations = SimpleNamespace(
+        find_one=AsyncMock(side_effect=[None, existing_team]),
+        insert_one=AsyncMock(),
+    )
+    db = SimpleNamespace(tournament_registrations=registrations)
+
+    async def valid_team(*_args):
+        return {"id": "team-1", "name": "Lions", "tag": "TLS"}
+
+    monkeypatch.setattr(tournament_routes, "_validate_registration_actor", valid_team)
+    result = asyncio.run(tournament_routes._create_self_registration(
+        db,
+        "t1",
+        {"id": "t1"},
+        object(),
+        {"id": "manager-2"},
+        None,
+    ))
+
+    assert result["id"] == "reg-team"
+    assert result["idempotent_replay"] is True
+    registrations.insert_one.assert_not_awaited()
+
+
+@asynccontextmanager
+async def _uncontended_lock(*_args, **_kwargs):
+    yield "test-owner"
+
+
+def test_staff_checkin_replay_skips_badges_and_audit(monkeypatch):
+    registration = {"id": "reg-1", "tournament_id": "t1", "user_id": "user-1", "status": "checked_in"}
+    registrations = SimpleNamespace(
+        find_one=AsyncMock(return_value=registration),
+        update_one=AsyncMock(),
+    )
+    db = SimpleNamespace(tournament_registrations=registrations)
+
+    async def identity(value):
+        return value
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "_resolve_tid", identity)
+    monkeypatch.setattr(tournament_routes, "_ensure_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(tournament_routes, "require_tournament_staff_permission", AsyncMock())
+    monkeypatch.setattr(tournament_routes, "mutation_lock", _uncontended_lock)
+    badges = AsyncMock()
+    audit = AsyncMock()
+    monkeypatch.setattr(tournament_routes, "_apply_checked_in_badges", badges)
+    monkeypatch.setattr(tournament_routes, "_audit_tournament_action", audit)
+
+    result = asyncio.run(tournament_routes.staff_set_registration_checkin(
+        "t1",
+        "reg-1",
+        {"status": "checked_in"},
+        {"id": "admin-1"},
+    ))
+
+    assert result["idempotent_replay"] is True
+    registrations.update_one.assert_not_awaited()
+    badges.assert_not_awaited()
+    audit.assert_not_awaited()
+
+
+def test_self_checkin_replay_skips_late_hooks_badges_and_audit(monkeypatch):
+    db = SimpleNamespace()
+
+    async def identity(value):
+        return value
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "_resolve_tid", identity)
+    monkeypatch.setattr(tournament_routes, "_ensure_tournament_unlocked", AsyncMock(return_value={"event_mode": "online"}))
+    monkeypatch.setattr(tournament_routes, "mutation_lock", _uncontended_lock)
+    monkeypatch.setattr(tournament_routes, "_find_self_registration", AsyncMock(return_value={
+        "id": "reg-1", "user_id": "user-1", "status": "checked_in",
+    }))
+    late_hooks = AsyncMock()
+    badges = AsyncMock()
+    audit = AsyncMock()
+    monkeypatch.setattr(tournament_routes, "_apply_late_checkin_hooks", late_hooks)
+    monkeypatch.setattr(tournament_routes, "_apply_checked_in_badges", badges)
+    monkeypatch.setattr(tournament_routes, "_audit_tournament_action", audit)
+
+    result = asyncio.run(tournament_routes.checkin_self("t1", {"id": "user-1"}))
+
+    assert result == {"ok": True, "idempotent_replay": True}
+    late_hooks.assert_not_awaited()
+    badges.assert_not_awaited()
+    audit.assert_not_awaited()
+
+
+def test_registration_update_replay_skips_write_and_bracket_refresh(monkeypatch):
+    registration = {"id": "reg-1", "tournament_id": "t1", "status": "approved"}
+    registrations = SimpleNamespace(
+        find_one=AsyncMock(return_value=registration),
+        update_one=AsyncMock(),
+    )
+    db = SimpleNamespace(tournament_registrations=registrations)
+
+    async def identity(value):
+        return value
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "_resolve_tid", identity)
+    monkeypatch.setattr(tournament_routes, "_ensure_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(tournament_routes, "require_tournament_staff_permission", AsyncMock())
+    refresh = AsyncMock()
+    monkeypatch.setattr(tournament_routes, "_refresh_tournament_previews_after_registration", refresh)
+
+    result = asyncio.run(tournament_routes.update_registration(
+        "t1",
+        "reg-1",
+        RegistrationUpdate(status="approved"),
+        {"id": "admin-1"},
+    ))
+
+    assert result["idempotent_replay"] is True
+    registrations.update_one.assert_not_awaited()
+    refresh.assert_not_awaited()
+
+
+def test_lock_and_unlock_replays_skip_second_audit(monkeypatch):
+    async def identity(value):
+        return value
+
+    audit = AsyncMock()
+    updates = AsyncMock()
+    monkeypatch.setattr(tournament_routes, "_resolve_tid", identity)
+    monkeypatch.setattr(tournament_routes, "_audit_tournament_action", audit)
+
+    locked_db = SimpleNamespace(tournaments=SimpleNamespace(
+        find_one=AsyncMock(return_value={"id": "t1", "status": "completed", "locked_at": "2026-08-12T12:00:00+00:00"}),
+        update_one=updates,
+    ))
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: locked_db)
+    locked = asyncio.run(tournament_routes.lock_tournament("t1", {"id": "admin-1"}))
+    assert locked["idempotent_replay"] is True
+
+    unlocked_db = SimpleNamespace(tournaments=SimpleNamespace(
+        find_one=AsyncMock(return_value={"id": "t1", "status": "completed"}),
+        update_one=updates,
+    ))
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: unlocked_db)
+    unlocked = asyncio.run(tournament_routes.unlock_tournament("t1", {"id": "admin-1"}))
+    assert unlocked["idempotent_replay"] is True
+
+    updates.assert_not_awaited()
+    audit.assert_not_awaited()
+
+
+def test_tournament_creation_replay_reuses_existing_document(monkeypatch):
+    tournaments = SimpleNamespace(
+        find_one=AsyncMock(return_value={
+            "id": "t1",
+            "title": "Sommer-Cup",
+            "game_id": "game-1",
+            "creation_key": "internal",
+        }),
+        insert_one=AsyncMock(),
+    )
+    games = SimpleNamespace(find_one=AsyncMock())
+    db = SimpleNamespace(tournaments=tournaments, games=games)
+    preview = AsyncMock()
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "mutation_lock", _uncontended_lock)
+    monkeypatch.setattr(tournament_routes, "_create_initial_bracket_preview", preview)
+
+    result = asyncio.run(tournament_routes.create_tournament(
+        TournamentCreate(title="Sommer-Cup", game_id="game-1"),
+        {"id": "admin-1"},
+    ))
+
+    assert result["id"] == "t1"
+    assert result["idempotent_replay"] is True
+    assert "creation_key" not in result
+    games.find_one.assert_not_awaited()
+    tournaments.insert_one.assert_not_awaited()
+    preview.assert_not_awaited()
+
+
+def test_tournament_stage_creation_replay_reuses_existing_document(monkeypatch):
+    stages = SimpleNamespace(
+        find_one=AsyncMock(return_value={
+            "id": "stage-1",
+            "tournament_id": "t1",
+            "name": "Finale",
+            "number": 1,
+            "creation_key": "internal",
+        }),
+        insert_one=AsyncMock(),
+    )
+    db = SimpleNamespace(tournament_stages=stages)
+
+    async def identity(value):
+        return value
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "_resolve_tid", identity)
+    monkeypatch.setattr(tournament_routes, "_ensure_tournament_unlocked", AsyncMock())
+    monkeypatch.setattr(tournament_routes, "require_tournament_staff_permission", AsyncMock())
+    audit = AsyncMock()
+    monkeypatch.setattr(tournament_routes, "_audit_tournament_action", audit)
+
+    result = asyncio.run(tournament_routes.create_tournament_stage(
+        "t1",
+        TournamentStageCreate(name="Finale", number=1),
+        {"id": "admin-1"},
+    ))
+
+    assert result["id"] == "stage-1"
+    assert result["idempotent_replay"] is True
+    assert "creation_key" not in result
+    stages.insert_one.assert_not_awaited()
+    audit.assert_not_awaited()

--- a/backend/tests/test_v2_result_submission_unit.py
+++ b/backend/tests/test_v2_result_submission_unit.py
@@ -1,0 +1,186 @@
+import asyncio
+from copy import deepcopy
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.v2_result_submission import submit_v2_result
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def to_list(self, _limit):
+        return deepcopy(self.rows)
+
+
+class _Matches:
+    def __init__(self, rows):
+        self.rows = {row["id"]: deepcopy(row) for row in rows}
+        self.update_count = 0
+
+    def find(self, query, _projection=None):
+        return _Cursor([
+            row for row in self.rows.values()
+            if row.get("stage_id") == query.get("stage_id")
+        ])
+
+    async def update_one(self, query, update):
+        self.update_count += 1
+        self.rows[query["id"]].update(deepcopy(update["$set"]))
+
+    async def find_one(self, query, _projection=None):
+        row = self.rows.get(query["id"])
+        return deepcopy(row) if row else None
+
+
+class _Inserts:
+    def __init__(self):
+        self.docs = []
+
+    async def insert_one(self, doc):
+        self.docs.append(deepcopy(doc))
+
+    async def update_one(self, query, update, upsert=False):
+        existing = next((doc for doc in self.docs if all(doc.get(k) == v for k, v in query.items())), None)
+        if existing is None and upsert:
+            self.docs.append(deepcopy(update.get("$setOnInsert") or {}))
+
+
+class _Db:
+    def __init__(self, rows):
+        self.matches_v2 = _Matches(rows)
+        self.match_reports_v2 = _Inserts()
+        self.audit_logs = _Inserts()
+
+
+def _source_match():
+    return {
+        "id": "match-a",
+        "tournament_id": "t1",
+        "stage_id": "stage-1",
+        "match_key": "A",
+        "status": "ready",
+        "settings": {"min_players": 2},
+        "slots": [
+            {"slot": 1, "registration_id": "reg-1", "user_id": "user-1", "status": "filled"},
+            {"slot": 2, "registration_id": "reg-2", "user_id": "user-2", "status": "filled"},
+        ],
+        "advancement": [
+            {"flow": "W", "rank": 1, "to_match_id": "match-b", "to_match_key": "B", "to_slot": 1},
+        ],
+    }
+
+
+def _target_match():
+    return {
+        "id": "match-b",
+        "tournament_id": "t1",
+        "stage_id": "stage-1",
+        "match_key": "B",
+        "status": "pending",
+        "settings": {"min_players": 2},
+        "slots": [
+            {"slot": 1, "registration_id": None, "user_id": None, "status": "pending"},
+            {"slot": 2, "registration_id": None, "user_id": None, "status": "pending"},
+        ],
+    }
+
+
+RESULTS = [
+    {"registration_id": "reg-1", "score": 2},
+    {"registration_id": "reg-2", "score": 0},
+]
+
+
+def test_submit_v2_result_replay_has_no_second_side_effect():
+    async def scenario():
+        db = _Db([_source_match(), _target_match()])
+        first = await submit_v2_result(
+            db,
+            _source_match(),
+            RESULTS,
+            actor_id="admin-1",
+            proof_url="https://example.test/proof",
+            note="final",
+            force=False,
+            audit_action="match.result.submit",
+        )
+        completed = await db.matches_v2.find_one({"id": "match-a"})
+        second = await submit_v2_result(
+            db,
+            completed,
+            RESULTS,
+            actor_id="admin-1",
+            proof_url="https://example.test/proof",
+            note="final",
+            force=False,
+            audit_action="match.result.submit",
+        )
+
+        assert first["idempotent_replay"] is False
+        assert second["idempotent_replay"] is True
+        assert second["report_id"] == first["report_id"]
+        assert first["report_id"].startswith("v2-result-")
+        assert second["advanced_match_ids"] == ["match-b"]
+        assert len(db.match_reports_v2.docs) == 1
+        assert len(db.audit_logs.docs) == 1
+        assert db.matches_v2.update_count == 2
+        assert db.matches_v2.rows["match-b"]["slots"][0]["registration_id"] == "reg-1"
+
+    asyncio.run(scenario())
+
+
+def test_submit_v2_result_resumes_after_interrupted_source_commit():
+    async def scenario():
+        db = _Db([_source_match(), _target_match()])
+        original_update = db.matches_v2.update_one
+        failed_once = False
+
+        async def fail_source_once(query, update):
+            nonlocal failed_once
+            if query["id"] == "match-a" and not failed_once:
+                failed_once = True
+                raise RuntimeError("simulated worker crash")
+            await original_update(query, update)
+
+        db.matches_v2.update_one = fail_source_once
+        try:
+            await submit_v2_result(
+                db,
+                _source_match(),
+                RESULTS,
+                actor_id="admin-1",
+                proof_url=None,
+                note="final",
+                force=False,
+                audit_action="match.result.submit",
+            )
+        except RuntimeError as exc:
+            assert str(exc) == "simulated worker crash"
+        else:
+            raise AssertionError("interruption was not simulated")
+
+        source_after_crash = await db.matches_v2.find_one({"id": "match-a"})
+        assert source_after_crash["status"] == "ready"
+        assert db.matches_v2.rows["match-b"]["slots"][0]["registration_id"] == "reg-1"
+
+        resumed = await submit_v2_result(
+            db,
+            source_after_crash,
+            RESULTS,
+            actor_id="admin-1",
+            proof_url=None,
+            note="final",
+            force=False,
+            audit_action="match.result.submit",
+        )
+
+        assert resumed["idempotent_replay"] is False
+        assert resumed["match"]["status"] == "completed"
+        assert len(db.match_reports_v2.docs) == 1
+        assert len(db.audit_logs.docs) == 1
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Zusammenfassung

- serialisiert kritische Turnier-, Match- und Adminmutationen über eine erneuerbare MongoDB-Lease, die auch über mehrere Backend-Worker hinter dem Reverse Proxy hinweg gilt
- schützt Turnier-/Stage-Erstellung und Nutzer-/Team-Anmeldungen zusätzlich mit eindeutigen Datenbankidentitäten
- beantwortet exakte Wiederholungen von Anmeldung, Check-in, Terminaktion, Matchupdate, Report, Dispute, Forfeit, Status und Sperraktion ohne zweite Nebenwirkung
- vereinheitlicht beide V2-Ergebnisrouten in einem wiederaufnehmbaren Persistenzdienst
- verwendet deterministische Report-/Audit-IDs, idempotente Upserts und deduplizierte Ergebnisbenachrichtigungen
- verhindert erneutes Advancement, Badge- und Discord-Auslösen bei reinen Änderungen an bereits abgeschlossenen Legacy-Matches
- gibt bei konkurrierenden bzw. abweichenden Aktionen einen stabilen `409` zurück; absichtliche Ergebniskorrekturen bleiben explizit über `force=true` möglich

## Ausfallsicherheit

Die Produktion verwendet eine einzelne MongoDB-Instanz und damit keine Multi-Document-Transaktionen. Der V2-Ergebnisweg ist deshalb bewusst wiederaufnehmbar aufgebaut:

1. Report idempotent vormerken
2. Downstream-Advancement wiederholbar schreiben
3. Source-Match zuletzt finalisieren
4. Audit idempotent upserten
5. Notifications deduplizieren und Stationsfreigabe zustandsbasiert ausführen

Ein Regressionstest simuliert einen Worker-Abbruch vor dem Source-Commit und bestätigt, dass der Retry genau einen Report und ein Audit erzeugt.

## Prüfung

- Backend: 222 bestanden, 282 umgebungsabhängige Live-Tests erwartungsgemäß übersprungen
- neue/gezielte Idempotenz-, Parallelitäts- und Crash-Recovery-Tests grün
- `python -m compileall -q backend`
- OpenAPI-Erzeugung: 358 Routen
- Frontend-Produktions-Build
- Frontend-Unit: 10 bestanden
- High-Severity-Dependency-Audit grün
- `git diff --check`

Schließt den offenen P0-Prüfpunkt zu Turnier-, Ergebnis- und Adminaktionen in #95.