### PR TITLE
feat: Live-Invalidierungen scopen und reconnect-sicher machen

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -80,6 +80,27 @@ https://developers.cloudflare.com/cloudflare-challenges/challenge-types/javascri
 Externe Google-Fonts werden nicht geladen; die Seite verwendet lokale System-Fallbacks. Damit
 entsteht weder ein CSP-Fehler noch ein unangekuendigter Drittanbieter-Request fuer Schriften.
 
+## Live-Updates per SSE
+
+Web- und TV-Ansichten erhalten gezielte Aktualisierungssignale ueber
+`/api/changes/stream`. Der Stream laeuft hinter dem Reverse Proxy als Server-Sent Events (SSE):
+
+- Proxy-Buffering und Proxy-Cache muessen fuer genau diese Route deaktiviert bleiben.
+- Die Read-/Send-Timeouts muessen lang genug fuer dauerhafte Verbindungen sein.
+- `Last-Event-ID` muss unveraendert an das Backend weitergereicht werden.
+- Das Backend laeuft aktuell bewusst mit genau einem Uvicorn-Worker. Der Replay-Puffer und die
+  Subscriber sind in-process; mehrere Worker wuerden ohne gemeinsamen Event-Bus unterschiedliche
+  Live-Staende sehen. `backend/docker-entrypoint.py` erzwingt deshalb `--workers 1`, auch wenn der
+  Host `WEB_CONCURRENCY` setzt.
+
+Oeffentliche Clients erhalten nur redaktierte Ressourcen-Signale. Rohe Admin-/private API-Pfade
+werden ausschliesslich an authentifizierte Staff-Sessions ausgeliefert. Nach einem kurzen
+Verbindungsabbruch spielt das Backend noch gepufferte Events nach; bei einem zu alten Cursor oder
+nach einem Prozessneustart fordert ein `reset`-Event einen konsistenten Voll-Refetch an.
+
+Ein spaeterer Betrieb mit mehreren Backend-Workern setzt zuerst einen gemeinsamen Event-Bus mit
+workeruebergreifendem Replay voraus.
+
 ## Wenn `/community` alte Assets referenziert
 
 Symptom:

--- a/backend/docker-entrypoint.py
+++ b/backend/docker-entrypoint.py
@@ -81,7 +81,12 @@ def assert_upload_writable() -> None:
 
 def build_uvicorn_args() -> list[str]:
     port = os.environ.get("PORT", "8001")
-    args = ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", port]
+    # The SSE invalidation stream is currently in-process. Keep one worker
+    # explicit even if WEB_CONCURRENCY is present in the host environment.
+    args = [
+        "uvicorn", "server:app", "--host", "0.0.0.0", "--port", port,
+        "--workers", "1",
+    ]
     if env_flag("TRUST_PROXY_HEADERS"):
         args.extend([
             "--proxy-headers",

--- a/backend/server.py
+++ b/backend/server.py
@@ -7,7 +7,7 @@ load_dotenv(ROOT / ".env")
 import os
 import logging
 from urllib.parse import urlparse
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, FileResponse, StreamingResponse
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
@@ -56,7 +56,12 @@ from routes.search_routes import router as search_router
 from routes.extras_routes import (
     settings_router, season_router, widget_router, dsgvo_router, pdf_router, audit_router,
 )
-from services.change_events import change_event_stream, publish_api_change
+from services.change_events import (
+    change_event_stream,
+    publish_api_change,
+    visibility_scope_for_user,
+)
+from auth import get_optional_user
 from services.csrf import (
     UNSAFE_METHODS,
     csrf_rejection_detail,
@@ -355,9 +360,9 @@ async def health():
 
 
 @app.get("/api/changes/stream")
-async def changes_stream(request: Request):
+async def changes_stream(request: Request, user: dict | None = Depends(get_optional_user)):
     return StreamingResponse(
-        change_event_stream(request),
+        change_event_stream(request, visibility_scope_for_user(user)),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-store",

--- a/backend/services/change_events.py
+++ b/backend/services/change_events.py
@@ -1,18 +1,72 @@
-"""Lightweight in-process API change event stream."""
+"""Scoped, replayable API invalidation events for the browser SSE bridge.
+
+The transport intentionally remains in-process. Production therefore runs one
+API worker until a shared event bus is introduced. Public subscribers only see
+redacted resource invalidations; authenticated staff can receive the original
+API path needed by internal screens.
+"""
 import asyncio
 import json
 import time
 import uuid
+from collections import deque
 from contextlib import suppress
+from datetime import datetime, timezone
 
 from fastapi import Request
 
 
-_subscribers: set[asyncio.Queue] = set()
+PUBLIC_RESOURCES = frozenset({
+    "board",
+    "events",
+    "f1",
+    "gallery",
+    "game-servers",
+    "games",
+    "home",
+    "matches",
+    "matches-v2",
+    "nav",
+    "news",
+    "pages",
+    "partners",
+    "references",
+    "seasons",
+    "sponsors",
+    "stations",
+    "streams",
+    "tournaments",
+})
+PUBLIC_RESOURCE_ALIASES = {
+    "admin/nav": "nav",
+    "admin/pages": "pages",
+    "admin/streams": "streams",
+    "settings/branding": "settings",
+    "settings/site-banners/admin": "settings",
+}
+STAFF_STREAM_ROLES = frozenset({"moderator", "tournament_admin", "club_admin", "superadmin"})
+EVENT_BUFFER_SIZE = 256
+SUBSCRIBER_QUEUE_SIZE = 100
+
+_subscribers: set[tuple[asyncio.Queue, str]] = set()
+_event_buffer: deque[dict] = deque(maxlen=EVENT_BUFFER_SIZE)
+_stream_epoch = str(uuid.uuid4())
+_version = 0
+
+
+def visibility_scope_for_user(user: dict | None) -> str:
+    if user and user.get("role") in STAFF_STREAM_ROLES:
+        return "staff"
+    return "public"
+
+
+def _normalized_path(path: str) -> str:
+    value = (path or "").split("?", 1)[0]
+    return "/" + value.lstrip("/")
 
 
 def _resource_from_path(path: str) -> str:
-    parts = [p for p in path.split("/") if p]
+    parts = [part for part in _normalized_path(path).split("/") if part]
     if parts and parts[0] == "api":
         parts = parts[1:]
     if not parts:
@@ -22,43 +76,170 @@ def _resource_from_path(path: str) -> str:
     return parts[0]
 
 
-def _format_sse(event: str, data: dict) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
+def _public_resource_from_path(path: str) -> str | None:
+    parts = [part for part in _normalized_path(path).split("/") if part]
+    if parts and parts[0] == "api":
+        parts = parts[1:]
+    normalized = "/".join(parts)
+    for prefix, resource in PUBLIC_RESOURCE_ALIASES.items():
+        if normalized == prefix or normalized.startswith(f"{prefix}/"):
+            return resource
+    if parts and parts[0] in PUBLIC_RESOURCES:
+        return parts[0]
+    return None
 
 
-async def publish_api_change(method: str, path: str, status_code: int):
-    if path.startswith("/api/auth/refresh") or path.startswith("/api/changes/stream"):
-        return
-    payload = {
-        "id": str(uuid.uuid4()),
+def _next_version() -> int:
+    global _version
+    _version += 1
+    return _version
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _build_api_change_event(method: str, path: str, status_code: int) -> dict:
+    event_id = str(uuid.uuid4())
+    raw_path = _normalized_path(path)
+    resource = _resource_from_path(raw_path)
+    public_resource = _public_resource_from_path(raw_path)
+    return {
+        "event_id": event_id,
+        "event_type": "api.changed",
+        "entity_type": public_resource or resource,
+        "entity_id": None,
+        "version": _next_version(),
+        "occurred_at": _utc_now(),
+        "visibility_scope": "public" if public_resource else "staff",
+        "dedupe_key": f"api.changed:{event_id}",
+        # Compatibility fields consumed by the existing invalidation bridge.
+        "id": event_id,
         "method": method.upper(),
-        "path": path,
-        "resource": _resource_from_path(path),
+        "path": raw_path,
+        "resource": resource,
         "status": status_code,
         "ts": int(time.time() * 1000),
     }
-    for queue in list(_subscribers):
+
+
+def _event_for_scope(event: dict, visibility_scope: str) -> dict | None:
+    if event.get("visibility_scope") != "public" and visibility_scope != "staff":
+        return None
+    if visibility_scope == "staff":
+        return dict(event)
+
+    resource = event.get("entity_type") or ""
+    public_event = dict(event)
+    public_event.update({
+        "entity_id": None,
+        "path": f"/api/{resource}" if resource else "/api",
+        "resource": resource,
+    })
+    return public_event
+
+
+def _reset_event(visibility_scope: str, reason: str, version: int | None = None) -> dict:
+    reset_version = _version if version is None else version
+    reset_key = reset_version if reason == "queue_overflow" else visibility_scope
+    event_id = f"stream-reset:{_stream_epoch}:{reason}:{reset_key}"
+    return {
+        "event_id": event_id,
+        "event_type": "stream.reset",
+        "entity_type": "*",
+        "entity_id": None,
+        "version": reset_version,
+        "occurred_at": _utc_now(),
+        "visibility_scope": visibility_scope,
+        "dedupe_key": event_id,
+        "reason": reason,
+        "reset": True,
+    }
+
+
+def _format_sse(event: str, data: dict, *, include_id: bool = True) -> str:
+    lines: list[str] = []
+    if include_id and data.get("event_id"):
+        lines.append(f"id: {data['event_id']}")
+    lines.extend([
+        f"event: {event}",
+        f"data: {json.dumps(data, separators=(',', ':'))}",
+    ])
+    return "\n".join(lines) + "\n\n"
+
+
+def _replay_after(last_event_id: str, visibility_scope: str) -> tuple[list[dict], bool]:
+    if not last_event_id:
+        return [], False
+    events = list(_event_buffer)
+    for index, event in enumerate(events):
+        if event.get("event_id") == last_event_id:
+            replay = [
+                scoped
+                for item in events[index + 1:]
+                if (scoped := _event_for_scope(item, visibility_scope)) is not None
+            ]
+            return replay, False
+    return [], True
+
+
+def _queue_reset(queue: asyncio.Queue, visibility_scope: str, version: int) -> None:
+    while True:
+        with suppress(asyncio.QueueEmpty):
+            queue.get_nowait()
+            continue
+        break
+    queue.put_nowait(("reset", _reset_event(visibility_scope, "queue_overflow", version)))
+
+
+async def publish_api_change(method: str, path: str, status_code: int):
+    normalized_path = _normalized_path(path)
+    if normalized_path.startswith("/api/auth/refresh") or normalized_path.startswith("/api/changes/stream"):
+        return
+
+    event = _build_api_change_event(method, normalized_path, status_code)
+    _event_buffer.append(event)
+    for queue, visibility_scope in list(_subscribers):
+        scoped_event = _event_for_scope(event, visibility_scope)
+        if scoped_event is None:
+            continue
         try:
-            queue.put_nowait(payload)
+            queue.put_nowait(("change", scoped_event))
         except asyncio.QueueFull:
-            with suppress(asyncio.QueueEmpty):
-                queue.get_nowait()
-            with suppress(asyncio.QueueFull):
-                queue.put_nowait(payload)
+            _queue_reset(queue, visibility_scope, event["version"])
 
 
-async def change_event_stream(request: Request):
-    queue: asyncio.Queue = asyncio.Queue(maxsize=100)
-    _subscribers.add(queue)
+async def change_event_stream(request: Request, visibility_scope: str = "public"):
+    scope = "staff" if visibility_scope == "staff" else "public"
+    queue: asyncio.Queue = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_SIZE)
+    subscriber = (queue, scope)
+    _subscribers.add(subscriber)
+    last_event_id = request.headers.get("last-event-id", "").strip()
+    replay, reset_required = _replay_after(last_event_id, scope)
     try:
-        yield _format_sse("connected", {"ok": True, "ts": int(time.time() * 1000)})
+        yield _format_sse("connected", {
+            "ok": True,
+            "ts": int(time.time() * 1000),
+            "visibility_scope": scope,
+            "replayed": len(replay),
+        }, include_id=False)
+        if reset_required:
+            yield _format_sse(
+                "reset",
+                _reset_event(scope, "replay_unavailable"),
+                include_id=False,
+            )
+        else:
+            for event in replay:
+                yield _format_sse("change", event)
+
         while True:
             if await request.is_disconnected():
                 break
             try:
-                event = await asyncio.wait_for(queue.get(), timeout=15)
-                yield _format_sse("change", event)
+                event_name, event = await asyncio.wait_for(queue.get(), timeout=15)
+                yield _format_sse(event_name, event, include_id=event_name == "change")
             except asyncio.TimeoutError:
                 yield ": heartbeat\n\n"
     finally:
-        _subscribers.discard(queue)
+        _subscribers.discard(subscriber)

--- a/backend/tests/test_change_events_unit.py
+++ b/backend/tests/test_change_events_unit.py
@@ -1,0 +1,197 @@
+"""Regressions for scoped and replayable API change events."""
+import asyncio
+import json
+
+import pytest
+
+from services import change_events
+
+
+@pytest.fixture(autouse=True)
+def reset_change_event_state():
+    change_events._subscribers.clear()
+    change_events._event_buffer.clear()
+    change_events._version = 0
+    yield
+    change_events._subscribers.clear()
+    change_events._event_buffer.clear()
+
+
+def test_public_event_redacts_raw_path_and_identifiers():
+    event = change_events._build_api_change_event(
+        "PATCH",
+        "/api/tournaments/tournament-secret/stages/stage-secret",
+        200,
+    )
+
+    public_event = change_events._event_for_scope(event, "public")
+    staff_event = change_events._event_for_scope(event, "staff")
+
+    assert public_event["visibility_scope"] == "public"
+    assert public_event["path"] == "/api/tournaments"
+    assert public_event["resource"] == "tournaments"
+    assert public_event["entity_id"] is None
+    assert "tournament-secret" not in json.dumps(public_event)
+    assert staff_event["path"].endswith("/tournament-secret/stages/stage-secret")
+
+
+def test_only_global_staff_roles_receive_internal_stream_scope():
+    assert change_events.visibility_scope_for_user(None) == "public"
+    assert change_events.visibility_scope_for_user({"role": "player"}) == "public"
+    assert change_events.visibility_scope_for_user({
+        "role": "player",
+        "is_tournament_staff": True,
+    }) == "public"
+    assert change_events.visibility_scope_for_user({"role": "moderator"}) == "staff"
+    assert change_events.visibility_scope_for_user({"role": "superadmin"}) == "staff"
+
+
+def test_admin_cms_mutation_maps_to_public_resource_without_admin_path():
+    event = change_events._build_api_change_event(
+        "PUT",
+        "/api/admin/pages/private-draft-slug",
+        200,
+    )
+
+    public_event = change_events._event_for_scope(event, "public")
+
+    assert public_event["entity_type"] == "pages"
+    assert public_event["path"] == "/api/pages"
+    assert "admin" not in json.dumps(public_event)
+    assert "private-draft-slug" not in json.dumps(public_event)
+
+
+def test_private_mutation_is_visible_to_staff_only():
+    async def scenario():
+        public_queue = asyncio.Queue()
+        staff_queue = asyncio.Queue()
+        change_events._subscribers.update({
+            (public_queue, "public"),
+            (staff_queue, "staff"),
+        })
+
+        await change_events.publish_api_change(
+            "PATCH",
+            "/api/users/private-user-id/role",
+            200,
+        )
+
+        assert public_queue.empty()
+        event_name, staff_event = staff_queue.get_nowait()
+        assert event_name == "change"
+        assert staff_event["visibility_scope"] == "staff"
+        assert staff_event["path"] == "/api/users/private-user-id/role"
+
+    asyncio.run(scenario())
+
+
+def test_event_envelope_and_sse_id_are_stable_for_replay():
+    event = change_events._build_api_change_event("POST", "/api/matches/match-1/result", 201)
+    rendered = change_events._format_sse("change", event)
+
+    assert event["event_type"] == "api.changed"
+    assert event["entity_type"] == "matches"
+    assert event["version"] == 1
+    assert event["occurred_at"].endswith("Z")
+    assert event["dedupe_key"].endswith(event["event_id"])
+    assert rendered.startswith(f"id: {event['event_id']}\nevent: change\n")
+
+
+def test_replay_returns_only_events_after_cursor_and_for_requested_scope():
+    async def scenario():
+        await change_events.publish_api_change("PATCH", "/api/tournaments/one", 200)
+        cursor = change_events._event_buffer[-1]["event_id"]
+        await change_events.publish_api_change("PATCH", "/api/matches/two", 200)
+        await change_events.publish_api_change("PATCH", "/api/users/private", 200)
+
+        public_replay, public_reset = change_events._replay_after(cursor, "public")
+        staff_replay, staff_reset = change_events._replay_after(cursor, "staff")
+
+        assert public_reset is False
+        assert [event["resource"] for event in public_replay] == ["matches"]
+        assert public_replay[0]["path"] == "/api/matches"
+        assert staff_reset is False
+        assert [event["resource"] for event in staff_replay] == ["matches", "users"]
+
+    asyncio.run(scenario())
+
+
+def test_unknown_replay_cursor_requires_snapshot_reset():
+    replay, reset_required = change_events._replay_after("expired-event-id", "public")
+
+    assert replay == []
+    assert reset_required is True
+    reset = change_events._reset_event("public", "replay_unavailable")
+    assert reset["event_type"] == "stream.reset"
+    assert reset["reset"] is True
+    assert reset["visibility_scope"] == "public"
+
+
+def test_stream_replays_change_after_last_event_id():
+    class DisconnectedRequest:
+        def __init__(self, last_event_id):
+            self.headers = {"last-event-id": last_event_id}
+
+        async def is_disconnected(self):
+            return True
+
+    async def scenario():
+        await change_events.publish_api_change("PATCH", "/api/tournaments/one", 200)
+        cursor = change_events._event_buffer[-1]["event_id"]
+        await change_events.publish_api_change("PATCH", "/api/matches/two", 200)
+        stream = change_events.change_event_stream(DisconnectedRequest(cursor), "public")
+        return [chunk async for chunk in stream]
+
+    chunks = asyncio.run(scenario())
+
+    assert len(chunks) == 2
+    assert "event: connected" in chunks[0]
+    assert '"replayed":1' in chunks[0]
+    assert "event: change" in chunks[1]
+    assert '"resource":"matches"' in chunks[1]
+    assert "/api/matches/two" not in chunks[1]
+
+
+def test_stream_emits_exactly_one_reset_for_unknown_cursor():
+    class DisconnectedRequest:
+        headers = {"last-event-id": "cursor-from-an-old-process"}
+
+        async def is_disconnected(self):
+            return True
+
+    async def scenario():
+        stream = change_events.change_event_stream(DisconnectedRequest(), "public")
+        return [chunk async for chunk in stream]
+
+    chunks = asyncio.run(scenario())
+
+    assert len(chunks) == 2
+    assert sum("event: reset" in chunk for chunk in chunks) == 1
+    assert '"reason":"replay_unavailable"' in chunks[1]
+    assert "\nid: " not in chunks[1]
+
+
+def test_queue_overflow_replaces_stale_changes_with_snapshot_reset():
+    async def scenario():
+        queue = asyncio.Queue(maxsize=1)
+        change_events._subscribers.add((queue, "public"))
+
+        await change_events.publish_api_change("PATCH", "/api/tournaments/one", 200)
+        await change_events.publish_api_change("PATCH", "/api/tournaments/two", 200)
+
+        event_name, event = queue.get_nowait()
+        assert event_name == "reset"
+        assert event["reason"] == "queue_overflow"
+        assert event["reset"] is True
+        assert queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_refresh_and_stream_endpoints_do_not_publish_changes():
+    async def scenario():
+        await change_events.publish_api_change("POST", "/api/auth/refresh", 200)
+        await change_events.publish_api_change("POST", "/api/changes/stream", 200)
+
+    asyncio.run(scenario())
+    assert list(change_events._event_buffer) == []

--- a/backend/tests/test_security_hardening_unit.py
+++ b/backend/tests/test_security_hardening_unit.py
@@ -60,6 +60,16 @@ def test_entrypoint_limits_forwarded_headers_to_configured_proxy_networks(monkey
     assert args[args.index("--forwarded-allow-ips") + 1] == "127.0.0.1/32,172.20.0.0/24"
 
 
+def test_entrypoint_pins_one_worker_for_in_process_live_events(monkeypatch):
+    fake_pwd = types.SimpleNamespace(struct_passwd=object)
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+    entrypoint = runpy.run_path(str(Path(__file__).resolve().parents[1] / "docker-entrypoint.py"))
+
+    args = entrypoint["build_uvicorn_args"]()
+    assert args[args.index("--workers") + 1] == "1"
+
+
 def test_rate_limit_identity_ignores_unvalidated_forwarding_headers():
     from services.rate_limit import get_client_ip
 

--- a/frontend/src/components/tls/ApiInvalidationBridge.jsx
+++ b/frontend/src/components/tls/ApiInvalidationBridge.jsx
@@ -7,13 +7,15 @@ export function ApiInvalidationBridge() {
     if (typeof window === "undefined" || typeof EventSource === "undefined") return undefined;
 
     const source = new EventSource(`${API}/changes/stream`, { withCredentials: true });
-    source.addEventListener("change", (message) => {
+    const forward = (message, reset = false) => {
       try {
-        emitApiInvalidation({ ...JSON.parse(message.data), source: "server" });
+        emitApiInvalidation({ ...JSON.parse(message.data), reset, source: "server" });
       } catch {
         // Ignore malformed stream events; the browser will keep the stream alive.
       }
-    });
+    };
+    source.addEventListener("change", (message) => forward(message));
+    source.addEventListener("reset", (message) => forward(message, true));
 
     return () => source.close();
   }, []);

--- a/frontend/src/lib/apiInvalidation.js
+++ b/frontend/src/lib/apiInvalidation.js
@@ -1,5 +1,8 @@
 const listeners = new Set();
 let version = 0;
+const seenServerEvents = new Set();
+const seenServerEventOrder = [];
+const SEEN_SERVER_EVENT_LIMIT = 512;
 
 export function normalizeApiPath(path) {
   if (!path) return "";
@@ -63,11 +66,22 @@ function eventKeys(event) {
 }
 
 export function emitApiInvalidation(event = {}) {
+  const eventKey = event.event_id || event.id || event.dedupe_key;
+  if (event.source === "server" && eventKey) {
+    if (seenServerEvents.has(eventKey)) return false;
+    seenServerEvents.add(eventKey);
+    seenServerEventOrder.push(eventKey);
+    if (seenServerEventOrder.length > SEEN_SERVER_EVENT_LIMIT) {
+      seenServerEvents.delete(seenServerEventOrder.shift());
+    }
+  }
+  const clientVersion = ++version;
   const enriched = {
     ...event,
     path: event.path || "",
     resource: event.resource || resourceFromPath(event.path),
-    version: ++version,
+    version: event.version ?? clientVersion,
+    clientVersion,
     receivedAt: Date.now(),
   };
   listeners.forEach((listener) => {
@@ -80,6 +94,7 @@ export function emitApiInvalidation(event = {}) {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent("tls:api-change", { detail: enriched }));
   }
+  return true;
 }
 
 export function subscribeApiInvalidation(listener) {
@@ -88,6 +103,7 @@ export function subscribeApiInvalidation(listener) {
 }
 
 export function invalidationMatches(event, resources = []) {
+  if (event?.reset || event?.event_type === "stream.reset") return true;
   if (!resources.length) return true;
   const keys = eventKeys(event);
   return resources.some((candidate) => {

--- a/frontend/src/lib/apiInvalidation.test.js
+++ b/frontend/src/lib/apiInvalidation.test.js
@@ -1,0 +1,54 @@
+import {
+  emitApiInvalidation,
+  invalidationMatches,
+  subscribeApiInvalidation,
+} from "./apiInvalidation";
+
+describe("API invalidation stream", () => {
+  test("a stream reset invalidates every selected resource", () => {
+    expect(invalidationMatches({ event_type: "stream.reset" }, ["tournaments"])).toBe(true);
+    expect(invalidationMatches({ reset: true }, ["admin/settings"])).toBe(true);
+  });
+
+  test("a redacted public resource still matches its live view", () => {
+    const event = {
+      event_type: "api.changed",
+      entity_type: "tournaments",
+      path: "/api/tournaments",
+      resource: "tournaments",
+    };
+
+    expect(invalidationMatches(event, ["tournaments", "matches"])).toBe(true);
+    expect(invalidationMatches(event, ["news"])).toBe(false);
+  });
+
+  test("the same server event is emitted only once", () => {
+    const received = [];
+    const unsubscribe = subscribeApiInvalidation((event) => received.push(event));
+    const eventId = `dedupe-${Date.now()}-${Math.random()}`;
+
+    expect(emitApiInvalidation({ event_id: eventId, source: "server", resource: "matches" })).toBe(true);
+    expect(emitApiInvalidation({ event_id: eventId, source: "server", resource: "matches" })).toBe(false);
+
+    unsubscribe();
+    expect(received).toHaveLength(1);
+    expect(received[0].clientVersion).toEqual(expect.any(Number));
+  });
+
+  test("server sequence is preserved separately from the client sequence", () => {
+    const received = [];
+    const unsubscribe = subscribeApiInvalidation((event) => received.push(event));
+    const eventId = `version-${Date.now()}-${Math.random()}`;
+
+    emitApiInvalidation({
+      event_id: eventId,
+      source: "server",
+      resource: "events",
+      version: 42,
+    });
+
+    unsubscribe();
+    expect(received[0].version).toBe(42);
+    expect(received[0].clientVersion).toEqual(expect.any(Number));
+  });
+});


### PR DESCRIPTION
## Ergebnis

Die bestehende SSE-Invalidierung wird scoped, replaybar und reconnect-sicher. Das Paket ist der erste abgegrenzte Baustein aus #96 und schließt #118.

## Änderungen

- semantisches Envelope mit `event_id`, `event_type`, `entity_type`, `entity_id`, `version`, `occurred_at`, `visibility_scope` und `dedupe_key`
- echte SSE-`id:`-Zeilen für automatische `Last-Event-ID`-Reconnects
- begrenzter Replay-Puffer; unbekannte/zu alte Cursor erhalten genau ein deduplizierbares `reset`-Signal für konsistenten Refetch
- Queue-Überlauf verwirft keine Änderung mehr still, sondern fordert einen Snapshot-Reset an
- anonyme und normale Nutzer erhalten nur redaktierte Public-Ressourcen ohne interne Pfade oder IDs
- authentifizierte globale Staff-Rollen behalten notwendige interne Invalidierungspfade
- Frontend dedupliziert Serverevents und invalidiert bei Reset alle aktiven Datenquellen
- Uvicorn wird für die aktuelle In-Process-Lösung explizit auf einen Worker festgelegt, auch bei gesetztem `WEB_CONCURRENCY`
- Reverse-Proxy-/SSE-Betriebsgrenzen in `OPERATIONS.md` dokumentiert

## Sicherheit

Eine Mutation wie `/api/users/<id>/role` wird nicht mehr an öffentliche Streams gesendet. Öffentliche Turnier-/Match-/Event-Änderungen werden als ressourcenbezogene Signale ohne konkrete interne IDs ausgeliefert.

## Prüfungen

- `python -m pytest backend/tests -m "not live" -q` → 248 passed, 5 skipped
- gezielte Change-Event-/Security-Suite → 21 passed
- Frontend Unit → 14 passed
- Frontend Production Build → grün
- Playwright Desktop/Mobile → 54 passed, 8 Live-Admin-Tests bewusst übersprungen
- `python -m compileall -q backend` → grün
- `git diff --check` → grün

## Bewusste Grenze

Ein verteilter Event-Bus und mehrere Backend-Worker sind nicht Teil dieses Pakets. Bis zu einem Folgepaket erzwingt der Container einen Worker, damit Replay und Subscriber konsistent bleiben.

Closes #118