### PR TITLE
feat: add canonical competition read contract

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -139,6 +139,22 @@ Beweise/Disputes und konfigurierbare Punkte/Tiebreaker.
 9. Legacy-Schreibwege read-only schalten, Nutzung messen und spaeter separat
    entfernen.
 
+## Kanonischer Read-Vertrag v1
+
+`backend/services/competition_snapshot.py` projiziert beide aktiven
+Matchspeicher rein lesend auf `competition.structure.v1`. Der Vertrag enthaelt
+stabile Match-IDs, variable Slots, normalisierte Resultate und explizite
+Advancement-Kanten sowie Scheduling-/Stationsfelder und die Herkunft des
+Dokuments. Er schreibt weder in MongoDB noch veraendert er Quelldokumente.
+
+Der Match-Overview-Service ist der erste produktive Leser dieses Vertrags. Die
+bestehende Bracket-API liefert die Projektion zusaetzlich als `structure`, ohne
+`matches`, `matches_v2`, `stages` oder `engine` zu entfernen. `collection`
+bleibt fuer bestehende Deep Links erhalten, waehrend Legacy-A/B und Stage-Slots
+intern denselben Pfad verwenden. Golden-/Differentialtests vergleichen
+engine-unabhaengige Semantik; eine read-only Integritaetspruefung meldet
+doppelte IDs, fehlende Ziele/Slots, doppelte Slotquellen und Advancement-Zyklen.
+
 Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,
 Zielversion, ID-Mapping, Hash/Diff und Rollback-ID. Ein Fehler darf nie durch
 erneute Bracket-Generierung "repariert" werden.

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -31,6 +31,7 @@ from services.tournament_permissions import (
 )
 from services.custom_bracket import BracketSchemaError, build_matches_v2_from_schema
 from services.competition_formats import find_format_capability
+from services.competition_snapshot import build_structure_snapshot
 from services.match_v2_results import (
     MatchV2ResultError,
     build_v2_result_application,
@@ -3201,6 +3202,12 @@ async def _build_bracket_payload(db, t: dict, user: dict | None, is_staff: bool)
             r["user"] = {"id": u.get("id"), "username": u.get("username"),
                          "display_name": u.get("display_name"), "avatar_url": u.get("avatar_url")}
     t["can_view_display"] = bool(is_staff)
+    structure = build_structure_snapshot(
+        t["id"],
+        legacy_matches=matches,
+        stage_matches=matches_v2,
+        stages=stages,
+    )
     return {
         "tournament": t,
         "matches": matches,
@@ -3208,6 +3215,7 @@ async def _build_bracket_payload(db, t: dict, user: dict | None, is_staff: bool)
         "stages": stages,
         "matches_v2": matches_v2,
         "engine": "stage" if stages or matches_v2 else "legacy",
+        "structure": structure,
     }
 
 

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -1,0 +1,440 @@
+"""Read-only canonical projection for legacy and stage competition matches.
+
+The adapters in this module never mutate source documents and never write to
+MongoDB.  They provide the seam required to move readers away from collection-
+specific fields before any tournament changes its source of truth.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Iterable
+
+
+STRUCTURE_SNAPSHOT_VERSION = "competition.structure.v1"
+
+
+def _positive_int(value, default: int | None = None) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _slot_position(value) -> int | None:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"a", "1"}:
+        return 1
+    if normalized in {"b", "2"}:
+        return 2
+    return _positive_int(normalized)
+
+
+def _legacy_advancement(match: dict) -> list[dict]:
+    edges: list[dict] = []
+    for outcome, id_field, slot_field in (
+        ("winner", "next_match_id", "next_match_slot"),
+        ("loser", "next_loser_match_id", "next_loser_slot"),
+    ):
+        target_id = match.get(id_field)
+        if not target_id:
+            continue
+        edges.append({
+            "outcome": outcome,
+            "rank": 1,
+            "to_match_id": target_id,
+            "to_match_key": None,
+            "to_position": _slot_position(match.get(slot_field)),
+        })
+    return edges
+
+
+def _stage_advancement(match: dict) -> list[dict]:
+    edges: list[dict] = []
+    for edge in match.get("advancement") or []:
+        flow = str(edge.get("flow") or "R").upper()
+        outcome = {"W": "winner", "L": "loser", "R": "rank"}.get(flow, "rank")
+        edges.append({
+            "outcome": outcome,
+            "rank": _positive_int(edge.get("rank"), 1),
+            "to_match_id": edge.get("to_match_id"),
+            "to_match_key": edge.get("to_match_key"),
+            "to_position": _slot_position(edge.get("to_slot")),
+        })
+    return edges
+
+
+def _legacy_results(match: dict) -> list[dict]:
+    status = str(match.get("status") or "pending")
+    winner_id = match.get("winner_id")
+    loser_id = match.get("loser_id")
+    completed = status in {"completed", "forfeit"} or bool(winner_id)
+    if not completed:
+        return []
+
+    participants = [
+        (match.get("participant_a_id"), match.get("score_a")),
+        (match.get("participant_b_id"), match.get("score_b")),
+    ]
+    score_by_id = {registration_id: score for registration_id, score in participants if registration_id}
+    if not winner_id and len(score_by_id) == 2:
+        ordered = list(score_by_id.items())
+        if ordered[0][1] is not None and ordered[1][1] is not None:
+            if ordered[0][1] > ordered[1][1]:
+                winner_id, loser_id = ordered[0][0], ordered[1][0]
+            elif ordered[1][1] > ordered[0][1]:
+                winner_id, loser_id = ordered[1][0], ordered[0][0]
+
+    draw = (
+        not winner_id
+        and len(score_by_id) == 2
+        and all(score is not None for score in score_by_id.values())
+        and len(set(score_by_id.values())) == 1
+    )
+    results: list[dict] = []
+    for registration_id, score in participants:
+        if not registration_id:
+            continue
+        if registration_id == winner_id:
+            outcome, rank = "winner", 1
+        elif registration_id == loser_id or winner_id:
+            outcome, rank = "loser", 2
+        elif draw:
+            outcome, rank = "draw", 1
+        else:
+            outcome, rank = None, None
+        results.append({
+            "registration_id": registration_id,
+            "rank": rank,
+            "score": score,
+            "points": None,
+            "time_ms": None,
+            "outcome": outcome,
+            "dnf": False,
+            "forfeit": bool(status == "forfeit" and outcome == "loser"),
+            "note": None,
+        })
+    return results
+
+
+def _stage_results(match: dict) -> list[dict]:
+    results: list[dict] = []
+    for result in match.get("results") or []:
+        rank = result.get("rank")
+        if result.get("forfeit"):
+            outcome = "forfeit"
+        elif result.get("dnf"):
+            outcome = "dnf"
+        elif rank == 1:
+            outcome = "winner"
+        elif rank is not None:
+            outcome = "placed"
+        else:
+            outcome = None
+        results.append({
+            "registration_id": result.get("registration_id"),
+            "rank": rank,
+            "score": result.get("score"),
+            "points": result.get("points"),
+            "time_ms": result.get("time_ms"),
+            "outcome": outcome,
+            "dnf": bool(result.get("dnf")),
+            "forfeit": bool(result.get("forfeit")),
+            "note": result.get("note"),
+        })
+    return results
+
+
+def _legacy_incoming_sources(matches: Iterable[dict]) -> dict[tuple[str, int], dict]:
+    incoming: dict[tuple[str, int], dict] = {}
+    for match in matches:
+        source_id = match.get("id")
+        if not source_id:
+            continue
+        for edge in _legacy_advancement(match):
+            target_id = edge.get("to_match_id")
+            position = edge.get("to_position")
+            if target_id and position:
+                incoming[(target_id, position)] = {
+                    "type": "match_result",
+                    "match_id": source_id,
+                    "match_key": None,
+                    "outcome": edge["outcome"],
+                    "rank": edge["rank"],
+                }
+    return incoming
+
+
+def _legacy_slot(match: dict, position: int, incoming: dict[tuple[str, int], dict]) -> dict:
+    participant_field = "participant_a_id" if position == 1 else "participant_b_id"
+    registration_id = match.get(participant_field)
+    source = incoming.get((match.get("id"), position))
+    if not source:
+        if registration_id:
+            source = {"type": "direct"}
+        elif match.get("status") == "completed" and match.get("winner_id"):
+            source = {"type": "bye"}
+        else:
+            source = {"type": "unassigned"}
+    if registration_id:
+        state = "filled"
+    elif source.get("type") == "bye":
+        state = "bye"
+    elif match.get("is_preview") or match.get("status") == "preview":
+        state = "preview"
+    else:
+        state = "pending"
+    return {
+        "position": position,
+        "registration_id": registration_id,
+        "user_id": None,
+        "seed": None,
+        "state": state,
+        "source": source,
+    }
+
+
+def _stage_source(source: dict, match_ids_by_key: dict[tuple[str | None, str], str]) -> dict:
+    source_type = source.get("type")
+    if source_type == "seed":
+        return {"type": "seed", "seed": source.get("seed")}
+    if source_type == "bye":
+        return {"type": "bye"}
+    if source_type == "rank":
+        flow = str(source.get("flow") or "R").upper()
+        match_key = source.get("match_key")
+        stage_id = source.get("stage_id")
+        return {
+            "type": "match_result",
+            "match_id": source.get("match_id") or match_ids_by_key.get((stage_id, match_key)),
+            "match_key": match_key,
+            "outcome": {"W": "winner", "L": "loser", "R": "rank"}.get(flow, "rank"),
+            "rank": _positive_int(source.get("rank"), 1),
+        }
+    return deepcopy(source) if source else {"type": "unassigned"}
+
+
+def _common_match_fields(match: dict, collection: str, engine: str) -> dict:
+    return {
+        "schema_version": STRUCTURE_SNAPSHOT_VERSION,
+        "id": match.get("id"),
+        "tournament_id": match.get("tournament_id"),
+        "stage_id": match.get("stage_id"),
+        "stage_number": match.get("stage_number"),
+        "group_id": match.get("group_id"),
+        "round": match.get("round") or match.get("matchday_number"),
+        "round_name": match.get("round_name") or match.get("matchday_label"),
+        "match_key": match.get("match_key"),
+        "section": match.get("section") or match.get("bracket"),
+        "match_type": match.get("match_type") or "duel",
+        "status": match.get("status") or "pending",
+        "scheduled_at": match.get("scheduled_at"),
+        "duration_minutes": match.get("duration_minutes"),
+        "station_id": match.get("station_id"),
+        "station": deepcopy(match.get("station")),
+        "station_name": match.get("station_name"),
+        "station_label": match.get("station_label"),
+        "best_of": match.get("best_of"),
+        "map": match.get("map"),
+        "order": match.get("order") if match.get("order") is not None else match.get("match_index"),
+        "is_preview": bool(match.get("is_preview") or match.get("status") == "preview"),
+        "generation_mode": match.get("generation_mode"),
+        "collection": collection,
+        "source": {"engine": engine, "collection": collection},
+    }
+
+
+def adapt_legacy_matches(matches: Iterable[dict]) -> list[dict]:
+    """Project legacy A/B matches into canonical variable-slot matches."""
+
+    source_matches = [dict(match) for match in matches]
+    incoming = _legacy_incoming_sources(source_matches)
+    adapted: list[dict] = []
+    for match in source_matches:
+        canonical = _common_match_fields(match, "matches", "legacy")
+        canonical["slots"] = [_legacy_slot(match, 1, incoming), _legacy_slot(match, 2, incoming)]
+        canonical["results"] = _legacy_results(match)
+        canonical["advancement"] = _legacy_advancement(match)
+        adapted.append(canonical)
+    return _sort_matches(adapted)
+
+
+def adapt_stage_matches(matches: Iterable[dict]) -> list[dict]:
+    """Project stage/V2 documents into the same canonical match shape."""
+
+    source_matches = [dict(match) for match in matches]
+    match_ids_by_key = {
+        (match.get("stage_id"), match.get("match_key")): match.get("id")
+        for match in source_matches
+        if match.get("match_key") and match.get("id")
+    }
+    adapted: list[dict] = []
+    for match in source_matches:
+        canonical = _common_match_fields(match, "matches_v2", "stage")
+        canonical["slots"] = [
+            {
+                "position": _slot_position(slot.get("slot")) or index,
+                "registration_id": slot.get("registration_id"),
+                "user_id": slot.get("user_id"),
+                "seed": slot.get("seed"),
+                "state": slot.get("status") or "pending",
+                "source": _stage_source(
+                    {**(slot.get("source") or {}), "stage_id": match.get("stage_id")},
+                    match_ids_by_key,
+                ),
+            }
+            for index, slot in enumerate(match.get("slots") or [], start=1)
+        ]
+        canonical["results"] = _stage_results(match)
+        canonical["advancement"] = _stage_advancement(match)
+        adapted.append(canonical)
+    return _sort_matches(adapted)
+
+
+def _sort_matches(matches: Iterable[dict]) -> list[dict]:
+    return sorted(
+        matches,
+        key=lambda match: (
+            _positive_int(match.get("stage_number"), 0),
+            _positive_int(match.get("round"), 0),
+            _positive_int(match.get("order"), 0),
+            str(match.get("id") or ""),
+        ),
+    )
+
+
+def build_structure_snapshot(
+    tournament_id: str,
+    *,
+    legacy_matches: Iterable[dict] = (),
+    stage_matches: Iterable[dict] = (),
+    stages: Iterable[dict] = (),
+) -> dict:
+    legacy = adapt_legacy_matches(legacy_matches)
+    stage = adapt_stage_matches(stage_matches)
+    engines = [engine for engine, rows in (("legacy", legacy), ("stage", stage)) if rows]
+    return {
+        "schema_version": STRUCTURE_SNAPSHOT_VERSION,
+        "tournament_id": tournament_id,
+        "source_engines": engines,
+        "mixed_source": len(engines) > 1,
+        "stages": [
+            {
+                "id": item.get("id"),
+                "number": item.get("number"),
+                "name": item.get("name"),
+                "stage_type": item.get("stage_type"),
+                "match_type": item.get("match_type"),
+                "status": item.get("status"),
+                "settings": deepcopy(item.get("settings") or {}),
+            }
+            for item in stages
+        ],
+        "matches": _sort_matches([*legacy, *stage]),
+    }
+
+
+def semantic_match_projection(match: dict) -> dict:
+    """Return engine-independent fields used by shadow/differential tests."""
+
+    return {
+        "id": match.get("id"),
+        "tournament_id": match.get("tournament_id"),
+        "round": match.get("round"),
+        "status": match.get("status"),
+        "scheduled_at": match.get("scheduled_at"),
+        "station_id": match.get("station_id"),
+        "slots": [
+            {
+                "position": slot.get("position"),
+                "registration_id": slot.get("registration_id"),
+                "state": slot.get("state"),
+            }
+            for slot in match.get("slots") or []
+        ],
+        "results": [
+            {
+                "registration_id": result.get("registration_id"),
+                "rank": result.get("rank"),
+                "score": result.get("score"),
+            }
+            for result in match.get("results") or []
+        ],
+        "advancement": [
+            {
+                "outcome": edge.get("outcome"),
+                "rank": edge.get("rank"),
+                "to_match_id": edge.get("to_match_id"),
+                "to_position": edge.get("to_position"),
+            }
+            for edge in match.get("advancement") or []
+        ],
+    }
+
+
+def structure_snapshot_issues(snapshot: dict) -> list[dict]:
+    """Validate read-side graph references without changing source data."""
+
+    issues: list[dict] = []
+    matches = snapshot.get("matches") or []
+    by_id: dict[str, dict] = {}
+    for match in matches:
+        match_id = match.get("id")
+        if not match_id:
+            issues.append({"code": "missing_match_id"})
+            continue
+        if match_id in by_id:
+            issues.append({"code": "duplicate_match_id", "match_id": match_id})
+            continue
+        by_id[match_id] = match
+
+    graph: dict[str, set[str]] = {match_id: set() for match_id in by_id}
+    incoming_slots: set[tuple[str, int]] = set()
+    for source_id, match in by_id.items():
+        for edge in match.get("advancement") or []:
+            target_id = edge.get("to_match_id")
+            position = edge.get("to_position")
+            if not target_id or target_id not in by_id:
+                issues.append({
+                    "code": "missing_advancement_target",
+                    "match_id": source_id,
+                    "target_id": target_id,
+                })
+                continue
+            valid_positions = {slot.get("position") for slot in by_id[target_id].get("slots") or []}
+            if position not in valid_positions:
+                issues.append({
+                    "code": "missing_target_slot",
+                    "match_id": source_id,
+                    "target_id": target_id,
+                    "position": position,
+                })
+                continue
+            slot_key = (target_id, position)
+            if slot_key in incoming_slots:
+                issues.append({
+                    "code": "duplicate_target_slot_source",
+                    "target_id": target_id,
+                    "position": position,
+                })
+            incoming_slots.add(slot_key)
+            graph[source_id].add(target_id)
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(match_id: str) -> bool:
+        if match_id in visiting:
+            return True
+        if match_id in visited:
+            return False
+        visiting.add(match_id)
+        has_cycle = any(visit(target_id) for target_id in graph.get(match_id, set()))
+        visiting.remove(match_id)
+        visited.add(match_id)
+        return has_cycle
+
+    if any(visit(match_id) for match_id in graph if match_id not in visited):
+        issues.append({"code": "advancement_cycle"})
+    return issues

--- a/backend/services/match_overview.py
+++ b/backend/services/match_overview.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matches
 from services.station_labels import attach_station_info
 from services.tournament_permissions import RESULT_STAFF_ROLES, is_global_tournament_staff
 
@@ -73,10 +74,7 @@ async def _active_registrations_for_user(db, user: dict) -> list[dict]:
 async def _matches_for_query(db, query: dict, per_collection_limit: int = 240) -> list[dict]:
     legacy = await db.matches.find(query, {"_id": 0}).to_list(per_collection_limit)
     v2 = await db.matches_v2.find(query, {"_id": 0}).to_list(per_collection_limit)
-    return [
-        *({**match, "collection": "matches"} for match in legacy),
-        *({**match, "collection": "matches_v2"} for match in v2),
-    ]
+    return [*adapt_legacy_matches(legacy), *adapt_stage_matches(v2)]
 
 
 def _registration_label(registration: dict | None, team_map: dict[str, dict]) -> str:

--- a/backend/tests/test_competition_snapshot_unit.py
+++ b/backend/tests/test_competition_snapshot_unit.py
@@ -1,0 +1,230 @@
+from services.competition_snapshot import (
+    STRUCTURE_SNAPSHOT_VERSION,
+    adapt_legacy_matches,
+    adapt_stage_matches,
+    build_structure_snapshot,
+    semantic_match_projection,
+    structure_snapshot_issues,
+)
+
+
+def _legacy_fixture():
+    return [
+        {
+            "id": "m1",
+            "tournament_id": "t1",
+            "round": 1,
+            "match_index": 0,
+            "bracket": "winner",
+            "participant_a_id": "r1",
+            "participant_b_id": "r2",
+            "score_a": 2,
+            "score_b": 1,
+            "winner_id": "r1",
+            "loser_id": "r2",
+            "status": "completed",
+            "scheduled_at": "2026-08-17T18:00:00+00:00",
+            "station_id": "station-1",
+            "next_match_id": "m3",
+            "next_match_slot": "a",
+        },
+        {
+            "id": "m2",
+            "tournament_id": "t1",
+            "round": 1,
+            "match_index": 1,
+            "bracket": "winner",
+            "participant_a_id": "r3",
+            "participant_b_id": "r4",
+            "score_a": 0,
+            "score_b": 0,
+            "status": "ready",
+            "next_match_id": "m3",
+            "next_match_slot": "b",
+        },
+        {
+            "id": "m3",
+            "tournament_id": "t1",
+            "round": 2,
+            "match_index": 0,
+            "bracket": "winner",
+            "participant_a_id": "r1",
+            "participant_b_id": None,
+            "score_a": 0,
+            "score_b": 0,
+            "status": "pending",
+        },
+    ]
+
+
+def _stage_fixture():
+    return [
+        {
+            "id": "m1",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "stage_number": 1,
+            "round": 1,
+            "order": 0,
+            "match_key": "A",
+            "section": "WB",
+            "match_type": "duel",
+            "slots": [
+                {"slot": 1, "source": {"type": "seed", "seed": 1}, "registration_id": "r1", "status": "filled"},
+                {"slot": 2, "source": {"type": "seed", "seed": 2}, "registration_id": "r2", "status": "filled"},
+            ],
+            "results": [
+                {"registration_id": "r1", "rank": 1, "score": 2},
+                {"registration_id": "r2", "rank": 2, "score": 1},
+            ],
+            "advancement": [
+                {"flow": "W", "rank": 1, "to_match_id": "m3", "to_match_key": "C", "to_slot": 1},
+            ],
+            "status": "completed",
+            "scheduled_at": "2026-08-17T18:00:00+00:00",
+            "station_id": "station-1",
+        },
+        {
+            "id": "m2",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "stage_number": 1,
+            "round": 1,
+            "order": 1,
+            "match_key": "B",
+            "section": "WB",
+            "match_type": "duel",
+            "slots": [
+                {"slot": 1, "source": {"type": "seed", "seed": 3}, "registration_id": "r3", "status": "filled"},
+                {"slot": 2, "source": {"type": "seed", "seed": 4}, "registration_id": "r4", "status": "filled"},
+            ],
+            "results": [],
+            "advancement": [
+                {"flow": "W", "rank": 1, "to_match_id": "m3", "to_match_key": "C", "to_slot": 2},
+            ],
+            "status": "ready",
+        },
+        {
+            "id": "m3",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "stage_number": 1,
+            "round": 2,
+            "order": 0,
+            "match_key": "C",
+            "section": "WB",
+            "match_type": "duel",
+            "slots": [
+                {"slot": 1, "source": {"type": "rank", "flow": "W", "match_key": "A", "rank": 1}, "registration_id": "r1", "status": "filled"},
+                {"slot": 2, "source": {"type": "rank", "flow": "W", "match_key": "B", "rank": 1}, "registration_id": None, "status": "pending"},
+            ],
+            "results": [],
+            "advancement": [],
+            "status": "pending",
+        },
+    ]
+
+
+def test_legacy_adapter_builds_slots_results_and_graph_sources_without_mutation():
+    source = _legacy_fixture()
+    adapted = adapt_legacy_matches(source)
+    first = adapted[0]
+    final = adapted[2]
+
+    assert first["schema_version"] == STRUCTURE_SNAPSHOT_VERSION
+    assert first["source"] == {"engine": "legacy", "collection": "matches"}
+    assert [slot["registration_id"] for slot in first["slots"]] == ["r1", "r2"]
+    assert [(result["registration_id"], result["rank"], result["score"]) for result in first["results"]] == [
+        ("r1", 1, 2),
+        ("r2", 2, 1),
+    ]
+    assert first["advancement"] == [{
+        "outcome": "winner",
+        "rank": 1,
+        "to_match_id": "m3",
+        "to_match_key": None,
+        "to_position": 1,
+    }]
+    assert final["slots"][0]["source"] == {
+        "type": "match_result",
+        "match_id": "m1",
+        "match_key": None,
+        "outcome": "winner",
+        "rank": 1,
+    }
+    assert "slots" not in source[0]
+
+
+def test_stage_adapter_resolves_match_key_sources_to_stable_match_ids():
+    adapted = adapt_stage_matches(_stage_fixture())
+    final = adapted[2]
+
+    assert adapted[0]["source"] == {"engine": "stage", "collection": "matches_v2"}
+    assert final["slots"][0]["source"]["match_id"] == "m1"
+    assert final["slots"][1]["source"]["match_id"] == "m2"
+    assert final["slots"][0]["source"]["outcome"] == "winner"
+
+
+def test_adapter_tolerates_unset_scores_and_non_numeric_sort_fields():
+    legacy = adapt_legacy_matches([{
+        "id": "m-void",
+        "tournament_id": "t1",
+        "round": "Finale",
+        "match_index": "unbekannt",
+        "participant_a_id": "r1",
+        "participant_b_id": "r2",
+        "score_a": None,
+        "score_b": None,
+        "status": "completed",
+    }])
+
+    assert [result["outcome"] for result in legacy[0]["results"]] == [None, None]
+
+
+def test_legacy_and_stage_fixtures_have_equal_engine_independent_semantics():
+    legacy = adapt_legacy_matches(_legacy_fixture())
+    stage = adapt_stage_matches(_stage_fixture())
+
+    assert [semantic_match_projection(match) for match in legacy] == [
+        semantic_match_projection(match) for match in stage
+    ]
+
+
+def test_structure_snapshot_marks_mixed_sources_and_keeps_stage_metadata():
+    snapshot = build_structure_snapshot(
+        "t1",
+        legacy_matches=_legacy_fixture(),
+        stage_matches=_stage_fixture(),
+        stages=[{"id": "s1", "number": 1, "name": "Finals", "stage_type": "single_elimination", "match_type": "duel"}],
+    )
+
+    assert snapshot["schema_version"] == STRUCTURE_SNAPSHOT_VERSION
+    assert snapshot["source_engines"] == ["legacy", "stage"]
+    assert snapshot["mixed_source"] is True
+    assert len(snapshot["matches"]) == 6
+    assert snapshot["stages"][0]["name"] == "Finals"
+
+
+def test_structure_snapshot_validator_reports_broken_duplicate_and_cyclic_edges():
+    snapshot = {
+        "matches": [
+            {
+                "id": "a",
+                "slots": [{"position": 1}, {"position": 2}],
+                "advancement": [
+                    {"to_match_id": "b", "to_position": 1},
+                    {"to_match_id": "missing", "to_position": 1},
+                ],
+            },
+            {
+                "id": "b",
+                "slots": [{"position": 1}, {"position": 2}],
+                "advancement": [{"to_match_id": "a", "to_position": 1}],
+            },
+            {"id": "b", "slots": [], "advancement": []},
+        ],
+    }
+
+    codes = {issue["code"] for issue in structure_snapshot_issues(snapshot)}
+
+    assert {"duplicate_match_id", "missing_advancement_target", "advancement_cycle"} <= codes

--- a/backend/tests/test_match_overview_unit.py
+++ b/backend/tests/test_match_overview_unit.py
@@ -121,3 +121,31 @@ def test_operational_overview_honors_exact_match_assignment():
     assert [row["id"] for row in rows] == ["m-live"]
     assert rows[0]["can_submit_result"] is True
     assert rows[0]["is_own_match"] is False
+
+
+def test_own_overview_uses_same_contract_for_stage_matches():
+    db = FakeDb()
+    db.matches = FakeCollection()
+    db.matches_v2 = FakeCollection([{
+        "id": "m-stage",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "stage_number": 1,
+        "match_key": "A",
+        "round": 1,
+        "status": "in_progress",
+        "slots": [
+            {"slot": 1, "source": {"type": "seed", "seed": 1}, "registration_id": "r-own", "status": "filled"},
+            {"slot": 2, "source": {"type": "seed", "seed": 2}, "registration_id": "r-other", "status": "filled"},
+        ],
+        "results": [],
+        "advancement": [],
+    }])
+
+    rows, _registrations = asyncio.run(own_match_overviews(db, {"id": "u1", "role": "user"}))
+
+    assert [row["id"] for row in rows] == ["m-stage"]
+    assert rows[0]["collection"] == "matches_v2"
+    assert rows[0]["participant_names"] == ["Lion", "Opponent"]
+    assert rows[0]["opponent_name"] == "Opponent"
+    assert rows[0]["is_own_match"] is True


### PR DESCRIPTION
## Zusammenfassung

Erster sicherer Umsetzungsschritt von Paket 2 aus #120:

- führt den versionierten, rein lesenden Vertrag `competition.structure.v1` ein;
- normalisiert Legacy-A/B-Matches und Stage-/`matches_v2`-Dokumente auf identische Slots, Resultate und Advancement-Kanten;
- behält stabile Match-IDs sowie Scheduling-, Stations- und Herkunftsfelder;
- liefert die kanonische Sicht zusätzlich als `structure` im bestehenden Bracket-Payload, ohne bestehende Felder oder Endpunkte zu entfernen;
- stellt den Match-Overview-Service als ersten produktiven Consumer auf die Adapter um;
- ergänzt Golden-/Differentialtests, Mutationsschutz und read-only Graphprüfungen für doppelte IDs, fehlende Ziele/Slots, Mehrfachbelegung und Zyklen.

Es gibt keine Datenmigration, kein Dual-Write und keinen Engine-Cutover. Bestehende Turnierdaten werden weder neu generiert noch verändert.

## Verifikation

- `python -m pytest -q`
- Ergebnis: `271 passed, 282 skipped, 1 warning`
- `git diff --check`

Refs #120
Teil von #95