### PR TITLE
fix: freie Turnierbäume wieder sicher aufbauen

### DIFF
--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -190,6 +190,14 @@ def _can_create_initial_stage_preview(tournament: dict) -> bool:
     return (tournament.get("format") or "single_elim") in STAGE_AUTO_PREVIEW_FORMATS
 
 
+def _can_rebuild_bracket_from_format(tournament: dict) -> bool:
+    """Return whether either bracket engine supports the tournament format."""
+    return (
+        _can_create_initial_legacy_preview(tournament)
+        or _can_create_initial_stage_preview(tournament)
+    )
+
+
 def _legacy_plan_key(match: dict) -> tuple:
     return (
         "legacy",
@@ -2761,7 +2769,7 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
     tid = await _resolve_tid(tid)
     tournament = await _ensure_tournament_unlocked(db, tid)
     await require_tournament_staff_permission(me, tid, STRUCTURE_STAFF_ROLES)
-    if not _can_create_initial_legacy_preview(tournament):
+    if not _can_rebuild_bracket_from_format(tournament):
         raise HTTPException(status_code=400, detail="Für dieses Format gibt es keinen automatischen Format-Bracket-Generator.")
     if tournament.get("status") in ("live", "paused", "completed", "results_published", "archived") and not force:
         raise HTTPException(status_code=409, detail="Laufende oder beendete Turniere brauchen force=true.")
@@ -2783,11 +2791,6 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
         raise HTTPException(status_code=409, detail="Es gibt bereits echte Spiele. Mit force=true neu aufbauen.")
 
     v2_match_ids = [match["id"] for match in v2_matches if match.get("id")]
-    await db.matches.delete_many({"tournament_id": tid})
-    await db.matches_v2.delete_many({"tournament_id": tid})
-    if v2_match_ids:
-        await db.match_reports_v2.delete_many({"match_id": {"$in": v2_match_ids}})
-    await db.tournament_stages.delete_many({"tournament_id": tid})
 
     stage_defaults = _stage_defaults_for_tournament_format(tournament, body)
     if stage_defaults:
@@ -2810,8 +2813,28 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
         if not matches:
             raise HTTPException(status_code=400, detail="Die Struktur erzeugt keine Spiele.")
         _apply_match_plan(matches, match_plan, _v2_plan_key)
-        await db.tournament_stages.insert_one(stage)
-        await db.matches_v2.insert_many(matches)
+
+        # Build and validate the replacement before touching the active bracket.
+        # Insert the new generation first so a database write failure can be
+        # cleaned up without losing the previous structure.
+        new_match_ids = [match["id"] for match in matches if match.get("id")]
+        try:
+            await db.tournament_stages.insert_one(stage)
+            await db.matches_v2.insert_many(matches)
+        except Exception:
+            if new_match_ids:
+                await db.matches_v2.delete_many({"id": {"$in": new_match_ids}})
+            await db.tournament_stages.delete_one({"id": stage["id"]})
+            raise
+
+        await db.matches.delete_many({"tournament_id": tid})
+        if v2_match_ids:
+            await db.matches_v2.delete_many({"id": {"$in": v2_match_ids}})
+            await db.match_reports_v2.delete_many({"match_id": {"$in": v2_match_ids}})
+        await db.tournament_stages.delete_many({
+            "tournament_id": tid,
+            "id": {"$ne": stage["id"]},
+        })
         await _audit_tournament_action(
             db,
             "tournament.bracket.rebuild_from_structure",
@@ -2840,9 +2863,13 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
         tournament,
         me.get("id"),
         preview=preview,
-        force=False,
+        force=force,
         set_live=False,
     )
+    if v2_match_ids:
+        await db.matches_v2.delete_many({"id": {"$in": v2_match_ids}})
+        await db.match_reports_v2.delete_many({"match_id": {"$in": v2_match_ids}})
+    await db.tournament_stages.delete_many({"tournament_id": tid})
     await _audit_tournament_action(
         db,
         "tournament.bracket.rebuild_from_format",

--- a/backend/tests/test_tournament_initial_preview_unit.py
+++ b/backend/tests/test_tournament_initial_preview_unit.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from routes.tournament_routes import (
     _can_create_initial_stage_preview,
+    _can_rebuild_bracket_from_format,
     _create_initial_bracket_preview,
     _finalize_bracket_for_checkin,
     _can_create_initial_legacy_preview,
@@ -94,6 +95,9 @@ def test_initial_preview_skips_unsupported_or_too_large_formats():
     assert _can_create_initial_stage_preview({"format": "battle_royale", "max_participants": 8}) is True
     assert _can_create_initial_stage_preview({"format": "custom_bracket", "max_participants": 8}) is True
     assert _can_create_initial_stage_preview({"format": "ffa_custom_bracket", "max_participants": 8}) is True
+    assert _can_rebuild_bracket_from_format({"format": "custom_bracket", "max_participants": 64}) is True
+    assert _can_rebuild_bracket_from_format({"format": "ffa_custom_bracket", "max_participants": 64}) is True
+    assert _can_rebuild_bracket_from_format({"format": "time_trial", "max_participants": 64}) is False
 
 
 def test_mixed_preview_fills_free_slots_with_preview_seeds():

--- a/backend/tests/test_tournament_operations_unit.py
+++ b/backend/tests/test_tournament_operations_unit.py
@@ -2,7 +2,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import HTTPException
@@ -14,6 +14,17 @@ from routes.station_routes import (
 )
 from services.match_reminder import _uses_actual_start_notifications
 from models import RegistrationUpdate, TournamentCreate, TournamentStageCreate
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    async def to_list(self, _limit):
+        return list(self.rows)
 
 
 def _legacy_match(**updates):
@@ -391,3 +402,194 @@ def test_tournament_stage_creation_replay_reuses_existing_document(monkeypatch):
     assert "creation_key" not in result
     stages.insert_one.assert_not_awaited()
     audit.assert_not_awaited()
+
+
+def _bracket_rebuild_db(*, tournament, legacy_matches=None, v2_matches=None,
+                        existing_stage=None, registrations=None):
+    matches = SimpleNamespace(
+        find=Mock(return_value=_Cursor(legacy_matches or [])),
+        delete_many=AsyncMock(),
+        insert_many=AsyncMock(),
+    )
+    matches_v2 = SimpleNamespace(
+        find=Mock(return_value=_Cursor(v2_matches or [])),
+        delete_many=AsyncMock(),
+        insert_many=AsyncMock(),
+    )
+    stages = SimpleNamespace(
+        find_one=AsyncMock(return_value=existing_stage),
+        insert_one=AsyncMock(),
+        delete_one=AsyncMock(),
+        delete_many=AsyncMock(),
+    )
+    tournament_registrations = SimpleNamespace(
+        find=Mock(return_value=_Cursor(registrations or [])),
+    )
+    return SimpleNamespace(
+        tournaments=SimpleNamespace(find_one=AsyncMock(return_value=tournament)),
+        matches=matches,
+        matches_v2=matches_v2,
+        tournament_stages=stages,
+        tournament_registrations=tournament_registrations,
+        match_reports_v2=SimpleNamespace(delete_many=AsyncMock()),
+    )
+
+
+def _patch_bracket_rebuild_dependencies(monkeypatch, db):
+    async def identity(value):
+        return value
+
+    async def unlocked(db_arg, tournament_id):
+        return await db_arg.tournaments.find_one({"id": tournament_id}, {"_id": 0})
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "_resolve_tid", identity)
+    monkeypatch.setattr(tournament_routes, "_ensure_tournament_unlocked", unlocked)
+    monkeypatch.setattr(tournament_routes, "require_tournament_staff_permission", AsyncMock())
+    monkeypatch.setattr(tournament_routes, "_audit_tournament_action", AsyncMock())
+
+
+@pytest.mark.parametrize(("tournament_format", "stage_type", "match_type", "match_count"), [
+    ("custom_bracket", "custom_bracket", "duel", 63),
+    ("ffa_custom_bracket", "ffa_custom_bracket", "ffa", 17),
+])
+def test_rebuild_from_format_supports_64_player_custom_brackets(
+    monkeypatch,
+    tournament_format,
+    stage_type,
+    match_type,
+    match_count,
+):
+    tournament = {
+        "id": "t1",
+        "format": tournament_format,
+        "max_participants": 64,
+        "match_duration_minutes": 30,
+        "seeding_mode": "manual",
+        "status": "draft",
+    }
+    db = _bracket_rebuild_db(tournament=tournament)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+
+    result = asyncio.run(tournament_routes.rebuild_bracket_from_tournament_format(
+        "t1",
+        tournament_routes.TournamentBracketStructurePayload(
+            name="Turnierbaum",
+            stage_type=stage_type,
+            match_type=match_type,
+        ),
+        preview=True,
+        me={"id": "admin-1"},
+    ))
+
+    assert result["engine"] == "stages"
+    assert result["match_count"] == match_count
+    inserted_matches = db.matches_v2.insert_many.await_args.args[0]
+    assert len(inserted_matches) == match_count
+    assert all(match["is_preview"] for match in inserted_matches)
+    db.tournament_stages.insert_one.assert_awaited_once()
+
+
+def test_invalid_custom_schema_preserves_existing_bracket(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "ffa_custom_bracket",
+        "max_participants": 64,
+        "match_duration_minutes": 30,
+        "seeding_mode": "manual",
+        "status": "draft",
+    }
+    old_match = {
+        "id": "old-match",
+        "tournament_id": "t1",
+        "stage_id": "old-stage",
+        "is_preview": True,
+        "status": "preview",
+    }
+    old_stage = {
+        "id": "old-stage",
+        "tournament_id": "t1",
+        "number": 1,
+        "name": "Alter Baum",
+        "stage_type": "ffa_custom_bracket",
+        "match_type": "ffa",
+        "settings": {},
+    }
+    db = _bracket_rebuild_db(
+        tournament=tournament,
+        v2_matches=[old_match],
+        existing_stage=old_stage,
+    )
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(tournament_routes.rebuild_bracket_from_tournament_format(
+            "t1",
+            tournament_routes.TournamentBracketStructurePayload(
+                name="Neuer Baum",
+                stage_type="ffa_custom_bracket",
+                match_type="ffa",
+                settings={"schema": "[MAIN]\nA=[ungueltig]"},
+            ),
+            preview=True,
+            me={"id": "admin-1"},
+        ))
+
+    assert error.value.status_code == 400
+    assert "Ungültiger Slot-Ausdruck" in error.value.detail
+    db.matches.delete_many.assert_not_awaited()
+    db.matches_v2.delete_many.assert_not_awaited()
+    db.tournament_stages.delete_many.assert_not_awaited()
+    db.tournament_stages.insert_one.assert_not_awaited()
+    db.matches_v2.insert_many.assert_not_awaited()
+
+
+def test_custom_bracket_write_failure_cleans_new_generation_only(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "custom_bracket",
+        "max_participants": 8,
+        "match_duration_minutes": 30,
+        "seeding_mode": "manual",
+        "status": "draft",
+    }
+    old_match = {
+        "id": "old-match",
+        "tournament_id": "t1",
+        "stage_id": "old-stage",
+        "is_preview": True,
+        "status": "preview",
+    }
+    db = _bracket_rebuild_db(
+        tournament=tournament,
+        v2_matches=[old_match],
+        existing_stage={
+            "id": "old-stage",
+            "tournament_id": "t1",
+            "number": 1,
+            "stage_type": "custom_bracket",
+            "match_type": "duel",
+            "settings": {},
+        },
+    )
+    db.matches_v2.insert_many.side_effect = RuntimeError("database write failed")
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+
+    with pytest.raises(RuntimeError, match="database write failed"):
+        asyncio.run(tournament_routes.rebuild_bracket_from_tournament_format(
+            "t1",
+            tournament_routes.TournamentBracketStructurePayload(
+                stage_type="custom_bracket",
+                match_type="duel",
+            ),
+            preview=True,
+            me={"id": "admin-1"},
+        ))
+
+    db.tournament_stages.insert_one.assert_awaited_once()
+    cleanup_query = db.matches_v2.delete_many.await_args.args[0]
+    assert cleanup_query.get("id", {}).get("$in")
+    db.tournament_stages.delete_one.assert_awaited_once()
+    db.matches.delete_many.assert_not_awaited()
+    db.tournament_stages.delete_many.assert_not_awaited()
+    db.match_reports_v2.delete_many.assert_not_awaited()


### PR DESCRIPTION
## Was wurde geändert?

- akzeptiert freie und Mehrspieler-freie Turnierbäume im gemeinsamen Format-Rebuild-Endpunkt
- validiert und erzeugt die neue V2-Struktur, bevor bestehende Daten ersetzt werden
- räumt eine nur teilweise geschriebene neue Generation bei Datenbankfehlern wieder auf
- erhält bestehende Matchpläne beim erfolgreichen Neuaufbau
- deckt normale und Mehrspieler-Bäume mit 64 Plätzen sowie ungültige Schemas und Schreibfehler ab

## Root Cause

`POST /api/tournaments/{id}/bracket/from-format` prüfte nur den Legacy-Generator. `custom_bracket` und `ffa_custom_bracket` werden jedoch von der V2-Stage-Engine unterstützt und wurden deshalb fälschlich mit HTTP 400 abgewiesen. Außerdem wurden alte Matches und Phasen vor der Schema-Validierung gelöscht.

## Auswirkung

„Speichern & Struktur anwenden“ funktioniert wieder für beide freien Turnierbaum-Varianten. Fehlerhafte Schemas oder fehlgeschlagene neue Schreibvorgänge lassen den bisherigen Baum bestehen.

## Validierung

- `python -m compileall -q backend`
- `python -m pytest -m "not live" -q` → 236 bestanden, 5 übersprungen, 277 Live-Tests abgewählt
- gezielte Bracket-Suite → 44 bestanden

Closes #114