### PR TITLE
fix: harden auth sessions behind proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ AUTH_COOKIE_DOMAIN=.lionsquad.at
 
 Wenn die Seite sowohl unter `lionsquad.at` als auch unter `www.lionsquad.at` erreichbar ist,
 setze `AUTH_COOKIE_DOMAIN=.lionsquad.at` und nimm beide Origins in `CORS_ORIGINS` auf. Sonst
-kann ein Login auf einer Host-Variante fuer die andere Host-Variante unsichtbar sein.
+kann ein Login auf einer Host-Variante fuer die andere Host-Variante unsichtbar sein. Das interne
+Nginx leitet `www` mit `308 Permanent Redirect` auf die kanonische Domain um, damit auch bei einem
+versehentlichen API-Aufruf Methode und Request-Body erhalten bleiben. Der aeussere Reverse Proxy
+sollte denselben kanonischen Host verwenden.
 
 `PUBLIC_UPLOAD_BACKEND_URL` ist optional, aber fuer grosse Galerie-Videos hinter Cloudflare
 empfohlen. Lege dafuer z. B. `upload.lionsquad.at` als DNS-only Record an und leite ihn im
@@ -229,6 +232,8 @@ In beiden Faellen:
 - HTTP auf HTTPS weiterleiten.
 - Eingehende `X-Forwarded-*`-Header am aeusseren Proxy ersetzen bzw. korrekt
   erweitern; niemals ungeprueft vom Internet uebernehmen.
+- Den Browser-Header `Origin` unveraendert weiterreichen. Schreibende Cookie-Requests
+  werden gegen `FRONTEND_URL`/`CORS_ORIGINS` und den CSRF-Token geprueft.
 
 Wenn Nginx Proxy Manager auf dem Docker-Host laeuft:
 
@@ -273,9 +278,11 @@ docker compose up -d --build
 curl -I https://lionsquad.at/api/health
 ```
 
-Die API-Antwort muss ueber die oeffentliche URL erreichbar sein. Login, Logout,
-ein Upload und ein absichtlich wiederholter Request bis zur `429`-Antwort pruefen
-zusaetzlich Cookies, Client-IP und Rate-Limit hinter dem Proxy.
+Die API-Antwort muss ueber die oeffentliche URL erreichbar sein. Login, Ablauf/Refresh,
+Logout, Rollenwechsel, ein Upload, ein Wechsel von `www` auf die kanonische Domain und
+ein absichtlich wiederholter Request bis zur `429`-Antwort pruefen zusaetzlich Cookies,
+CSRF, Session-Widerruf, Client-IP und Rate-Limit hinter dem Proxy. Bestehende Refresh-Sessions
+werden beim ersten Refresh automatisch in das aktuelle Session-Familienformat migriert.
 
 ## Analytics
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -40,22 +40,29 @@ def verify_password(plain: str, hashed: str) -> bool:
         return False
 
 
-def create_access_token(user_id: str, email: str, role: str) -> str:
+def create_access_token(user_id: str, email: str, role: str, session_id: str) -> str:
     payload = {
         "sub": user_id,
         "email": email,
         "role": role,
+        "sid": session_id,
         "exp": datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_MINUTES),
         "type": "access",
     }
     return jwt.encode(payload, get_jwt_secret(), algorithm=JWT_ALGORITHM)
 
 
-def create_refresh_token(user_id: str, token_id: str) -> str:
+def create_refresh_token(
+    user_id: str,
+    token_id: str,
+    family_id: str,
+    expires_at: datetime | None = None,
+) -> str:
     payload = {
         "sub": user_id,
         "jti": token_id,
-        "exp": datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_DAYS),
+        "fid": family_id,
+        "exp": expires_at or refresh_expires_at(),
         "type": "refresh",
     }
     return jwt.encode(payload, get_jwt_secret(), algorithm=JWT_ALGORITHM)
@@ -63,6 +70,16 @@ def create_refresh_token(user_id: str, token_id: str) -> str:
 
 def refresh_expires_at() -> datetime:
     return datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_DAYS)
+
+
+def as_utc_datetime(value) -> datetime | None:
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def hash_token(token: str) -> str:
@@ -82,7 +99,13 @@ def _secure_cookies() -> bool:
 def _cookie_domain() -> str | None:
     explicit = os.environ.get("AUTH_COOKIE_DOMAIN", "").strip()
     if explicit:
-        return explicit if explicit.startswith(".") else f".{explicit}"
+        domain = explicit.lower().strip(".")
+        if not domain or "." not in domain or any(char in domain for char in "/:@"):
+            raise RuntimeError("AUTH_COOKIE_DOMAIN must be a hostname without scheme or port.")
+        frontend_host = (urlparse(os.environ.get("FRONTEND_URL", "")).hostname or "").lower().strip(".")
+        if frontend_host and frontend_host != domain and not frontend_host.endswith(f".{domain}"):
+            raise RuntimeError("AUTH_COOKIE_DOMAIN must contain the configured FRONTEND_URL host.")
+        return f".{domain}"
     host = urlparse(os.environ.get("FRONTEND_URL", "")).hostname or ""
     host = host.lower().strip(".")
     if not host or host in {"localhost", "127.0.0.1"} or host.endswith(".local"):
@@ -97,21 +120,18 @@ def _cookie_domain() -> str | None:
 
 def set_auth_cookies(response: Response, access: str, refresh: str, csrf_token: str | None = None):
     secure = _secure_cookies()
-    # When on HTTPS (cross-site scenarios behind CDN), use SameSite=None + Secure.
-    # When purely local HTTP, use SameSite=Lax.
-    samesite = "none" if secure else "lax"
     csrf_token = csrf_token or new_csrf_token()
     domain = _cookie_domain()
     response.set_cookie(
-        "access_token", access, httponly=True, secure=secure, samesite=samesite,
+        "access_token", access, httponly=True, secure=secure, samesite="lax",
         max_age=ACCESS_TOKEN_MINUTES * 60, path="/", domain=domain,
     )
     response.set_cookie(
-        "refresh_token", refresh, httponly=True, secure=secure, samesite=samesite,
+        "refresh_token", refresh, httponly=True, secure=secure, samesite="lax",
         max_age=REFRESH_TOKEN_DAYS * 24 * 3600, path="/", domain=domain,
     )
     response.set_cookie(
-        "csrf_token", csrf_token, httponly=False, secure=secure, samesite=samesite,
+        "csrf_token", csrf_token, httponly=False, secure=secure, samesite="lax",
         max_age=REFRESH_TOKEN_DAYS * 24 * 3600, path="/", domain=domain,
     )
 
@@ -154,9 +174,25 @@ async def get_current_user(request: Request) -> dict:
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
     db = get_db()
-    user = await db.users.find_one({"id": payload["sub"]}, {"_id": 0, "password_hash": 0})
+    user_id = payload.get("sub")
+    session_id = payload.get("sid")
+    if not user_id or not session_id:
+        raise HTTPException(status_code=401, detail="Session expired")
+    session = await db.refresh_tokens.find_one({
+        "jti": session_id,
+        "user_id": user_id,
+        "revoked": {"$ne": True},
+    }, {"_id": 0, "expires_at": 1})
+    if not session:
+        raise HTTPException(status_code=401, detail="Session expired")
+    expires_at = as_utc_datetime(session.get("expires_at"))
+    if expires_at and expires_at <= datetime.now(timezone.utc):
+        raise HTTPException(status_code=401, detail="Session expired")
+    user = await db.users.find_one({"id": user_id}, {"_id": 0, "password_hash": 0})
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
+    if user.get("is_active") is False:
+        raise HTTPException(status_code=403, detail="Account is inactive")
     if user.get("is_banned"):
         raise HTTPException(status_code=403, detail="Account is banned")
     # Attach membership for downstream guards / UI

--- a/backend/database.py
+++ b/backend/database.py
@@ -136,6 +136,7 @@ async def init_indexes():
     await db.refresh_tokens.create_index("id", unique=True)
     await db.refresh_tokens.create_index("jti", unique=True)
     await db.refresh_tokens.create_index("user_id")
+    await db.refresh_tokens.create_index([("family_id", 1), ("revoked", 1)])
     await db.refresh_tokens.create_index("expires_at", expireAfterSeconds=0)
     # Phase 2/3 collections
     await db.settings.create_index("id", unique=True)

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -4,11 +4,13 @@ import secrets
 from datetime import datetime, timezone, timedelta
 from fastapi import APIRouter, Response, Request, HTTPException, Depends
 from pydantic import BaseModel
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
 from database import get_db
 from auth import (
     hash_password, verify_password, create_access_token, create_refresh_token,
     set_auth_cookies, clear_auth_cookies, get_current_user, get_optional_user, _decode,
-    hash_token, refresh_expires_at,
+    hash_token, refresh_expires_at, as_utc_datetime,
 )
 from email_service import send_template
 from models import (
@@ -21,6 +23,7 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 BRUTE_FORCE_MAX = 7
 BRUTE_FORCE_WINDOW_MIN = 15
+REFRESH_REPLAY_GRACE_SECONDS = 10
 
 
 class MobileRefreshBody(BaseModel):
@@ -60,21 +63,83 @@ async def _clear_failed(db, identifier: str):
     await db.login_attempts.delete_many({"identifier": identifier})
 
 
-async def _issue_session(db, response: Response, user: dict, request: Request):
-    access = create_access_token(user["id"], user["email"], user.get("role", "player"))
-    token_id = secrets.token_urlsafe(24)
-    refresh = create_refresh_token(user["id"], token_id)
-    await db.refresh_tokens.insert_one({
-        "id": new_id(),
+def _request_identity(request: Request) -> tuple[str, str]:
+    return (str(request.headers.get("user-agent") or "")[:512], get_client_ip(request))
+
+
+def _eligible_session_user(user: dict | None) -> dict:
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    if user.get("is_active") is False:
+        raise HTTPException(status_code=403, detail="Account deaktiviert")
+    if user.get("is_banned"):
+        raise HTTPException(status_code=403, detail="Account gesperrt")
+    if user.get("password_setup_required"):
+        raise HTTPException(status_code=403, detail="Bitte zuerst ein Passwort erstellen")
+    return user
+
+
+async def _store_session(
+    db,
+    user: dict,
+    request: Request,
+    *,
+    token_id: str,
+    family_id: str,
+    record_id: str,
+    expires_at: datetime,
+    client: str | None = None,
+) -> tuple[str, str]:
+    refresh = create_refresh_token(user["id"], token_id, family_id, expires_at)
+    access = create_access_token(
+        user["id"], user["email"], user.get("role", "player"), token_id,
+    )
+    user_agent, ip = _request_identity(request)
+    document = {
+        "id": record_id,
         "jti": token_id,
+        "family_id": family_id,
         "user_id": user["id"],
         "token_hash": hash_token(refresh),
         "revoked": False,
         "created_at": now_utc(),
-        "expires_at": refresh_expires_at(),
-        "user_agent": request.headers.get("user-agent"),
-        "ip": get_client_ip(request),
-    })
+        "expires_at": expires_at,
+        "user_agent": user_agent,
+        "ip": ip,
+    }
+    if client:
+        document["client"] = client
+    try:
+        await db.refresh_tokens.insert_one(document)
+    except DuplicateKeyError:
+        existing = await db.refresh_tokens.find_one({"jti": token_id})
+        if not existing or existing.get("token_hash") != document["token_hash"] or existing.get("revoked") is True:
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+    return access, refresh
+
+
+async def _issue_tokens(
+    db,
+    user: dict,
+    request: Request,
+    *,
+    client: str | None = None,
+) -> tuple[str, str]:
+    token_id = secrets.token_urlsafe(24)
+    return await _store_session(
+        db,
+        user,
+        request,
+        token_id=token_id,
+        family_id=token_id,
+        record_id=new_id(),
+        expires_at=refresh_expires_at(),
+        client=client,
+    )
+
+
+async def _issue_session(db, response: Response, user: dict, request: Request):
+    access, refresh = await _issue_tokens(db, user, request)
     set_auth_cookies(response, access, refresh)
     return access, refresh
 
@@ -99,51 +164,103 @@ async def _attach_membership(user: dict) -> dict:
 
 
 async def _issue_mobile_session(db, user: dict, request: Request) -> tuple[str, str]:
-    access = create_access_token(user["id"], user["email"], user.get("role", "player"))
-    token_id = secrets.token_urlsafe(24)
-    refresh = create_refresh_token(user["id"], token_id)
-    await db.refresh_tokens.insert_one({
-        "id": new_id(),
-        "jti": token_id,
-        "user_id": user["id"],
-        "token_hash": hash_token(refresh),
-        "revoked": False,
-        "created_at": now_utc(),
-        "expires_at": refresh_expires_at(),
-        "user_agent": request.headers.get("user-agent"),
-        "ip": get_client_ip(request),
-        "client": "mobile",
-    })
-    return access, refresh
+    return await _issue_tokens(db, user, request, client="mobile")
 
 
-async def _refresh_mobile_session(db, token: str, request: Request) -> tuple[dict, str, str]:
+def _recent_same_client_rotation(stored: dict, request: Request, now: datetime) -> bool:
+    rotated_at = as_utc_datetime(stored.get("rotated_at"))
+    if not rotated_at or now - rotated_at > timedelta(seconds=REFRESH_REPLAY_GRACE_SECONDS):
+        return False
+    user_agent, ip = _request_identity(request)
+    return (
+        stored.get("rotation_user_agent", "") == user_agent
+        and stored.get("rotation_ip", "") == ip
+    )
+
+
+async def _revoke_refresh_family(db, user_id: str, family_id: str, reason: str):
+    await db.refresh_tokens.update_many(
+        {"user_id": user_id, "$or": [{"family_id": family_id}, {"jti": family_id}]},
+        {"$set": {
+            "revoked": True,
+            "revoked_at": now_utc(),
+            "revocation_reason": reason,
+        }},
+    )
+
+
+async def _rotate_session(
+    db,
+    token: str,
+    request: Request,
+    *,
+    client: str | None = None,
+) -> tuple[dict, str, str]:
     payload = _decode(token)
     if payload.get("type") != "refresh":
         raise HTTPException(status_code=401, detail="Invalid refresh token")
     token_id = payload.get("jti")
-    if not token_id:
+    user_id = payload.get("sub")
+    if not token_id or not user_id:
         raise HTTPException(status_code=401, detail="Invalid refresh token")
-    stored = await db.refresh_tokens.find_one({
-        "jti": token_id,
-        "token_hash": hash_token(token),
-        "revoked": {"$ne": True},
-    })
-    if not stored:
-        await db.refresh_tokens.update_many(
-            {"user_id": payload["sub"]},
-            {"$set": {"revoked": True, "revoked_at": now_utc(), "revocation_reason": "refresh_reuse"}},
-        )
-        raise HTTPException(status_code=401, detail="Invalid refresh token")
-    user = await db.users.find_one({"id": payload["sub"]})
-    if not user:
-        raise HTTPException(status_code=401, detail="User not found")
-    await db.refresh_tokens.update_one(
-        {"id": stored["id"]},
-        {"$set": {"revoked": True, "rotated_at": now_utc()}},
+
+    now = datetime.now(timezone.utc)
+    family_id = payload.get("fid") or token_id
+    replacement_jti = secrets.token_urlsafe(24)
+    replacement_id = new_id()
+    replacement_expires_at = refresh_expires_at()
+    user_agent, ip = _request_identity(request)
+    stored = await db.refresh_tokens.find_one_and_update(
+        {
+            "jti": token_id,
+            "token_hash": hash_token(token),
+            "revoked": {"$ne": True},
+        },
+        {"$set": {
+            "revoked": True,
+            "rotated_at": now,
+            "revocation_reason": "rotated",
+            "family_id": family_id,
+            "replacement_jti": replacement_jti,
+            "replacement_id": replacement_id,
+            "replacement_expires_at": replacement_expires_at,
+            "rotation_user_agent": user_agent,
+            "rotation_ip": ip,
+        }},
+        return_document=ReturnDocument.BEFORE,
     )
-    access, refresh = await _issue_mobile_session(db, user, request)
+
+    if stored is None:
+        stored = await db.refresh_tokens.find_one({
+            "jti": token_id,
+            "token_hash": hash_token(token),
+        })
+        if not stored or not _recent_same_client_rotation(stored, request, now):
+            await _revoke_refresh_family(db, user_id, family_id, "refresh_reuse")
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+        replacement_jti = stored.get("replacement_jti")
+        replacement_id = stored.get("replacement_id")
+        replacement_expires_at = as_utc_datetime(stored.get("replacement_expires_at"))
+        if not replacement_jti or not replacement_id or not replacement_expires_at:
+            await _revoke_refresh_family(db, user_id, family_id, "incomplete_rotation")
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    user = _eligible_session_user(await db.users.find_one({"id": user_id}))
+    access, refresh = await _store_session(
+        db,
+        user,
+        request,
+        token_id=replacement_jti,
+        family_id=family_id,
+        record_id=replacement_id,
+        expires_at=replacement_expires_at,
+        client=client,
+    )
     return user, access, refresh
+
+
+async def _refresh_mobile_session(db, token: str, request: Request) -> tuple[dict, str, str]:
+    return await _rotate_session(db, token, request, client="mobile")
 
 
 async def _revoke_refresh(db, token: str):
@@ -228,6 +345,8 @@ async def login(body: UserLogin, request: Request, response: Response):
     if not user or not verify_password(body.password, user["password_hash"]):
         await _record_failed(db, identifier)
         raise HTTPException(status_code=401, detail="Ungültige Zugangsdaten")
+    if user.get("is_active") is False:
+        raise HTTPException(status_code=403, detail="Account deaktiviert")
     if user.get("is_banned"):
         raise HTTPException(status_code=403, detail="Account gesperrt")
 
@@ -308,6 +427,8 @@ async def mobile_login(body: UserLogin, request: Request):
     if not user or not verify_password(body.password, user["password_hash"]):
         await _record_failed(db, identifier)
         raise HTTPException(status_code=401, detail="Ungültige Zugangsdaten")
+    if user.get("is_active") is False:
+        raise HTTPException(status_code=403, detail="Account deaktiviert")
     if user.get("is_banned"):
         raise HTTPException(status_code=403, detail="Account gesperrt")
 
@@ -363,32 +484,9 @@ async def refresh(request: Request, response: Response):
     token = request.cookies.get("refresh_token")
     if not token:
         raise HTTPException(status_code=401, detail="No refresh token")
-    payload = _decode(token)
-    if payload.get("type") != "refresh":
-        raise HTTPException(status_code=401, detail="Invalid refresh token")
-    token_id = payload.get("jti")
-    if not token_id:
-        raise HTTPException(status_code=401, detail="Invalid refresh token")
     db = get_db()
-    stored = await db.refresh_tokens.find_one({
-        "jti": token_id,
-        "token_hash": hash_token(token),
-        "revoked": {"$ne": True},
-    })
-    if not stored:
-        await db.refresh_tokens.update_many(
-            {"user_id": payload["sub"]},
-            {"$set": {"revoked": True, "revoked_at": now_utc(), "revocation_reason": "refresh_reuse"}},
-        )
-        raise HTTPException(status_code=401, detail="Invalid refresh token")
-    user = await db.users.find_one({"id": payload["sub"]})
-    if not user:
-        raise HTTPException(status_code=401, detail="User not found")
-    await db.refresh_tokens.update_one(
-        {"id": stored["id"]},
-        {"$set": {"revoked": True, "rotated_at": now_utc()}},
-    )
-    await _issue_session(db, response, user, request)
+    _user, access, refresh_token = await _rotate_session(db, token, request)
+    set_auth_cookies(response, access, refresh_token)
     return {"ok": True}
 
 
@@ -425,9 +523,7 @@ async def reset_password(body: ResetPasswordBody, request: Request):
     if not doc:
         raise HTTPException(status_code=400, detail="Ungültiger oder abgelaufener Token")
     # Expiry check (defense-in-depth; Mongo TTL also handles it)
-    exp = doc.get("expires_at")
-    if isinstance(exp, str):
-        exp = datetime.fromisoformat(exp.replace("Z", "+00:00"))
+    exp = as_utc_datetime(doc.get("expires_at"))
     if exp and exp < datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="Token abgelaufen")
     await db.users.update_one(

--- a/backend/routes/user_routes.py
+++ b/backend/routes/user_routes.py
@@ -869,7 +869,10 @@ async def unban_user(user_id: str, me: dict = Depends(require_admin())):
 @router.post("/{user_id}/role")
 async def set_role(user_id: str, body: RoleUpdate, me: dict = Depends(require_super())):
     db = get_db()
-    await db.users.update_one({"id": user_id}, {"$set": {"role": body.role, "updated_at": now_utc().isoformat()}})
+    await db.users.update_one(
+        {"id": user_id},
+        {"$set": {"role": body.role, "roles": [body.role], "updated_at": now_utc().isoformat()}},
+    )
     await db.audit_logs.insert_one({"id": new_id(), "action": "user.role_change", "target_id": user_id,
                                      "actor_id": me["id"], "data": {"role": body.role},
                                      "created_at": now_utc().isoformat()})

--- a/backend/runtime_config.py
+++ b/backend/runtime_config.py
@@ -131,6 +131,16 @@ def validate_runtime_environment(environ: Mapping[str, str] | None = None) -> st
         raise RuntimeError("JWT_SECRET must be a real secret with at least 32 characters in production.")
     if not str(source.get("FRONTEND_URL", "")).strip():
         raise RuntimeError("FRONTEND_URL must be set in production.")
+    frontend_url = urlparse(str(source.get("FRONTEND_URL", "")).strip())
+    if frontend_url.scheme != "https" or not frontend_url.hostname:
+        raise RuntimeError("FRONTEND_URL must use https in production.")
+    for raw_origin in str(source.get("CORS_ORIGINS", "")).split(","):
+        origin = raw_origin.strip()
+        if not origin:
+            continue
+        parsed = urlparse(origin)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise RuntimeError("CORS_ORIGINS must contain only https origins in production.")
     if env_flag("ALLOW_INSECURE_CORS", source):
         raise RuntimeError("ALLOW_INSECURE_CORS is blocked in production.")
     if env_flag("SEED_DEMO", source) or env_flag("SEED_GAME_SERVERS", source):

--- a/backend/server.py
+++ b/backend/server.py
@@ -57,6 +57,7 @@ from routes.extras_routes import (
     settings_router, season_router, widget_router, dsgvo_router, pdf_router, audit_router,
 )
 from services.change_events import change_event_stream, publish_api_change
+from services.csrf import csrf_rejection_detail, normalize_origin
 from runtime_config import (
     resolve_app_environment,
     trusted_http_hosts,
@@ -148,6 +149,9 @@ for origin in list(explicit_origins):
             explicit_origins.append(candidate)
 if not explicit_origins and not allow_insecure_cors:
     explicit_origins.extend(["http://localhost:3000", "http://127.0.0.1:3000"])
+trusted_browser_origins = frozenset(
+    origin for value in explicit_origins if (origin := normalize_origin(value))
+)
 
 if explicit_origins:
     app.add_middleware(
@@ -283,11 +287,13 @@ async def legacy_public_upload(filename: str, request: Request):
     return await public_upload(filename, request)
 
 
-UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 CSRF_EXEMPT_PATHS = {
     "/api/auth/login",
     "/api/auth/register",
-    "/api/auth/refresh",
+    "/api/auth/mobile/login",
+    "/api/auth/mobile/register",
+    "/api/auth/mobile/refresh",
+    "/api/auth/mobile/logout",
     "/api/auth/forgot-password",
     "/api/auth/reset-password",
 }
@@ -295,21 +301,13 @@ CSRF_EXEMPT_PATHS = {
 
 @app.middleware("http")
 async def csrf_protection(request, call_next):
-    path = request.url.path
-    has_auth_cookie = bool(request.cookies.get("access_token") or request.cookies.get("refresh_token"))
-    if (
-        request.method.upper() in UNSAFE_METHODS
-        and path.startswith("/api/")
-        and path not in CSRF_EXEMPT_PATHS
-        and has_auth_cookie
-    ):
-        cookie_token = request.cookies.get("csrf_token")
-        header_token = request.headers.get("x-csrf-token")
-        if not cookie_token or not header_token or cookie_token != header_token:
-            return JSONResponse(
-                status_code=403,
-                content={"detail": "CSRF token missing or invalid"},
-            )
+    rejection = csrf_rejection_detail(
+        request,
+        trusted_browser_origins,
+        CSRF_EXEMPT_PATHS,
+    )
+    if rejection:
+        return JSONResponse(status_code=403, content={"detail": rejection})
     return await call_next(request)
 
 

--- a/backend/services/csrf.py
+++ b/backend/services/csrf.py
@@ -1,0 +1,67 @@
+"""Browser request checks for cookie-authenticated API mutations."""
+from __future__ import annotations
+
+import secrets
+from collections.abc import Collection
+from urllib.parse import urlparse
+
+
+UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def normalize_origin(value: str | None) -> str:
+    raw = str(value or "").strip()
+    if not raw or raw.lower() == "null":
+        return ""
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return ""
+    host = parsed.hostname.lower().rstrip(".")
+    default_port = 443 if parsed.scheme == "https" else 80
+    try:
+        parsed_port = parsed.port
+    except ValueError:
+        return ""
+    port = f":{parsed_port}" if parsed_port and parsed_port != default_port else ""
+    return f"{parsed.scheme}://{host}{port}"
+
+
+def csrf_rejection_detail(
+    request,
+    allowed_origins: Collection[str],
+    exempt_paths: Collection[str],
+) -> str | None:
+    """Return a safe error detail or ``None`` when the request may proceed."""
+    method = str(request.method or "").upper()
+    path = request.url.path
+    if method not in UNSAFE_METHODS or not path.startswith("/api/"):
+        return None
+
+    fetch_site = str(request.headers.get("sec-fetch-site", "")).strip().lower()
+    if fetch_site == "cross-site":
+        return "Untrusted request origin"
+
+    origin_header = request.headers.get("origin")
+    if origin_header is not None:
+        origin = normalize_origin(origin_header)
+        trusted = {normalize_origin(value) for value in allowed_origins}
+        trusted.discard("")
+        if not origin or origin not in trusted:
+            return "Untrusted request origin"
+
+    if path in exempt_paths:
+        return None
+    has_auth_cookie = bool(
+        request.cookies.get("access_token") or request.cookies.get("refresh_token")
+    )
+    if not has_auth_cookie:
+        return None
+    cookie_token = request.cookies.get("csrf_token")
+    header_token = request.headers.get("x-csrf-token")
+    if (
+        not cookie_token
+        or not header_token
+        or not secrets.compare_digest(str(cookie_token), str(header_token))
+    ):
+        return "CSRF token missing or invalid"
+    return None

--- a/backend/tests/test_auth_security_unit.py
+++ b/backend/tests/test_auth_security_unit.py
@@ -1,0 +1,349 @@
+import asyncio
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import jwt
+import pytest
+from fastapi import HTTPException, Response
+from pymongo.errors import DuplicateKeyError
+
+import auth
+from auth import (
+    create_access_token,
+    create_refresh_token,
+    get_current_user,
+    hash_token,
+    refresh_expires_at,
+    set_auth_cookies,
+)
+from routes.auth_routes import _rotate_session
+from services.csrf import csrf_rejection_detail, normalize_origin
+
+
+class _Documents:
+    def __init__(self, documents=None):
+        self.documents = [deepcopy(document) for document in (documents or [])]
+        self.lock = asyncio.Lock()
+
+    @staticmethod
+    def _matches(document, query):
+        for key, expected in query.items():
+            if key == "$or":
+                if not any(_Documents._matches(document, branch) for branch in expected):
+                    return False
+                continue
+            actual = document.get(key)
+            if isinstance(expected, dict) and "$ne" in expected:
+                if actual == expected["$ne"]:
+                    return False
+            elif actual != expected:
+                return False
+        return True
+
+    async def insert_one(self, document):
+        async with self.lock:
+            if any(
+                row.get("id") == document.get("id") or row.get("jti") == document.get("jti")
+                for row in self.documents
+            ):
+                raise DuplicateKeyError("duplicate session")
+            self.documents.append(deepcopy(document))
+
+    async def find_one(self, query, *_args, **_kwargs):
+        async with self.lock:
+            for document in self.documents:
+                if self._matches(document, query):
+                    return deepcopy(document)
+        return None
+
+    async def find_one_and_update(self, query, update, **_kwargs):
+        async with self.lock:
+            for document in self.documents:
+                if self._matches(document, query):
+                    before = deepcopy(document)
+                    document.update(deepcopy(update["$set"]))
+                    return before
+        return None
+
+    async def update_one(self, query, update):
+        async with self.lock:
+            for document in self.documents:
+                if self._matches(document, query):
+                    document.update(deepcopy(update["$set"]))
+                    return SimpleNamespace(matched_count=1)
+        return SimpleNamespace(matched_count=0)
+
+    async def update_many(self, query, update):
+        matched = 0
+        async with self.lock:
+            for document in self.documents:
+                if self._matches(document, query):
+                    document.update(deepcopy(update["$set"]))
+                    matched += 1
+        return SimpleNamespace(modified_count=matched)
+
+
+class _Users:
+    def __init__(self, user):
+        self.user = deepcopy(user)
+
+    async def find_one(self, query, *_args, **_kwargs):
+        if self.user and self.user.get("id") == query.get("id"):
+            return deepcopy(self.user)
+        return None
+
+
+def _request(*, access="", refresh="", csrf="", origin=None, fetch_site=None, user_agent="browser-a"):
+    headers = {"user-agent": user_agent}
+    if csrf:
+        headers["x-csrf-token"] = csrf
+    if origin is not None:
+        headers["origin"] = origin
+    if fetch_site is not None:
+        headers["sec-fetch-site"] = fetch_site
+    return SimpleNamespace(
+        method="POST",
+        url=SimpleNamespace(path="/api/auth/refresh"),
+        headers=headers,
+        cookies={
+            key: value
+            for key, value in {
+                "access_token": access,
+                "refresh_token": refresh,
+                "csrf_token": csrf,
+            }.items()
+            if value
+        },
+        client=SimpleNamespace(host="198.51.100.10"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _jwt_secret(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "unit-test-auth-secret-that-is-long-enough")
+
+
+def test_https_auth_cookies_are_lax_secure_and_shared_across_canonical_hosts(monkeypatch):
+    monkeypatch.setenv("FRONTEND_URL", "https://lionsquad.at")
+    monkeypatch.setenv("AUTH_COOKIE_DOMAIN", ".lionsquad.at")
+    response = Response()
+
+    set_auth_cookies(response, "access", "refresh", "csrf")
+
+    cookies = [
+        value.decode("latin-1")
+        for name, value in response.raw_headers
+        if name.lower() == b"set-cookie"
+    ]
+    assert len(cookies) == 3
+    assert all("Domain=.lionsquad.at" in value for value in cookies)
+    assert all("SameSite=lax" in value for value in cookies)
+    assert all("Secure" in value for value in cookies)
+    assert "HttpOnly" in cookies[0] and "HttpOnly" in cookies[1]
+    assert "HttpOnly" not in cookies[2]
+
+
+def test_cookie_domain_must_match_frontend_host(monkeypatch):
+    monkeypatch.setenv("FRONTEND_URL", "https://lionsquad.at")
+    monkeypatch.setenv("AUTH_COOKIE_DOMAIN", ".attacker.example")
+
+    with pytest.raises(RuntimeError, match="must contain"):
+        set_auth_cookies(Response(), "access", "refresh", "csrf")
+
+
+def test_csrf_checks_origin_fetch_metadata_and_refresh_token_pair():
+    allowed = {"https://lionsquad.at", "https://www.lionsquad.at"}
+    exempt = {"/api/auth/login"}
+    request = _request(refresh="refresh", csrf="same", origin="https://www.lionsquad.at")
+
+    assert csrf_rejection_detail(request, allowed, exempt) is None
+    request.headers["x-csrf-token"] = "different"
+    assert csrf_rejection_detail(request, allowed, exempt) == "CSRF token missing or invalid"
+    request.headers["origin"] = "https://attacker.example"
+    assert csrf_rejection_detail(request, allowed, exempt) == "Untrusted request origin"
+    request.headers.pop("origin")
+    request.headers["sec-fetch-site"] = "cross-site"
+    assert csrf_rejection_detail(request, allowed, exempt) == "Untrusted request origin"
+
+
+def test_cross_site_login_is_rejected_even_when_path_is_csrf_exempt():
+    request = _request(origin="https://attacker.example")
+    request.url.path = "/api/auth/login"
+
+    assert csrf_rejection_detail(
+        request,
+        {"https://lionsquad.at"},
+        {"/api/auth/login"},
+    ) == "Untrusted request origin"
+    assert normalize_origin("https://LIONSQUAD.AT:443/") == "https://lionsquad.at"
+    assert normalize_origin("https://lionsquad.at:invalid") == ""
+
+
+def test_parallel_refresh_replays_return_one_deterministic_successor():
+    async def scenario():
+        user = {
+            "id": "user-1",
+            "email": "player@example.test",
+            "role": "player",
+            "is_active": True,
+        }
+        old_jti = "old-session"
+        expiry = refresh_expires_at()
+        old_token = create_refresh_token(user["id"], old_jti, old_jti, expiry)
+        sessions = _Documents([{
+            "id": "old-record",
+            "jti": old_jti,
+            "family_id": old_jti,
+            "user_id": user["id"],
+            "token_hash": hash_token(old_token),
+            "revoked": False,
+            "expires_at": expiry,
+        }])
+        db = SimpleNamespace(refresh_tokens=sessions, users=_Users(user))
+        request = _request(refresh=old_token)
+
+        first, second = await asyncio.gather(
+            _rotate_session(db, old_token, request),
+            _rotate_session(db, old_token, request),
+        )
+
+        assert first[2] == second[2]
+        replacement = jwt.decode(first[2], auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+        assert replacement["fid"] == old_jti
+        active = [row for row in sessions.documents if row.get("revoked") is not True]
+        assert [row["jti"] for row in active] == [replacement["jti"]]
+        for result in (first, second):
+            access = jwt.decode(result[1], auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+            assert access["sid"] == replacement["jti"]
+
+    asyncio.run(scenario())
+
+
+def test_legacy_refresh_token_is_migrated_into_a_session_family():
+    async def scenario():
+        user = {
+            "id": "user-1",
+            "email": "player@example.test",
+            "role": "player",
+            "is_active": True,
+        }
+        expiry = refresh_expires_at()
+        legacy_token = jwt.encode({
+            "sub": user["id"],
+            "jti": "legacy-session",
+            "exp": expiry,
+            "type": "refresh",
+        }, auth.get_jwt_secret(), algorithm=auth.JWT_ALGORITHM)
+        sessions = _Documents([{
+            "id": "legacy-record",
+            "jti": "legacy-session",
+            "user_id": user["id"],
+            "token_hash": hash_token(legacy_token),
+            "revoked": False,
+            "expires_at": expiry,
+        }])
+        db = SimpleNamespace(refresh_tokens=sessions, users=_Users(user))
+
+        _user, access, refresh = await _rotate_session(db, legacy_token, _request(refresh=legacy_token))
+
+        refresh_payload = jwt.decode(refresh, auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+        access_payload = jwt.decode(access, auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+        assert refresh_payload["fid"] == "legacy-session"
+        assert access_payload["sid"] == refresh_payload["jti"]
+
+    asyncio.run(scenario())
+
+
+def test_refresh_reuse_outside_the_same_client_grace_revokes_only_that_family():
+    async def scenario():
+        user = {
+            "id": "user-1",
+            "email": "player@example.test",
+            "role": "player",
+            "is_active": True,
+        }
+        expiry = refresh_expires_at()
+        token = create_refresh_token(user["id"], "family-a", "family-a", expiry)
+        sessions = _Documents([
+            {
+                "id": "family-a-old",
+                "jti": "family-a",
+                "family_id": "family-a",
+                "user_id": user["id"],
+                "token_hash": hash_token(token),
+                "revoked": False,
+                "expires_at": expiry,
+            },
+            {
+                "id": "family-b-active",
+                "jti": "family-b",
+                "family_id": "family-b",
+                "user_id": user["id"],
+                "token_hash": "other",
+                "revoked": False,
+                "expires_at": expiry,
+            },
+        ])
+        db = SimpleNamespace(refresh_tokens=sessions, users=_Users(user))
+        await _rotate_session(db, token, _request(refresh=token, user_agent="browser-a"))
+
+        with pytest.raises(HTTPException) as exc:
+            await _rotate_session(db, token, _request(refresh=token, user_agent="browser-b"))
+
+        assert exc.value.status_code == 401
+        family_a = [row for row in sessions.documents if row.get("family_id") == "family-a"]
+        family_b = [row for row in sessions.documents if row.get("family_id") == "family-b"]
+        assert family_a and all(row.get("revoked") is True for row in family_a)
+        assert family_b[0].get("revoked") is False
+
+    asyncio.run(scenario())
+
+
+def test_access_token_is_rejected_after_its_session_is_revoked(monkeypatch):
+    async def scenario():
+        expiry = datetime.now(timezone.utc) + timedelta(days=1)
+        session = {"jti": "session-1", "user_id": "user-1", "expires_at": expiry}
+        db = SimpleNamespace(
+            refresh_tokens=SimpleNamespace(find_one=AsyncMock(return_value=session)),
+            users=SimpleNamespace(find_one=AsyncMock(return_value={
+                "id": "user-1", "role": "player", "is_active": True,
+            })),
+            memberships=SimpleNamespace(find_one=AsyncMock(return_value=None)),
+            tournament_staff_assignments=SimpleNamespace(count_documents=AsyncMock(return_value=0)),
+        )
+        monkeypatch.setattr(auth, "get_db", lambda: db)
+        token = create_access_token("user-1", "player@example.test", "player", "session-1")
+        request = SimpleNamespace(cookies={"access_token": token}, headers={})
+
+        assert (await get_current_user(request))["id"] == "user-1"
+        db.refresh_tokens.find_one.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(request)
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Session expired"
+
+    asyncio.run(scenario())
+
+
+def test_inactive_account_is_rejected_at_the_authenticated_boundary(monkeypatch):
+    async def scenario():
+        db = SimpleNamespace(
+            refresh_tokens=SimpleNamespace(find_one=AsyncMock(return_value={
+                "jti": "session-1",
+                "expires_at": datetime.now(timezone.utc) + timedelta(days=1),
+            })),
+            users=SimpleNamespace(find_one=AsyncMock(return_value={
+                "id": "user-1", "role": "player", "is_active": False,
+            })),
+        )
+        monkeypatch.setattr(auth, "get_db", lambda: db)
+        token = create_access_token("user-1", "player@example.test", "player", "session-1")
+
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(SimpleNamespace(cookies={"access_token": token}, headers={}))
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Account is inactive"
+
+    asyncio.run(scenario())

--- a/backend/tests/test_auth_security_unit.py
+++ b/backend/tests/test_auth_security_unit.py
@@ -9,10 +9,11 @@ import pytest
 from fastapi import HTTPException, Response
 from pymongo.errors import DuplicateKeyError
 
-import auth
 from auth import (
+    JWT_ALGORITHM,
     create_access_token,
     create_refresh_token,
+    get_jwt_secret,
     get_current_user,
     hash_token,
     refresh_expires_at,
@@ -210,12 +211,12 @@ def test_parallel_refresh_replays_return_one_deterministic_successor():
         )
 
         assert first[2] == second[2]
-        replacement = jwt.decode(first[2], auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+        replacement = jwt.decode(first[2], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
         assert replacement["fid"] == old_jti
         active = [row for row in sessions.documents if row.get("revoked") is not True]
         assert [row["jti"] for row in active] == [replacement["jti"]]
         for result in (first, second):
-            access = jwt.decode(result[1], auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+            access = jwt.decode(result[1], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
             assert access["sid"] == replacement["jti"]
 
     asyncio.run(scenario())
@@ -235,7 +236,7 @@ def test_legacy_refresh_token_is_migrated_into_a_session_family():
             "jti": "legacy-session",
             "exp": expiry,
             "type": "refresh",
-        }, auth.get_jwt_secret(), algorithm=auth.JWT_ALGORITHM)
+        }, get_jwt_secret(), algorithm=JWT_ALGORITHM)
         sessions = _Documents([{
             "id": "legacy-record",
             "jti": "legacy-session",
@@ -248,8 +249,8 @@ def test_legacy_refresh_token_is_migrated_into_a_session_family():
 
         _user, access, refresh = await _rotate_session(db, legacy_token, _request(refresh=legacy_token))
 
-        refresh_payload = jwt.decode(refresh, auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
-        access_payload = jwt.decode(access, auth.get_jwt_secret(), algorithms=[auth.JWT_ALGORITHM])
+        refresh_payload = jwt.decode(refresh, get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+        access_payload = jwt.decode(access, get_jwt_secret(), algorithms=[JWT_ALGORITHM])
         assert refresh_payload["fid"] == "legacy-session"
         assert access_payload["sid"] == refresh_payload["jti"]
 
@@ -313,7 +314,7 @@ def test_access_token_is_rejected_after_its_session_is_revoked(monkeypatch):
             memberships=SimpleNamespace(find_one=AsyncMock(return_value=None)),
             tournament_staff_assignments=SimpleNamespace(count_documents=AsyncMock(return_value=0)),
         )
-        monkeypatch.setattr(auth, "get_db", lambda: db)
+        monkeypatch.setattr("auth.get_db", lambda: db)
         token = create_access_token("user-1", "player@example.test", "player", "session-1")
         request = SimpleNamespace(cookies={"access_token": token}, headers={})
 
@@ -338,7 +339,7 @@ def test_inactive_account_is_rejected_at_the_authenticated_boundary(monkeypatch)
                 "id": "user-1", "role": "player", "is_active": False,
             })),
         )
-        monkeypatch.setattr(auth, "get_db", lambda: db)
+        monkeypatch.setattr("auth.get_db", lambda: db)
         token = create_access_token("user-1", "player@example.test", "player", "session-1")
 
         with pytest.raises(HTTPException) as exc:

--- a/backend/tests/test_runtime_security_unit.py
+++ b/backend/tests/test_runtime_security_unit.py
@@ -38,6 +38,23 @@ def test_production_rejects_demo_and_reset_flags():
         validate_runtime_environment({**base, "SEED_DEMO": "true"})
 
 
+def test_production_requires_https_public_origins():
+    base = {
+        "APP_ENV": "production",
+        "JWT_SECRET": "a" * 48,
+        "FRONTEND_URL": "http://lionsquad.at",
+    }
+    with pytest.raises(RuntimeError, match="FRONTEND_URL must use https"):
+        validate_runtime_environment(base)
+
+    with pytest.raises(RuntimeError, match="CORS_ORIGINS"):
+        validate_runtime_environment({
+            **base,
+            "FRONTEND_URL": "https://lionsquad.at",
+            "CORS_ORIGINS": "http://www.lionsquad.at",
+        })
+
+
 def test_development_still_rejects_api_reset_flag():
     with pytest.raises(RuntimeError, match="not supported by the API process"):
         validate_runtime_environment({"APP_ENV": "development", "TLS_RESET": "true"})

--- a/backend/tests/test_security_hardening_unit.py
+++ b/backend/tests/test_security_hardening_unit.py
@@ -115,13 +115,16 @@ def test_untrusted_direct_peer_cannot_override_client_or_scheme():
 
 
 def test_internal_nginx_preserves_tls_and_sanitizes_forwarded_host():
-    nginx = (Path(__file__).resolve().parents[2] / "frontend" / "nginx.conf").read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parents[2]
+    nginx = (root / "frontend" / "nginx.conf").read_text(encoding="utf-8")
+    route_contract = (root / "scripts" / "check-public-routes.sh").read_text(encoding="utf-8")
 
     assert "map $http_x_forwarded_proto $tls_forwarded_proto" in nginx
     assert "proxy_set_header X-Forwarded-Proto $scheme;" not in nginx
     assert nginx.count("proxy_set_header X-Forwarded-Host $host;") == 7
     assert 'if ($host = "www.lionsquad.at")' in nginx
     assert "return 308 https://lionsquad.at$request_uri;" in nginx
+    assert '"www.lionsquad.at" "308"' in route_contract
 
 
 def test_internal_nginx_uses_one_nonce_based_csp_without_external_fonts():

--- a/backend/tests/test_security_hardening_unit.py
+++ b/backend/tests/test_security_hardening_unit.py
@@ -120,6 +120,8 @@ def test_internal_nginx_preserves_tls_and_sanitizes_forwarded_host():
     assert "map $http_x_forwarded_proto $tls_forwarded_proto" in nginx
     assert "proxy_set_header X-Forwarded-Proto $scheme;" not in nginx
     assert nginx.count("proxy_set_header X-Forwarded-Host $host;") == 7
+    assert 'if ($host = "www.lionsquad.at")' in nginx
+    assert "return 308 https://lionsquad.at$request_uri;" in nginx
 
 
 def test_internal_nginx_uses_one_nonce_based_csp_without_external_fonts():

--- a/frontend/e2e/public.spec.js
+++ b/frontend/e2e/public.spec.js
@@ -198,6 +198,37 @@ test("login shows inline validation and blocks simultaneous requests", async ({ 
   expect(submissions).toBe(1);
 });
 
+test("logout keeps the visible session when server revocation fails", async ({ page }) => {
+  await mockPublicChrome(page);
+  const user = { id: "user-1", username: "testplayer", display_name: "Test Player", role: "player" };
+  let loggedIn = true;
+  let attempts = 0;
+  await page.route("**/api/auth/me", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(loggedIn ? user : null),
+  }));
+  await page.route("**/api/auth/logout", async (route) => {
+    attempts += 1;
+    if (attempts === 1) {
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ detail: "Logout derzeit nicht möglich" }) });
+      return;
+    }
+    loggedIn = false;
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/403");
+  await acceptCookies(page);
+  await expect(page.getByTestId("nav-logout")).toBeVisible();
+  await page.getByTestId("nav-logout").click();
+  await expect(page.getByText("Logout derzeit nicht möglich")).toBeVisible();
+  await expect(page.getByTestId("nav-logout")).toBeVisible();
+
+  await page.getByTestId("nav-logout").click();
+  await expect(page.getByTestId("nav-logout")).toHaveCount(0);
+  expect(attempts).toBe(2);
+});
+
 test("registration validates consent and exposes a single API failure", async ({ page }) => {
   await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
   let submissions = 0;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -86,7 +86,7 @@ server {
   sub_filter '<script type="application/ld+json">' '<script type="application/ld+json" nonce="$request_id">';
 
   if ($host = "www.lionsquad.at") {
-    return 301 https://lionsquad.at$request_uri;
+    return 308 https://lionsquad.at$request_uri;
   }
 
   location = /health {

--- a/frontend/src/components/tls/AdminLayout.jsx
+++ b/frontend/src/components/tls/AdminLayout.jsx
@@ -272,7 +272,7 @@ export function AdminLayout({ children }) {
               <div className="text-[10px] text-[#29B6E8] uppercase tracking-widest">{user?.role}</div>
             </div>
             <button
-              onClick={async () => { await logout(); nav("/"); }}
+              onClick={async () => { if (await logout()) nav("/"); }}
               data-testid="admin-logout"
               className="inline-flex items-center gap-1.5 px-2 py-2 text-[#FF3B30] border border-[#FF3B30]/30 hover:bg-[#FF3B30]/10 rounded-sm text-[10px] font-bold uppercase tracking-wider shrink-0"
               aria-label="Logout"

--- a/frontend/src/components/tls/PublicLayout.jsx
+++ b/frontend/src/components/tls/PublicLayout.jsx
@@ -96,7 +96,7 @@ export function PublicLayout({ children }) {
                 </Link>
                 <button
                   data-testid="nav-logout"
-                  onClick={async () => { await logout(); nav("/"); }}
+                  onClick={async () => { if (await logout()) nav("/"); }}
                   className="inline-flex items-center gap-1.5 px-3 py-2 border border-[#FF3B30]/35 text-[#FF3B30] hover:bg-[#FF3B30]/10 transition rounded-sm text-xs font-bold uppercase tracking-wider"
                   aria-label="Logout"
                 >
@@ -154,7 +154,12 @@ export function PublicLayout({ children }) {
                     <Link to="/dashboard" onClick={closeMobile} className="block px-3 py-2 text-sm font-semibold uppercase tracking-wider text-white/80">Mein Bereich</Link>
                     <button
                       type="button"
-                      onClick={async () => { await logout(); closeMobile(); nav("/"); }}
+                      onClick={async () => {
+                        if (await logout()) {
+                          closeMobile();
+                          nav("/");
+                        }
+                      }}
                       className="w-full text-left px-3 py-2 text-sm font-semibold uppercase tracking-wider text-[#FF3B30]"
                     >
                       <LogOut className="w-3.5 h-3.5 inline mr-1.5" /> Logout

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback } from "rea
 import { api, formatApiError } from "@/lib/api";
 import { normalizeApiPath } from "@/lib/apiInvalidation";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
+import { toast } from "sonner";
 
 const AuthContext = createContext(null);
 
@@ -65,8 +66,16 @@ export function AuthProvider({ children }) {
   };
 
   const logout = async () => {
-    try { await api.post("/auth/logout"); } catch {}
-    setUser(null);
+    try {
+      await api.post("/auth/logout");
+      setUser(null);
+      return true;
+    } catch (e) {
+      const msg = formatApiError(e.response?.data?.detail) || "Logout fehlgeschlagen.";
+      setError(msg);
+      toast.error(msg);
+      return false;
+    }
   };
 
   const isAdmin = user && ["tournament_admin", "club_admin", "superadmin"].includes(user.role);

--- a/frontend/src/pages/user/PrivacyAccountPage.jsx
+++ b/frontend/src/pages/user/PrivacyAccountPage.jsx
@@ -42,8 +42,7 @@ export default function PrivacyAccountPage() {
     try {
       await api.post("/dsgvo/anonymize-me");
       toast.success("Dein Account wurde anonymisiert.");
-      await logout();
-      nav("/");
+      if (await logout()) nav("/");
     } catch (err) { toast.error(formatRequestError(err, "Anonymisierung fehlgeschlagen.")); }
     setBusy(false);
   };

--- a/scripts/check-public-routes.sh
+++ b/scripts/check-public-routes.sh
@@ -53,12 +53,13 @@ expect_redirect() {
   local path="$1"
   local target="$2"
   local host="${3:-lionsquad.at}"
+  local expected_status="${4:-301}"
   local headers status location
   headers="$(request_headers "$path" "$host")"
   status="$(printf '%s\n' "$headers" | awk 'NR == 1 { print $2 }')"
   location="$(printf '%s\n' "$headers" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }')"
-  test "$status" = "301" && test "$location" = "$target" || {
-    printf 'Expected 301 -> %s for %s, received %s -> %s\n%s\n' "$target" "$path" "$status" "$location" "$headers" >&2
+  test "$status" = "$expected_status" && test "$location" = "$target" || {
+    printf 'Expected %s -> %s for %s, received %s -> %s\n%s\n' "$expected_status" "$target" "$path" "$status" "$location" "$headers" >&2
     return 1
   }
 }
@@ -131,7 +132,7 @@ for path in /elements/blockquote/ /product/demo /portfolio/demo /tag/demo /categ
   expect_gone "$path"
 done
 
-expect_redirect "/esports?view=live" "https://lionsquad.at/esports?view=live" "www.lionsquad.at"
+expect_redirect "/esports?view=live" "https://lionsquad.at/esports?view=live" "www.lionsquad.at" "308"
 expect_nonce_csp
 
 printf 'Public route contract passed.\n'


### PR DESCRIPTION
## Zusammenfassung

- bindet Access-Tokens an widerrufbare Server-Sessions, weist inaktive/gesperrte Konten zentral ab und synchronisiert die Rollenliste bei Rollenwechseln
- rotiert Refresh-Tokens atomar in Session-Familien; parallele identische Refreshes erhalten innerhalb eines engen, clientgebundenen Fensters denselben Nachfolger, echte Wiederverwendung widerruft nur die betroffene Familie
- migriert bestehende Refresh-Tokens ohne Session-Familie beim ersten Refresh automatisch
- härtet Cookie-Attribute und Domainvalidierung für `lionsquad.at`/`www`, schützt auch Refresh per CSRF und prüft Browser-Origin sowie Fetch-Metadaten
- verwendet für den kanonischen `www`-Wechsel `308`, damit Methode und Body erhalten bleiben
- meldet die UI nur nach bestätigtem Server-Logout ab und dokumentiert die Reverse-Proxy-Anforderungen

## Verifikation

- `python -m pytest -q`: **232 passed**, 282 umgebungsabhängige Live-Tests übersprungen
- gezielte Auth-/Proxy-Suite: **30 passed** (vor den zwei zusätzlichen Legacy-/Reuse-Regressionen)
- Playwright vollständig: **54 passed**, 8 Live-Admin-Tests erwartungsgemäß übersprungen; Desktop und Mobile
- Frontend Unit: **10 passed**
- Frontend Produktionsbuild: erfolgreich
- Frontend High/Critical Audit: ohne unakzeptierte Befunde
- Mobile Typecheck: erfolgreich
- Mobile Security: **3 passed**
- Mobile Audit: ohne unakzeptierte Befunde; zwei dokumentierte `image-size`-Ausnahmen bis 2026-09-30
- OpenAPI: **358 Pfade**
- Live-Read-only-Befund vor Deployment: Apex-Health `200`; `www` aktuell noch `301` und nach Deployment erneut auf `308` zu prüfen

## Deployment-Hinweis

Bestehende Sessions werden beim nächsten Refresh migriert. Der äußere Reverse Proxy muss `Host`, `X-Forwarded-For`, `X-Forwarded-Proto` und den Browser-Header `Origin` korrekt bzw. unverändert weitergeben. Nach Merge und `update.sh` bitte `www`-Redirect sowie einen echten Login → Ablauf/Refresh → Logout-Flow prüfen.
