### PR TITLE
fix: include stage matches in widgets and PDFs

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -174,7 +174,7 @@ geschrieben.
 | Turnier-Standings | kanonisch aktiv | konfigurierbare RankingPolicy folgt im Schreibkern |
 | Profile / DSGVO | beide Stores, aber eigene Projektionen | auf Read-Service umstellen |
 | Preise / Saisonwertung | beide Stores, aber eigene Projektionen | kanonische Standings konsumieren |
-| Widget / Match-PDF | weiterhin Legacy-only | priorisierter naechster Read-Consumer |
+| Widget / Match-PDF | kanonische Struktur bzw. variable Slots aktiv | alte Widget-Felder bis zum Frontend-Cutover behalten |
 | Badges / Admin-Zaehler / Penalties | weiterhin Legacy-lastig | vor Engine-Cutover migrieren |
 | Reminder / Notifications / Stationen | beide Formen mit Sonderzweigen | gemeinsame Match-Projektion verwenden |
 

--- a/backend/pdf_service.py
+++ b/backend/pdf_service.py
@@ -342,26 +342,128 @@ def pdf_f1_leaderboard(challenge: dict, track: dict, entries: list, pdf_sponsors
     return buf.getvalue()
 
 
+def _pdf_registration_name(registration: dict | None) -> str:
+    return str(
+        (registration or {}).get("display_name")
+        or (registration or {}).get("ingame_name")
+        or "TBD"
+    )
+
+
+def _pdf_slot_position(slot: dict) -> int:
+    try:
+        return int(slot.get("position") or slot.get("slot") or 999)
+    except (TypeError, ValueError):
+        return 999
+
+
+def _pdf_match_slots(match: dict) -> list[dict]:
+    if match.get("slots"):
+        return sorted(
+            match.get("slots") or [],
+            key=_pdf_slot_position,
+        )
+    return [
+        {"position": 1, "registration_id": match.get("participant_a_id")},
+        {"position": 2, "registration_id": match.get("participant_b_id")},
+    ]
+
+
+def _pdf_result_value(result: dict | None, *, include_rank: bool = False) -> str:
+    if not result:
+        return ""
+    value = result.get("points")
+    suffix = " P"
+    if value is None:
+        value = result.get("score")
+        suffix = ""
+    if value is None and result.get("time_ms") is not None:
+        value = f"{result['time_ms']} ms"
+        suffix = ""
+    rank = result.get("rank")
+    if value is not None and include_rank and rank is not None:
+        return f"#{rank} · {value}{suffix}"
+    if value is not None:
+        return f"{value}{suffix}"
+    return f"#{rank}" if rank is not None else ""
+
+
+def _pdf_duel_row(match: dict, reg_map: dict) -> list[str]:
+    slots = _pdf_match_slots(match)
+    slot_a = slots[0] if slots else {}
+    slot_b = slots[1] if len(slots) > 1 else {}
+    result_map = {
+        result.get("registration_id"): result
+        for result in match.get("results") or []
+        if result.get("registration_id")
+    }
+    registration_a = slot_a.get("registration_id")
+    registration_b = slot_b.get("registration_id")
+    score_a = _pdf_result_value(result_map.get(registration_a))
+    score_b = _pdf_result_value(result_map.get(registration_b))
+    if not match.get("slots"):
+        score_a = str(match.get("score_a", 0))
+        score_b = str(match.get("score_b", 0))
+    return [
+        match.get("round_name") or f"R{match.get('round')}",
+        _pdf_registration_name(reg_map.get(registration_a)),
+        f"{score_a or '—'} : {score_b or '—'}",
+        _pdf_registration_name(reg_map.get(registration_b)),
+        match.get("scheduled_at") or "—",
+        match.get("station_label") or match.get("station_name") or match.get("station_id") or "—",
+        match.get("status") or "—",
+    ]
+
+
+def _pdf_multi_slot_rows(match: dict, reg_map: dict) -> list[list[str]]:
+    result_map = {
+        result.get("registration_id"): result
+        for result in match.get("results") or []
+        if result.get("registration_id")
+    }
+    rows = []
+    slots = _pdf_match_slots(match)
+    for index, slot in enumerate(slots):
+        registration_id = slot.get("registration_id")
+        name = _pdf_registration_name(reg_map.get(registration_id))
+        value = _pdf_result_value(result_map.get(registration_id), include_rank=True)
+        rows.append([
+            (match.get("round_name") or f"R{match.get('round')}") if index == 0 else "",
+            f"{name} ({value})" if value else name,
+            (match.get("scheduled_at") or "—") if index == 0 else "",
+            (match.get("station_label") or match.get("station_name") or match.get("station_id") or "—") if index == 0 else "",
+            (match.get("status") or "—") if index == 0 else "",
+        ])
+    return rows or [[
+        match.get("round_name") or f"R{match.get('round')}",
+        "TBD",
+        match.get("scheduled_at") or "—",
+        match.get("station_label") or match.get("station_name") or match.get("station_id") or "—",
+        match.get("status") or "—",
+    ]]
+
+
+def _pdf_match_table(matches: list, reg_map: dict) -> tuple[list[str], list[list[str]], list]:
+    multi_slot = any(len(_pdf_match_slots(match)) > 2 for match in matches)
+    if multi_slot:
+        headers = ["Runde", "Teilnehmer / Ergebnis", "Zeit", "Station", "Status"]
+        rows = [row for match in matches for row in _pdf_multi_slot_rows(match, reg_map)]
+        widths = [3 * cm, 13 * cm, 3.25 * cm, 3 * cm, 3.25 * cm]
+    else:
+        headers = ["Runde", "Teilnehmer A", "vs", "Teilnehmer B", "Zeit", "Station", "Status"]
+        rows = [_pdf_duel_row(match, reg_map) for match in matches]
+        widths = [3.5 * cm, 6 * cm, 2.5 * cm, 6 * cm, 3 * cm, 2.5 * cm, 3 * cm]
+    return headers, rows, widths
+
+
 def pdf_matches(tournament: dict, matches: list, reg_map: dict, pdf_sponsors: list | None = None, pdf_branding: dict | None = None) -> bytes:
     buf = io.BytesIO()
     doc = _doc(buf, f"Matchplan - {tournament.get('title','')}", "landscape", sponsors=pdf_sponsors, branding=pdf_branding)
     styles = _base_styles()
     story = []
     _header(story, styles, "Matchplan", tournament.get("title", ""))
-    data = [["Runde", "Teilnehmer A", "vs", "Teilnehmer B", "Zeit", "Station", "Status"]]
-    for m in matches:
-        a = reg_map.get(m.get("participant_a_id"))
-        b = reg_map.get(m.get("participant_b_id"))
-        data.append([
-            m.get("round_name", f"R{m.get('round')}"),
-            (a or {}).get("display_name", "TBD"),
-            f"{m.get('score_a',0)} : {m.get('score_b',0)}",
-            (b or {}).get("display_name", "TBD"),
-            m.get("scheduled_at", "") or "—",
-            m.get("station_id", "") or "—",
-            m.get("status", "—"),
-        ])
-    t = Table(data, colWidths=[3.5 * cm, 6 * cm, 2.5 * cm, 6 * cm, 3 * cm, 2.5 * cm, 3 * cm], repeatRows=1)
+    headers, rows, widths = _pdf_match_table(matches, reg_map)
+    t = Table([headers, *rows], colWidths=widths, repeatRows=1)
     t.setStyle(_table_style())
     story.append(t)
     doc.build(story, onFirstPage=_page_bg, onLaterPages=_page_bg)

--- a/backend/routes/extras_routes.py
+++ b/backend/routes/extras_routes.py
@@ -14,6 +14,7 @@ from auth import require_admin, require_role, require_super, get_current_user, g
 from services.visibility import user_can_see
 from services.slug_utils import apply_slug_history, find_by_slug_or_history, slug_source_for_update, unique_slug
 from services.access_links import validate_access_link
+from services.competition_read import load_competition_read_model, observe_structure_read
 from services.public_site_settings import PUBLIC_LEGAL_SOURCE_FIELDS, build_public_legal_settings
 from models import now_utc, new_id
 from email_service import send_template, _get_email_config
@@ -1537,6 +1538,25 @@ def _public_registration(reg: dict) -> dict:
     }
 
 
+def _public_widget_legacy_match(match: dict) -> dict:
+    return {
+        key: value
+        for key, value in match.items()
+        if key not in {"admin_note", "reports", "disputes"}
+    }
+
+
+def _public_widget_stage_match(match: dict) -> dict:
+    public_fields = {
+        "id", "tournament_id", "stage_id", "stage_number", "stage_type",
+        "match_type", "match_key", "section", "round", "round_name", "order",
+        "slots", "results", "advancement", "status", "is_preview",
+        "generation_mode", "scheduled_at", "duration_minutes", "station_id",
+        "station_label", "station_name", "map", "best_of",
+    }
+    return {key: value for key, value in match.items() if key in public_fields}
+
+
 def _public_challenge_summary(challenge: dict) -> dict:
     return {
         "id": challenge.get("id"),
@@ -1551,14 +1571,22 @@ async def widget_bracket(slug_or_id: str):
     """Read-only bracket data for widget embed."""
     db = get_db()
     t = await _public_tournament_or_404(slug_or_id)
-    matches = await db.matches.find({"tournament_id": t["id"]}, {"_id": 0, "admin_note": 0,
-                                                                    "reports": 0, "disputes": 0}).to_list(2000)
+    read_model = await load_competition_read_model(db, t["id"])
+    structure = read_model.structure_snapshot()
+    observe_structure_read(structure, surface="widget")
     regs = await db.tournament_registrations.find(
         {"tournament_id": t["id"]},
         {"_id": 0},
     ).to_list(500)
-    return {"tournament": {"id": t["id"], "title": t["title"], "format": t["format"], "status": t["status"]},
-            "matches": matches, "registrations": [_public_registration(r) for r in regs]}
+    return {
+        "tournament": {"id": t["id"], "title": t["title"], "format": t["format"], "status": t["status"]},
+        "matches": [_public_widget_legacy_match(match) for match in read_model.legacy_matches],
+        "matches_v2": [_public_widget_stage_match(match) for match in read_model.stage_matches],
+        "stages": read_model.stages,
+        "engine": "stage" if read_model.stages or read_model.stage_matches else "legacy",
+        "structure": structure,
+        "registrations": [_public_registration(r) for r in regs],
+    }
 
 
 @widget_router.get("/f1/{slug_or_id}/leaderboard")
@@ -1914,7 +1942,10 @@ async def pdf_tournament_matches(slug_or_id: str, me: dict = Depends(require_rol
     t = await db.tournaments.find_one({"$or": [{"id": slug_or_id}, {"slug": slug_or_id}]}, {"_id": 0})
     if not t:
         raise HTTPException(status_code=404)
-    matches = await db.matches.find({"tournament_id": t["id"]}, {"_id": 0}).sort("round", 1).to_list(2000)
+    read_model = await load_competition_read_model(db, t["id"])
+    structure = read_model.structure_snapshot()
+    observe_structure_read(structure, surface="match_pdf")
+    matches = structure["matches"]
     regs = await db.tournament_registrations.find({"tournament_id": t["id"]}, {"_id": 0}).to_list(500)
     reg_map = {r["id"]: r for r in regs}
     sponsors = await _pdf_sponsors(db)

--- a/backend/tests/test_pdf_exports_unit.py
+++ b/backend/tests/test_pdf_exports_unit.py
@@ -1,6 +1,7 @@
 import re
 
 from pdf_service import (
+    _pdf_match_table,
     pdf_checkin,
     pdf_certificate,
     pdf_certificates,
@@ -130,3 +131,40 @@ def test_table_exports_generate_valid_pdfs():
 
     for payload in exports:
         assert_pdf_bytes(payload, minimum_size=20_000)
+
+
+def test_match_pdf_table_keeps_all_stage_ffa_slots_and_rank_results():
+    reg_map = {
+        "r1": {"display_name": "Alpha"},
+        "r2": {"display_name": "Bravo"},
+        "r3": {"display_name": "Charlie"},
+    }
+    matches = [{
+        "round_name": "Finale",
+        "slots": [
+            {"position": 1, "registration_id": "r1"},
+            {"position": 2, "registration_id": "r2"},
+            {"position": 3, "registration_id": "r3"},
+        ],
+        "results": [
+            {"registration_id": "r2", "rank": 1, "points": 10},
+            {"registration_id": "r1", "rank": 2, "points": 8},
+            {"registration_id": "r3", "rank": 3, "points": 6},
+        ],
+        "station_label": "Main Stage",
+        "status": "completed",
+    }]
+
+    headers, rows, _widths = _pdf_match_table(matches, reg_map)
+
+    assert headers == ["Runde", "Teilnehmer / Ergebnis", "Zeit", "Station", "Status"]
+    assert len(rows) == 3
+    assert rows[0][0] == "Finale"
+    assert [row[1] for row in rows] == [
+        "Alpha (#2 · 8 P)",
+        "Bravo (#1 · 10 P)",
+        "Charlie (#3 · 6 P)",
+    ]
+    assert rows[0][3] == "Main Stage"
+    assert rows[1][0] == ""
+    assert_pdf_bytes(pdf_matches(TOURNAMENT, matches, reg_map, SPONSORS, BRANDING), minimum_size=20_000)

--- a/backend/tests/test_widget_competition_read_unit.py
+++ b/backend/tests/test_widget_competition_read_unit.py
@@ -73,7 +73,7 @@ def test_widget_bracket_exposes_stage_data_and_keeps_legacy_fields(monkeypatch):
     async def visible_tournament(_slug_or_id):
         return tournament
 
-    monkeypatch.setattr(extras_routes, "get_db", lambda: FakeDb())
+    monkeypatch.setattr(extras_routes, "get_db", FakeDb)
     monkeypatch.setattr(extras_routes, "_public_tournament_or_404", visible_tournament)
 
     payload = asyncio.run(extras_routes.widget_bracket("ffa-cup"))

--- a/backend/tests/test_widget_competition_read_unit.py
+++ b/backend/tests/test_widget_competition_read_unit.py
@@ -1,0 +1,92 @@
+import asyncio
+
+from routes import extras_routes
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, *_args):
+        return self
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+
+    def find(self, query, _projection=None):
+        return FakeCursor([
+            row
+            for row in self.rows
+            if all(row.get(key) == value for key, value in query.items())
+        ])
+
+
+class FakeDb:
+    def __init__(self):
+        self.matches = FakeCollection()
+        self.matches_v2 = FakeCollection([{
+            "id": "ffa-1",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "stage_number": 1,
+            "match_key": "A",
+            "round": 1,
+            "match_type": "ffa",
+            "slots": [
+                {"slot": 1, "registration_id": "r1", "status": "filled", "source": {"type": "seed", "seed": 1}},
+                {"slot": 2, "registration_id": "r2", "status": "filled", "source": {"type": "seed", "seed": 2}},
+                {"slot": 3, "registration_id": "r3", "status": "filled", "source": {"type": "seed", "seed": 3}},
+            ],
+            "results": [],
+            "advancement": [],
+            "status": "ready",
+            "admin_note": "internal",
+            "result_meta": {"proof_url": "internal"},
+        }])
+        self.tournament_stages = FakeCollection([{
+            "id": "s1",
+            "tournament_id": "t1",
+            "number": 1,
+            "stage_type": "ffa_custom_bracket",
+            "match_type": "ffa",
+        }])
+        self.tournament_registrations = FakeCollection([
+            {"id": "r1", "tournament_id": "t1", "display_name": "Alpha", "status": "approved"},
+            {"id": "r2", "tournament_id": "t1", "display_name": "Bravo", "status": "approved"},
+            {"id": "r3", "tournament_id": "t1", "display_name": "Charlie", "status": "approved"},
+        ])
+
+
+def test_widget_bracket_exposes_stage_data_and_keeps_legacy_fields(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "title": "FFA Cup",
+        "format": "ffa_custom_bracket",
+        "status": "live",
+    }
+
+    async def visible_tournament(_slug_or_id):
+        return tournament
+
+    monkeypatch.setattr(extras_routes, "get_db", lambda: FakeDb())
+    monkeypatch.setattr(extras_routes, "_public_tournament_or_404", visible_tournament)
+
+    payload = asyncio.run(extras_routes.widget_bracket("ffa-cup"))
+
+    assert payload["matches"] == []
+    assert [match["id"] for match in payload["matches_v2"]] == ["ffa-1"]
+    assert "admin_note" not in payload["matches_v2"][0]
+    assert "result_meta" not in payload["matches_v2"][0]
+    assert payload["engine"] == "stage"
+    assert payload["structure"]["schema_version"] == "competition.structure.v1"
+    assert len(payload["structure"]["matches"][0]["slots"]) == 3
+    assert [registration["display_name"] for registration in payload["registrations"]] == [
+        "Alpha",
+        "Bravo",
+        "Charlie",
+    ]


### PR DESCRIPTION
## Zusammenfassung

Dritter read-only Consumer-Schritt aus Paket 2 von #120:

- erweitert das bestehende Turnier-Widget additiv um `matches_v2`, `stages`, `engine` und die kanonische `structure`;
- behält das bisherige Legacy-Feld `matches` unverändert kompatibel;
- filtert interne Stage-Admin- und Result-Metadaten aus der öffentlichen Widget-Antwort;
- lädt den Match-PDF-Export über die zentrale Competition-Read-Grenze;
- unterstützt im PDF sowohl Legacy-/Stage-Duelle als auch variable FFA-Slots;
- zeigt FFA-Platzierung/Punkte pro Teilnehmer in separaten, seitenumbruchfähigen Tabellenzeilen;
- aktualisiert die Read-Consumer-Matrix und ergänzt Widget-/PDF-Regressionstests.

Keine Datenmigration, kein Schreibpfad und kein Engine-Cutover.

## Verifikation

- `python -m pytest -q`
- Ergebnis: `282 passed, 282 skipped, 1 warning`
- `git diff --check`

Refs #120
Teil von #95