### PR TITLE
refactor: centralize competition reads and standings

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -155,6 +155,29 @@ intern denselben Pfad verwenden. Golden-/Differentialtests vergleichen
 engine-unabhaengige Semantik; eine read-only Integritaetspruefung meldet
 doppelte IDs, fehlende Ziele/Slots, doppelte Slotquellen und Advancement-Zyklen.
 
+`backend/services/competition_read.py` ist die Datenbankgrenze fuer Struktur
+und Match-Detail. `backend/services/competition_standings.py` berechnet Stage-,
+Elimination-, Round-Robin-, Liga-, Swiss- und Gruppenstaende ausschliesslich
+aus der kanonischen Projektion. Jeder produktive Struktur-Read erzeugt
+niedrig-kardinale Counts fuer Quellen, Status, Resultate, Advancement und
+Integritaetsfehler; `compare_structure_snapshots` liefert begrenzte
+Shadow-Diffs fuer eine spaetere Bestandsmigration. Dabei wird nichts doppelt
+geschrieben.
+
+### Read-Consumer-Status
+
+| Consumer | Status | Naechster Schritt |
+| --- | --- | --- |
+| Bracket-API / Display | kanonische `structure` zusaetzlich aktiv | Frontend schrittweise auf `structure` umstellen |
+| Match-Overview | kanonisch aktiv | keine Legacy-Sonderlogik mehr hinzufuegen |
+| Match-Detail | `canonical_match` zusaetzlich aktiv | UI nach Paritaet umstellen |
+| Turnier-Standings | kanonisch aktiv | konfigurierbare RankingPolicy folgt im Schreibkern |
+| Profile / DSGVO | beide Stores, aber eigene Projektionen | auf Read-Service umstellen |
+| Preise / Saisonwertung | beide Stores, aber eigene Projektionen | kanonische Standings konsumieren |
+| Widget / Match-PDF | weiterhin Legacy-only | priorisierter naechster Read-Consumer |
+| Badges / Admin-Zaehler / Penalties | weiterhin Legacy-lastig | vor Engine-Cutover migrieren |
+| Reminder / Notifications / Stationen | beide Formen mit Sonderzweigen | gemeinsame Match-Projektion verwenden |
+
 Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,
 Zielversion, ID-Mapping, Hash/Diff und Rollback-ID. Ein Fehler darf nie durch
 erneute Bracket-Generierung "repariert" werden.

--- a/backend/routes/match_routes.py
+++ b/backend/routes/match_routes.py
@@ -25,6 +25,7 @@ from models import (
 )
 from bracket_engine import advance_match_winner
 from match_rules import loser_for_winner, match_allows_draw, validate_winner_id
+from services.competition_read import canonical_match_for_source, find_match_source
 from services.match_notifications import notify_match_result_confirmed
 from services.match_overview import operational_match_overviews, own_match_overviews
 from services.match_planning import ensure_station_slot_available, ensure_tournament_accepts_results
@@ -209,13 +210,9 @@ async def _audit_match_action(db, action: str, match: dict, actor_id: str | None
 
 
 async def _find_match_any(match_id: str) -> tuple[dict, str]:
-    db = get_db()
-    match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
-    if match:
-        return match, "matches_v2"
-    match = await db.matches.find_one({"id": match_id}, {"_id": 0})
-    if match:
-        return match, "matches"
+    source = await find_match_source(get_db(), match_id)
+    if source:
+        return source.match, source.collection
     raise HTTPException(status_code=404, detail="Match nicht gefunden")
 
 
@@ -622,8 +619,10 @@ async def _match_page_payload(match: dict, collection: str, user: dict | None = 
     if not matchday_label:
         prefix = "Spieltag" if league_like else "Runde"
         matchday_label = f"{prefix} {round_number}" if round_number else "Match"
+    canonical_match = await canonical_match_for_source(db, match, collection)
     return {
         "match": match,
+        "canonical_match": canonical_match,
         "tournament": tournament,
         "stage": stage,
         "participants": await _match_participants(match, user),

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -31,7 +31,9 @@ from services.tournament_permissions import (
 )
 from services.custom_bracket import BracketSchemaError, build_matches_v2_from_schema
 from services.competition_formats import find_format_capability
-from services.competition_snapshot import build_structure_snapshot
+from services.competition_read import load_competition_read_model, observe_structure_read
+from services.competition_snapshot import adapt_stage_matches
+from services.competition_standings import stage_standings, standings_for_structure
 from services.match_v2_results import (
     MatchV2ResultError,
     build_v2_result_application,
@@ -46,9 +48,9 @@ from models import (
     TournamentStageCreate, TournamentStageUpdate,
     now_utc, new_id,
 )
-from bracket_engine import generate_bracket, compute_round_robin_standings
+from bracket_engine import generate_bracket
 from bracket_extensions import (
-    generate_swiss_round, compute_swiss_standings, generate_groups, compute_group_standings,
+    generate_swiss_round, generate_groups,
 )
 from services.user_notifications import create_user_notification
 
@@ -3027,7 +3029,7 @@ async def set_status(tid: str, body: dict, me: dict = Depends(get_current_user),
             if not placements:
                 matches_v2 = await db.matches_v2.find({"tournament_id": tid}, {"_id": 0}).to_list(3000)
                 if matches_v2:
-                    for row in _v2_standings(matches_v2, regs):
+                    for row in stage_standings(adapt_stage_matches(matches_v2), regs):
                         rid = row.get("registration_id")
                         if not rid or rid not in reg_map or rid in placed_reg_ids or not row.get("played"):
                             continue
@@ -3176,9 +3178,10 @@ async def export_match_plan_csv(tid: str, me: dict = Depends(get_current_user)):
 
 async def _build_bracket_payload(db, t: dict, user: dict | None, is_staff: bool) -> dict:
     t["public_phase"] = derive_public_phase(t, "tournament")
-    matches = await db.matches.find({"tournament_id": t["id"]}, {"_id": 0}).sort("round", 1).to_list(1000)
-    stages = await db.tournament_stages.find({"tournament_id": t["id"]}, {"_id": 0}).sort("number", 1).to_list(200)
-    matches_v2 = await db.matches_v2.find({"tournament_id": t["id"]}, {"_id": 0}).sort([("stage_number", 1), ("round", 1), ("order", 1)]).to_list(3000)
+    read_model = await load_competition_read_model(db, t["id"])
+    matches = read_model.legacy_matches
+    stages = read_model.stages
+    matches_v2 = read_model.stage_matches
     await attach_station_info(db, matches)
     await attach_station_info(db, matches_v2)
     regs = await db.tournament_registrations.find({"tournament_id": t["id"]}, {"_id": 0}).to_list(500)
@@ -3202,12 +3205,8 @@ async def _build_bracket_payload(db, t: dict, user: dict | None, is_staff: bool)
             r["user"] = {"id": u.get("id"), "username": u.get("username"),
                          "display_name": u.get("display_name"), "avatar_url": u.get("avatar_url")}
     t["can_view_display"] = bool(is_staff)
-    structure = build_structure_snapshot(
-        t["id"],
-        legacy_matches=matches,
-        stage_matches=matches_v2,
-        stages=stages,
-    )
+    structure = read_model.structure_snapshot()
+    observe_structure_read(structure, surface="bracket")
     return {
         "tournament": t,
         "matches": matches,
@@ -3245,61 +3244,6 @@ async def get_bracket_display(tid: str, me: dict = Depends(get_current_user)):
     return await _build_bracket_payload(db, t, me, True)
 
 
-def _v2_standings(matches_v2: list[dict], regs: list[dict]) -> list[dict]:
-    rank_map = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "display_name": r.get("display_name") or r.get("ingame_name") or r.get("user", {}).get("display_name"),
-            "played": 0,
-            "won": 0,
-            "top2": 0,
-            "lost": 0,
-            "points": 0,
-            "rank_sum": 0,
-            "furthest_round": 0,
-            "best_rank": None,
-        }
-        for r in regs
-    }
-    for match in matches_v2:
-        if match.get("status") not in {"completed", "forfeit"}:
-            continue
-        for result in match.get("results") or []:
-            rid = result.get("registration_id")
-            if rid not in rank_map:
-                continue
-            rank = int(result.get("rank") or 999)
-            row = rank_map[rid]
-            row["played"] += 1
-            row["rank_sum"] += rank
-            row["furthest_round"] = max(row["furthest_round"], int(match.get("round") or 0))
-            row["best_rank"] = rank if row["best_rank"] is None else min(row["best_rank"], rank)
-            if rank == 1:
-                row["won"] += 1
-            if rank <= 2:
-                row["top2"] += 1
-            else:
-                row["lost"] += 1
-            score = result.get("points")
-            if score is None:
-                score = result.get("score")
-            if isinstance(score, (int, float)):
-                row["points"] += score
-    rows = list(rank_map.values())
-    for row in rows:
-        row["avg_rank"] = round(row["rank_sum"] / row["played"], 2) if row["played"] else None
-    rows.sort(key=lambda row: (
-        row["furthest_round"],
-        row["won"],
-        row["top2"],
-        row["points"],
-        -(row["avg_rank"] or 999),
-    ), reverse=True)
-    for i, row in enumerate(rows, start=1):
-        row["rank"] = i
-    return rows
-
-
 @router.get("/{tid}/standings")
 async def standings(tid: str, access: str | None = None, user=Depends(get_optional_user)):
     db = get_db()
@@ -3312,8 +3256,7 @@ async def standings(tid: str, access: str | None = None, user=Depends(get_option
     else:
         t = await _get_visible_tournament(tid, user)
     is_staff = _is_staff(user) or await _is_tournament_staff(tid, user)
-    matches = await db.matches.find({"tournament_id": tid}, {"_id": 0}).to_list(1000)
-    matches_v2 = await db.matches_v2.find({"tournament_id": tid}, {"_id": 0}).to_list(3000)
+    read_model = await load_competition_read_model(db, tid)
     regs = await db.tournament_registrations.find({"tournament_id": tid}, {"_id": 0}).to_list(500)
     regs = [_public_registration(r, user, is_staff) for r in regs]
     user_ids = list({r["user_id"] for r in regs if r.get("user_id")})
@@ -3323,35 +3266,17 @@ async def standings(tid: str, access: str | None = None, user=Depends(get_option
         u = users.get(r.get("user_id") or "", {})
         r["display_name"] = r.get("display_name") or u.get("display_name") or u.get("username")
         r["user"] = {"id": u.get("id"), "username": u.get("username"), "display_name": u.get("display_name"), "avatar_url": u.get("avatar_url")}
-    if matches_v2:
-        return _v2_standings(matches_v2, regs)
-    fmt = t.get("format")
-    if fmt in ("round_robin", "league"):
-        return compute_round_robin_standings(matches, regs)
-    if fmt == "swiss":
-        return compute_swiss_standings(regs, matches)
-    if fmt == "groups":
+    groups = []
+    if t.get("format") == "groups":
         groups = await db.tournament_groups.find({"tournament_id": tid}, {"_id": 0}).to_list(50)
-        reg_map = {r["id"]: r for r in regs}
-        return compute_group_standings(groups, matches, reg_map)
-    # Elimination fallback
-    rank_map = {r["id"]: {"registration_id": r["id"], "display_name": r["display_name"],
-                           "furthest_round": 0, "wins": 0, "losses": 0} for r in regs}
-    for m in matches:
-        a, b, w = m.get("participant_a_id"), m.get("participant_b_id"), m.get("winner_id")
-        if a in rank_map and m.get("round"):
-            rank_map[a]["furthest_round"] = max(rank_map[a]["furthest_round"], m["round"])
-        if b in rank_map and m.get("round"):
-            rank_map[b]["furthest_round"] = max(rank_map[b]["furthest_round"], m["round"])
-        if m.get("status") == "completed" and w:
-            loser = a if w == b else b
-            if w in rank_map: rank_map[w]["wins"] += 1
-            if loser in rank_map: rank_map[loser]["losses"] += 1
-    arr = list(rank_map.values())
-    arr.sort(key=lambda s: (s["furthest_round"], s["wins"]), reverse=True)
-    for i, s in enumerate(arr):
-        s["rank"] = i + 1
-    return arr
+    structure = read_model.structure_snapshot()
+    observe_structure_read(structure, surface="standings")
+    return standings_for_structure(
+        t,
+        structure,
+        regs,
+        groups=groups,
+    )
 
 
 # ---------- Swiss / Groups specific ----------

--- a/backend/services/competition_read.py
+++ b/backend/services/competition_read.py
@@ -1,0 +1,125 @@
+"""Database boundary for read-only competition projections.
+
+Writes deliberately stay in their existing services until the canonical write
+core is ready.  This module only loads current documents and projects them via
+the versioned read contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import logging
+
+from services.competition_snapshot import build_structure_snapshot, structure_snapshot_metrics
+
+
+logger = logging.getLogger("tls.competition_read")
+
+
+@dataclass(slots=True)
+class CompetitionReadModel:
+    tournament_id: str
+    legacy_matches: list[dict]
+    stage_matches: list[dict]
+    stages: list[dict]
+
+    def structure_snapshot(self) -> dict:
+        return build_structure_snapshot(
+            self.tournament_id,
+            legacy_matches=self.legacy_matches,
+            stage_matches=self.stage_matches,
+            stages=self.stages,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MatchSourceRecord:
+    match: dict
+    collection: str
+
+
+def observe_structure_read(snapshot: dict, *, surface: str) -> dict:
+    """Emit one bounded shadow-read record and return its testable metrics."""
+
+    metrics = structure_snapshot_metrics(snapshot)
+    log = logger.warning if metrics["integrity_issue_count"] else logger.info
+    log(
+        "[competition-read] surface=%s tournament=%s schema=%s matches=%s sources=%s results=%s advancement=%s integrity_issues=%s issue_types=%s",
+        surface,
+        snapshot.get("tournament_id"),
+        metrics["schema_version"],
+        metrics["match_count"],
+        metrics["source_counts"],
+        metrics["result_count"],
+        metrics["advancement_count"],
+        metrics["integrity_issue_count"],
+        metrics["integrity_issue_counts"],
+    )
+    return metrics
+
+
+async def load_competition_read_model(
+    db,
+    tournament_id: str,
+    *,
+    legacy_limit: int = 3000,
+    stage_limit: int = 5000,
+    stages_limit: int = 200,
+) -> CompetitionReadModel:
+    """Load both historical stores once, without choosing a write engine."""
+
+    legacy_cursor = db.matches.find({"tournament_id": tournament_id}, {"_id": 0}).sort([
+        ("round", 1),
+        ("match_index", 1),
+    ])
+    stage_cursor = db.matches_v2.find({"tournament_id": tournament_id}, {"_id": 0}).sort([
+        ("stage_number", 1),
+        ("round", 1),
+        ("order", 1),
+    ])
+    stages_cursor = db.tournament_stages.find({"tournament_id": tournament_id}, {"_id": 0}).sort("number", 1)
+    legacy_matches, stage_matches, stages = await asyncio.gather(
+        legacy_cursor.to_list(legacy_limit),
+        stage_cursor.to_list(stage_limit),
+        stages_cursor.to_list(stages_limit),
+    )
+    return CompetitionReadModel(
+        tournament_id=tournament_id,
+        legacy_matches=legacy_matches,
+        stage_matches=stage_matches,
+        stages=stages,
+    )
+
+
+async def find_match_source(db, match_id: str) -> MatchSourceRecord | None:
+    """Resolve a stable match ID while preserving the backing collection."""
+
+    match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
+    if match:
+        return MatchSourceRecord(match=match, collection="matches_v2")
+    match = await db.matches.find_one({"id": match_id}, {"_id": 0})
+    if match:
+        return MatchSourceRecord(match=match, collection="matches")
+    return None
+
+
+async def canonical_match_for_source(db, source_match: dict, collection: str) -> dict | None:
+    """Return one canonical detail while retaining full graph context."""
+
+    tournament_id = source_match.get("tournament_id")
+    match_id = source_match.get("id")
+    if not tournament_id or not match_id:
+        return None
+    read_model = await load_competition_read_model(db, tournament_id)
+    snapshot = read_model.structure_snapshot()
+    observe_structure_read(snapshot, surface="match_detail")
+    return next(
+        (
+            match
+            for match in snapshot["matches"]
+            if match.get("id") == match_id
+            and match.get("source", {}).get("collection") == collection
+        ),
+        None,
+    )

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -7,6 +7,7 @@ specific fields before any tournament changes its source of truth.
 
 from __future__ import annotations
 
+from collections import Counter
 from copy import deepcopy
 from typing import Iterable
 
@@ -373,6 +374,44 @@ def semantic_match_projection(match: dict) -> dict:
     }
 
 
+def compare_structure_snapshots(reference: dict, candidate: dict) -> dict:
+    """Return bounded semantic diff metrics for migration shadow reads."""
+
+    reference_by_id = {
+        match.get("id"): semantic_match_projection(match)
+        for match in reference.get("matches") or []
+        if match.get("id")
+    }
+    candidate_by_id = {
+        match.get("id"): semantic_match_projection(match)
+        for match in candidate.get("matches") or []
+        if match.get("id")
+    }
+    reference_ids = set(reference_by_id)
+    candidate_ids = set(candidate_by_id)
+    shared_ids = reference_ids & candidate_ids
+    mismatches = sorted(
+        match_id
+        for match_id in shared_ids
+        if reference_by_id[match_id] != candidate_by_id[match_id]
+    )
+    missing_ids = sorted(reference_ids - candidate_ids)
+    extra_ids = sorted(candidate_ids - reference_ids)
+    return {
+        "reference_count": len(reference_ids),
+        "candidate_count": len(candidate_ids),
+        "shared_count": len(shared_ids),
+        "mismatch_count": len(mismatches),
+        "missing_count": len(missing_ids),
+        "extra_count": len(extra_ids),
+        "equivalent": not mismatches and not missing_ids and not extra_ids,
+        "mismatch_ids": mismatches[:25],
+        "missing_ids": missing_ids[:25],
+        "extra_ids": extra_ids[:25],
+        "truncated": any(len(items) > 25 for items in (mismatches, missing_ids, extra_ids)),
+    }
+
+
 def structure_snapshot_issues(snapshot: dict) -> list[dict]:
     """Validate read-side graph references without changing source data."""
 
@@ -438,3 +477,27 @@ def structure_snapshot_issues(snapshot: dict) -> list[dict]:
     if any(visit(match_id) for match_id in graph if match_id not in visited):
         issues.append({"code": "advancement_cycle"})
     return issues
+
+
+def structure_snapshot_metrics(snapshot: dict) -> dict:
+    """Build low-cardinality read metrics without persisting another model."""
+
+    matches = snapshot.get("matches") or []
+    issues = structure_snapshot_issues(snapshot)
+    source_counts = Counter(
+        match.get("source", {}).get("engine") or "unknown"
+        for match in matches
+    )
+    status_counts = Counter(str(match.get("status") or "unknown") for match in matches)
+    issue_counts = Counter(issue["code"] for issue in issues)
+    return {
+        "schema_version": snapshot.get("schema_version"),
+        "match_count": len(matches),
+        "stage_count": len(snapshot.get("stages") or []),
+        "source_counts": dict(sorted(source_counts.items())),
+        "status_counts": dict(sorted(status_counts.items())),
+        "result_count": sum(len(match.get("results") or []) for match in matches),
+        "advancement_count": sum(len(match.get("advancement") or []) for match in matches),
+        "integrity_issue_count": len(issues),
+        "integrity_issue_counts": dict(sorted(issue_counts.items())),
+    }

--- a/backend/services/competition_standings.py
+++ b/backend/services/competition_standings.py
@@ -1,0 +1,303 @@
+"""Standings projections over canonical competition matches."""
+
+from __future__ import annotations
+
+
+TERMINAL_MATCH_STATUSES = {"completed", "forfeit"}
+
+
+def _safe_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _display_name(registration: dict) -> str:
+    return (
+        registration.get("display_name")
+        or registration.get("ingame_name")
+        or (registration.get("user") or {}).get("display_name")
+        or "Teilnehmer"
+    )
+
+
+def _duel_entries(match: dict) -> tuple[dict | None, dict | None, dict | None, dict | None]:
+    slots = sorted(match.get("slots") or [], key=lambda slot: _safe_int(slot.get("position"), 999))
+    slot_a = slots[0] if slots else None
+    slot_b = slots[1] if len(slots) > 1 else None
+    results = {row.get("registration_id"): row for row in match.get("results") or []}
+    result_a = results.get((slot_a or {}).get("registration_id"))
+    result_b = results.get((slot_b or {}).get("registration_id"))
+    return slot_a, slot_b, result_a, result_b
+
+
+def stage_standings(matches: list[dict], registrations: list[dict]) -> list[dict]:
+    rank_map = {
+        registration["id"]: {
+            "registration_id": registration["id"],
+            "display_name": _display_name(registration),
+            "played": 0,
+            "won": 0,
+            "top2": 0,
+            "lost": 0,
+            "points": 0,
+            "rank_sum": 0,
+            "furthest_round": 0,
+            "best_rank": None,
+        }
+        for registration in registrations
+        if registration.get("id")
+    }
+    for match in matches:
+        if match.get("status") not in TERMINAL_MATCH_STATUSES:
+            continue
+        for result in match.get("results") or []:
+            registration_id = result.get("registration_id")
+            if registration_id not in rank_map:
+                continue
+            rank = _safe_int(result.get("rank"), 999)
+            row = rank_map[registration_id]
+            row["played"] += 1
+            row["rank_sum"] += rank
+            row["furthest_round"] = max(row["furthest_round"], _safe_int(match.get("round")))
+            row["best_rank"] = rank if row["best_rank"] is None else min(row["best_rank"], rank)
+            if rank == 1:
+                row["won"] += 1
+            if rank <= 2:
+                row["top2"] += 1
+            else:
+                row["lost"] += 1
+            score = result.get("points")
+            if score is None:
+                score = result.get("score")
+            if isinstance(score, (int, float)):
+                row["points"] += score
+    rows = list(rank_map.values())
+    for row in rows:
+        row["avg_rank"] = round(row["rank_sum"] / row["played"], 2) if row["played"] else None
+    rows.sort(
+        key=lambda row: (
+            row["furthest_round"],
+            row["won"],
+            row["top2"],
+            row["points"],
+            -(row["avg_rank"] or 999),
+        ),
+        reverse=True,
+    )
+    for index, row in enumerate(rows, start=1):
+        row["rank"] = index
+    return rows
+
+
+def elimination_standings(matches: list[dict], registrations: list[dict]) -> list[dict]:
+    rank_map = {
+        registration["id"]: {
+            "registration_id": registration["id"],
+            "display_name": _display_name(registration),
+            "furthest_round": 0,
+            "wins": 0,
+            "losses": 0,
+        }
+        for registration in registrations
+        if registration.get("id")
+    }
+    for match in matches:
+        round_number = _safe_int(match.get("round"))
+        for slot in match.get("slots") or []:
+            registration_id = slot.get("registration_id")
+            if registration_id in rank_map:
+                rank_map[registration_id]["furthest_round"] = max(
+                    rank_map[registration_id]["furthest_round"],
+                    round_number,
+                )
+        if match.get("status") not in TERMINAL_MATCH_STATUSES:
+            continue
+        for result in match.get("results") or []:
+            registration_id = result.get("registration_id")
+            if registration_id not in rank_map:
+                continue
+            outcome = result.get("outcome")
+            if outcome == "winner" or (outcome is None and _safe_int(result.get("rank"), 999) == 1):
+                rank_map[registration_id]["wins"] += 1
+            elif outcome in {"loser", "forfeit"} or (outcome is None and result.get("rank") is not None):
+                rank_map[registration_id]["losses"] += 1
+    rows = list(rank_map.values())
+    rows.sort(key=lambda row: (row["furthest_round"], row["wins"], -row["losses"]), reverse=True)
+    for index, row in enumerate(rows, start=1):
+        row["rank"] = index
+    return rows
+
+
+def round_robin_standings(matches: list[dict], registrations: list[dict]) -> list[dict]:
+    stats = {
+        registration["id"]: {
+            "registration_id": registration["id"],
+            "user_id": registration.get("user_id"),
+            "team_id": registration.get("team_id"),
+            "display_name": _display_name(registration),
+            "played": 0,
+            "won": 0,
+            "lost": 0,
+            "drawn": 0,
+            "score_for": 0,
+            "score_against": 0,
+            "points": 0,
+        }
+        for registration in registrations
+        if registration.get("id")
+    }
+    for match in matches:
+        if match.get("status") != "completed":
+            continue
+        slot_a, slot_b, result_a, result_b = _duel_entries(match)
+        registration_a = (slot_a or {}).get("registration_id")
+        registration_b = (slot_b or {}).get("registration_id")
+        score_a = (result_a or {}).get("score")
+        score_b = (result_b or {}).get("score")
+        score_a = score_a if isinstance(score_a, (int, float)) else 0
+        score_b = score_b if isinstance(score_b, (int, float)) else 0
+        if registration_a in stats:
+            stats[registration_a]["played"] += 1
+            stats[registration_a]["score_for"] += score_a
+            stats[registration_a]["score_against"] += score_b
+        if registration_b in stats:
+            stats[registration_b]["played"] += 1
+            stats[registration_b]["score_for"] += score_b
+            stats[registration_b]["score_against"] += score_a
+        winner_id = next(
+            (
+                result.get("registration_id")
+                for result in match.get("results") or []
+                if result.get("outcome") == "winner"
+            ),
+            None,
+        )
+        if winner_id == registration_a and registration_a in stats:
+            stats[registration_a]["won"] += 1
+            stats[registration_a]["points"] += 3
+            if registration_b in stats:
+                stats[registration_b]["lost"] += 1
+        elif winner_id == registration_b and registration_b in stats:
+            stats[registration_b]["won"] += 1
+            stats[registration_b]["points"] += 3
+            if registration_a in stats:
+                stats[registration_a]["lost"] += 1
+        else:
+            if registration_a in stats:
+                stats[registration_a]["drawn"] += 1
+                stats[registration_a]["points"] += 1
+            if registration_b in stats:
+                stats[registration_b]["drawn"] += 1
+                stats[registration_b]["points"] += 1
+    rows = list(stats.values())
+    rows.sort(key=lambda row: (row["points"], row["won"], row["score_for"] - row["score_against"]), reverse=True)
+    for index, row in enumerate(rows, start=1):
+        row["rank"] = index
+    return rows
+
+
+def swiss_standings(matches: list[dict], registrations: list[dict]) -> list[dict]:
+    stats = {
+        registration["id"]: {
+            "registration_id": registration["id"],
+            "display_name": _display_name(registration),
+            "points": 0,
+            "played": 0,
+            "won": 0,
+            "drawn": 0,
+            "lost": 0,
+            "opponents": [],
+        }
+        for registration in registrations
+        if registration.get("id")
+    }
+    for match in matches:
+        if match.get("status") != "completed":
+            continue
+        slot_a, slot_b, _result_a, _result_b = _duel_entries(match)
+        registration_a = (slot_a or {}).get("registration_id")
+        registration_b = (slot_b or {}).get("registration_id")
+        if registration_a not in stats or registration_b not in stats:
+            continue
+        stats[registration_a]["played"] += 1
+        stats[registration_b]["played"] += 1
+        stats[registration_a]["opponents"].append(registration_b)
+        stats[registration_b]["opponents"].append(registration_a)
+        winner_id = next(
+            (
+                result.get("registration_id")
+                for result in match.get("results") or []
+                if result.get("outcome") == "winner"
+            ),
+            None,
+        )
+        if winner_id == registration_a:
+            stats[registration_a]["won"] += 1
+            stats[registration_a]["points"] += 1
+            stats[registration_b]["lost"] += 1
+        elif winner_id == registration_b:
+            stats[registration_b]["won"] += 1
+            stats[registration_b]["points"] += 1
+            stats[registration_a]["lost"] += 1
+        else:
+            stats[registration_a]["drawn"] += 1
+            stats[registration_b]["drawn"] += 1
+            stats[registration_a]["points"] += 0.5
+            stats[registration_b]["points"] += 0.5
+    for row in stats.values():
+        row["buchholz"] = sum(stats[opponent]["points"] for opponent in row["opponents"] if opponent in stats)
+        row.pop("opponents", None)
+    rows = list(stats.values())
+    rows.sort(key=lambda row: (row["points"], row["buchholz"], row["won"]), reverse=True)
+    for index, row in enumerate(rows, start=1):
+        row["rank"] = index
+    return rows
+
+
+def group_standings(matches: list[dict], registrations: list[dict], groups: list[dict]) -> list[dict]:
+    registration_map = {registration["id"]: registration for registration in registrations if registration.get("id")}
+    result = []
+    for group in groups:
+        group_id = group.get("id")
+        section = f"group_{group.get('group_key')}"
+        group_matches = [
+            match
+            for match in matches
+            if match.get("group_id") == group_id or match.get("section") == section
+        ]
+        group_registrations = [
+            registration_map[registration_id]
+            for registration_id in group.get("participant_ids") or []
+            if registration_id in registration_map
+        ]
+        result.append({
+            "group": group,
+            "standings": round_robin_standings(group_matches, group_registrations),
+        })
+    return result
+
+
+def standings_for_structure(
+    tournament: dict,
+    snapshot: dict,
+    registrations: list[dict],
+    *,
+    groups: list[dict] = (),
+) -> list[dict]:
+    """Select the existing standings policy over one canonical read model."""
+
+    matches = snapshot.get("matches") or []
+    stage_matches = [match for match in matches if match.get("source", {}).get("engine") == "stage"]
+    if stage_matches:
+        return stage_standings(stage_matches, registrations)
+    legacy_matches = [match for match in matches if match.get("source", {}).get("engine") == "legacy"]
+    format_key = tournament.get("format")
+    if format_key in {"round_robin", "league"}:
+        return round_robin_standings(legacy_matches, registrations)
+    if format_key == "swiss":
+        return swiss_standings(legacy_matches, registrations)
+    if format_key == "groups":
+        return group_standings(legacy_matches, registrations, list(groups))
+    return elimination_standings(legacy_matches, registrations)

--- a/backend/tests/test_competition_read_unit.py
+++ b/backend/tests/test_competition_read_unit.py
@@ -1,0 +1,104 @@
+import asyncio
+
+from services.competition_read import (
+    canonical_match_for_source,
+    find_match_source,
+    load_competition_read_model,
+    observe_structure_read,
+)
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, *_args):
+        return self
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+
+    def find(self, query, _projection=None):
+        rows = [
+            row
+            for row in self.rows
+            if all(row.get(key) == value for key, value in query.items())
+        ]
+        return FakeCursor(rows)
+
+    async def find_one(self, query, _projection=None):
+        return next(
+            (
+                row
+                for row in self.rows
+                if all(row.get(key) == value for key, value in query.items())
+            ),
+            None,
+        )
+
+
+class FakeDb:
+    def __init__(self):
+        self.matches = FakeCollection([{
+            "id": "legacy-1",
+            "tournament_id": "t1",
+            "participant_a_id": "r1",
+            "participant_b_id": "r2",
+            "status": "ready",
+        }])
+        self.matches_v2 = FakeCollection([{
+            "id": "stage-1",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "match_key": "A",
+            "slots": [],
+            "results": [],
+            "advancement": [],
+            "status": "pending",
+        }])
+        self.tournament_stages = FakeCollection([{
+            "id": "s1",
+            "tournament_id": "t1",
+            "number": 1,
+            "stage_type": "single_elimination",
+        }])
+
+
+def test_read_model_loads_both_stores_into_one_snapshot():
+    model = asyncio.run(load_competition_read_model(FakeDb(), "t1"))
+    snapshot = model.structure_snapshot()
+
+    assert [match["id"] for match in snapshot["matches"]] == ["legacy-1", "stage-1"]
+    assert snapshot["source_engines"] == ["legacy", "stage"]
+    assert snapshot["mixed_source"] is True
+
+
+def test_match_source_prefers_stage_and_canonical_detail_keeps_collection():
+    db = FakeDb()
+    source = asyncio.run(find_match_source(db, "stage-1"))
+    canonical = asyncio.run(canonical_match_for_source(db, source.match, source.collection))
+
+    assert source.collection == "matches_v2"
+    assert canonical["id"] == "stage-1"
+    assert canonical["source"] == {"engine": "stage", "collection": "matches_v2"}
+
+
+def test_missing_match_source_returns_none():
+    assert asyncio.run(find_match_source(FakeDb(), "missing")) is None
+
+
+def test_structure_read_observation_emits_bounded_metrics(caplog):
+    caplog.set_level("INFO", logger="tls.competition_read")
+    model = asyncio.run(load_competition_read_model(FakeDb(), "t1"))
+
+    metrics = observe_structure_read(model.structure_snapshot(), surface="unit")
+
+    assert metrics["match_count"] == 2
+    assert metrics["source_counts"] == {"legacy": 1, "stage": 1}
+    assert metrics["integrity_issue_count"] == 0
+    assert "surface=unit" in caplog.text

--- a/backend/tests/test_competition_snapshot_unit.py
+++ b/backend/tests/test_competition_snapshot_unit.py
@@ -3,8 +3,10 @@ from services.competition_snapshot import (
     adapt_legacy_matches,
     adapt_stage_matches,
     build_structure_snapshot,
+    compare_structure_snapshots,
     semantic_match_projection,
     structure_snapshot_issues,
+    structure_snapshot_metrics,
 )
 
 
@@ -228,3 +230,22 @@ def test_structure_snapshot_validator_reports_broken_duplicate_and_cyclic_edges(
     codes = {issue["code"] for issue in structure_snapshot_issues(snapshot)}
 
     assert {"duplicate_match_id", "missing_advancement_target", "advancement_cycle"} <= codes
+
+
+def test_shadow_diff_and_metrics_are_bounded_and_machine_readable():
+    reference = build_structure_snapshot("t1", legacy_matches=_legacy_fixture())
+    equivalent = build_structure_snapshot("t1", stage_matches=_stage_fixture())
+    changed_fixture = _stage_fixture()
+    changed_fixture[0]["status"] = "in_progress"
+    candidate = build_structure_snapshot("t1", stage_matches=changed_fixture)
+
+    assert compare_structure_snapshots(reference, equivalent)["equivalent"] is True
+    diff = compare_structure_snapshots(reference, candidate)
+    metrics = structure_snapshot_metrics(reference)
+
+    assert diff["mismatch_count"] == 1
+    assert diff["mismatch_ids"] == ["m1"]
+    assert metrics["source_counts"] == {"legacy": 3}
+    assert metrics["result_count"] == 2
+    assert metrics["advancement_count"] == 2
+    assert metrics["integrity_issue_count"] == 0

--- a/backend/tests/test_competition_standings_unit.py
+++ b/backend/tests/test_competition_standings_unit.py
@@ -1,0 +1,111 @@
+from bracket_engine import compute_round_robin_standings
+from bracket_extensions import compute_swiss_standings
+from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matches, build_structure_snapshot
+from services.competition_standings import (
+    elimination_standings,
+    group_standings,
+    round_robin_standings,
+    stage_standings,
+    standings_for_structure,
+    swiss_standings,
+)
+
+
+REGISTRATIONS = [
+    {"id": "r1", "display_name": "Alpha", "user_id": "u1"},
+    {"id": "r2", "display_name": "Bravo", "user_id": "u2"},
+    {"id": "r3", "display_name": "Charlie", "user_id": "u3"},
+]
+
+
+def _legacy_matches():
+    return [
+        {
+            "id": "m1",
+            "tournament_id": "t1",
+            "round": 1,
+            "bracket": "winner",
+            "participant_a_id": "r1",
+            "participant_b_id": "r2",
+            "score_a": 2,
+            "score_b": 1,
+            "winner_id": "r1",
+            "loser_id": "r2",
+            "status": "completed",
+        },
+        {
+            "id": "m2",
+            "tournament_id": "t1",
+            "round": 2,
+            "bracket": "winner",
+            "participant_a_id": "r1",
+            "participant_b_id": "r3",
+            "score_a": 3,
+            "score_b": 3,
+            "winner_id": None,
+            "loser_id": None,
+            "status": "completed",
+        },
+    ]
+
+
+def test_round_robin_and_swiss_match_existing_legacy_calculators():
+    raw = _legacy_matches()
+    canonical = adapt_legacy_matches(raw)
+
+    assert round_robin_standings(canonical, REGISTRATIONS) == compute_round_robin_standings(raw, REGISTRATIONS)
+    assert swiss_standings(canonical, REGISTRATIONS) == compute_swiss_standings(REGISTRATIONS, raw)
+
+
+def test_elimination_standings_uses_canonical_slots_and_results():
+    rows = elimination_standings(adapt_legacy_matches(_legacy_matches()), REGISTRATIONS)
+
+    assert [row["registration_id"] for row in rows] == ["r1", "r3", "r2"]
+    assert rows[0]["wins"] == 1
+    assert rows[0]["furthest_round"] == 2
+
+
+def test_stage_standings_supports_rank_points_and_placement():
+    canonical = adapt_stage_matches([{
+        "id": "ffa-1",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "round": 1,
+        "slots": [
+            {"slot": 1, "registration_id": "r1", "status": "filled", "source": {"type": "seed", "seed": 1}},
+            {"slot": 2, "registration_id": "r2", "status": "filled", "source": {"type": "seed", "seed": 2}},
+            {"slot": 3, "registration_id": "r3", "status": "filled", "source": {"type": "seed", "seed": 3}},
+        ],
+        "results": [
+            {"registration_id": "r1", "rank": 2, "points": 8},
+            {"registration_id": "r2", "rank": 1, "points": 10},
+            {"registration_id": "r3", "rank": 3, "points": 6},
+        ],
+        "advancement": [],
+        "status": "completed",
+    }])
+
+    rows = stage_standings(canonical, REGISTRATIONS)
+
+    assert [row["registration_id"] for row in rows] == ["r2", "r1", "r3"]
+    assert rows[0]["points"] == 10
+    assert rows[0]["best_rank"] == 1
+
+
+def test_group_and_policy_selector_keep_public_shape():
+    raw = [
+        {**match, "bracket": "group_A", "group_id": "g1"}
+        for match in _legacy_matches()
+    ]
+    canonical = adapt_legacy_matches(raw)
+    groups = [{"id": "g1", "group_key": "A", "participant_ids": ["r1", "r2", "r3"]}]
+    grouped = group_standings(canonical, REGISTRATIONS, groups)
+    snapshot = build_structure_snapshot("t1", legacy_matches=raw)
+
+    assert grouped[0]["group"]["id"] == "g1"
+    assert standings_for_structure(
+        {"format": "groups"},
+        snapshot,
+        REGISTRATIONS,
+        groups=groups,
+    ) == grouped


### PR DESCRIPTION
## Zusammenfassung

Zweiter isolierter Schritt von Paket 2 aus #120:

- führt eine gemeinsame, ausschließlich lesende Datenbankgrenze für Legacy-, Stage- und Stage-Metadaten ein;
- zentralisiert die Match-ID-Auflösung und liefert in der bestehenden Match-Page-Payload zusätzlich `canonical_match`;
- berechnet Stage-, Elimination-, Round-Robin-/Liga-, Swiss- und Gruppen-Standings aus dem kanonischen Matchvertrag;
- entfernt die duplizierte Stage-Standings-Implementierung aus den Turnierrouten;
- erzeugt pro produktivem Struktur-Read begrenzte Counts für Quellen, Status, Resultate, Advancement und Integritätsfehler;
- ergänzt einen begrenzten semantischen Snapshot-Diff für spätere Shadow-Migrationstests;
- dokumentiert den exakten Migrationsstand aller relevanten Read-Consumer.

Bestehende Rohfelder und Endpunkte bleiben erhalten. Es gibt weiterhin keine Datenmigration, kein Dual-Write und keinen Engine-Cutover.

## Verifikation

- `python -m pytest -q`
- Ergebnis: `280 passed, 282 skipped, 1 warning`
- `python -m compileall -q services routes`
- `git diff --check`

Refs #120
Teil von #95