### PR TITLE
fix: cover stage matches in profiles and privacy

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -172,7 +172,7 @@ geschrieben.
 | Match-Overview | kanonisch aktiv | keine Legacy-Sonderlogik mehr hinzufuegen |
 | Match-Detail | `canonical_match` zusaetzlich aktiv | UI nach Paritaet umstellen |
 | Turnier-Standings | kanonisch aktiv | konfigurierbare RankingPolicy folgt im Schreibkern |
-| Profile / DSGVO | beide Stores, aber eigene Projektionen | auf Read-Service umstellen |
+| Profile / DSGVO | kanonische Standings, Match-Stats, Export und Referenz-Anonymisierung aktiv | weitere Chat-/Termin-/Audit-Referenzen separat pruefen |
 | Preise / Saisonwertung | beide Stores, aber eigene Projektionen | kanonische Standings konsumieren |
 | Widget / Match-PDF | kanonische Struktur bzw. variable Slots aktiv | alte Widget-Felder bis zum Frontend-Cutover behalten |
 | Badges / Admin-Zaehler / Penalties | weiterhin Legacy-lastig | vor Engine-Cutover migrieren |

--- a/backend/routes/extras_routes.py
+++ b/backend/routes/extras_routes.py
@@ -14,6 +14,7 @@ from auth import require_admin, require_role, require_super, get_current_user, g
 from services.visibility import user_can_see
 from services.slug_utils import apply_slug_history, find_by_slug_or_history, slug_source_for_update, unique_slug
 from services.access_links import validate_access_link
+from services.competition_privacy import registration_match_snapshot
 from services.competition_read import load_competition_read_model, observe_structure_read
 from services.public_site_settings import PUBLIC_LEGAL_SOURCE_FIELDS, build_public_legal_settings
 from models import now_utc, new_id
@@ -1637,6 +1638,10 @@ async def export_my_data(me: dict = Depends(get_current_user)):
     db = get_db()
     u = await db.users.find_one({"id": me["id"]}, {"_id": 0, "password_hash": 0})
     regs = await db.tournament_registrations.find({"user_id": me["id"]}, {"_id": 0}).to_list(500)
+    competition_matches = await registration_match_snapshot(
+        db,
+        [registration.get("id") for registration in regs if registration.get("id")],
+    )
     lap_times = await db.f1_lap_times.find({"user_id": me["id"]}, {"_id": 0}).to_list(500)
     teams = await db.teams.find({"member_ids": me["id"]}, {"_id": 0}).to_list(100)
     emails = await db.email_logs.find({"to": u.get("email", "")}, {"_id": 0}).to_list(200)
@@ -1644,6 +1649,7 @@ async def export_my_data(me: dict = Depends(get_current_user)):
         "exported_at": now_utc().isoformat(),
         "user": u,
         "tournament_registrations": regs,
+        "competition_matches": competition_matches,
         "f1_lap_times": lap_times,
         "teams": teams,
         "email_logs": emails,

--- a/backend/routes/user_routes.py
+++ b/backend/routes/user_routes.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, HTTPException, Depends
 from database import get_db
 from auth import get_current_user, get_optional_user, require_admin, require_super, hash_password, hash_token
 from email_service import send_template
+from services.competition_privacy import anonymize_registration_match_references, registration_match_snapshot
+from services.competition_standings import registration_match_summary
 from services.membership_service import get_membership, derived_user_type, is_active_member
 from services.profile_references import empty_profile_references, personal_profile_references
 from services.visibility import user_can_see
@@ -662,16 +664,10 @@ async def get_public_profile(username: str, viewer: dict | None = Depends(get_op
                 stats["wins"] += 1
             if final_pos and final_pos <= 3:
                 stats["top3"] += 1
-        # Match stats — look up by registration_id
-        reg_ids = visible_reg_ids
-        matches = await db.matches.find(
-            {"$or": [{"participant_a_id": {"$in": reg_ids}},
-                     {"participant_b_id": {"$in": reg_ids}}],
-             "status": "completed"}, {"_id": 0}).to_list(500)
-        for m in matches:
-            stats["matches_played"] += 1
-            if m.get("winner_id") in reg_ids:
-                stats["matches_won"] += 1
+        # Match stats use the canonical projection so Stage/FFA results count too.
+        canonical_matches = await registration_match_snapshot(db, visible_reg_ids, limit=500)
+        match_summary = registration_match_summary(canonical_matches, set(visible_reg_ids))
+        stats.update(match_summary)
         # F1 / Fast Lap
         from routes.f1_routes import _ms_to_time_str
         # Per track best
@@ -890,6 +886,11 @@ async def delete_user(user_id: str, me: dict = Depends(require_super())):
         raise HTTPException(status_code=404, detail="Nutzer nicht gefunden")
     regs = await db.tournament_registrations.find({"user_id": user_id}, {"_id": 0, "id": 1}).to_list(1000)
     reg_ids = [r["id"] for r in regs if r.get("id")]
+    match_anonymization = await anonymize_registration_match_references(
+        db,
+        reg_ids,
+        updated_at=now_utc().isoformat(),
+    )
     await db.users.delete_one({"id": user_id})
     await db.refresh_tokens.delete_many({"user_id": user_id})
     await db.login_attempts.delete_many({"identifier": user.get("email")})
@@ -899,12 +900,6 @@ async def delete_user(user_id: str, me: dict = Depends(require_super())):
     await db.tournament_registrations.delete_many({"user_id": user_id})
     await db.tournament_staff_assignments.delete_many({"user_id": user_id})
     await db.event_registrations.delete_many({"user_id": user_id})
-    if reg_ids:
-        for field in ("participant_a_id", "participant_b_id", "winner_id", "loser_id"):
-            await db.matches.update_many(
-                {field: {"$in": reg_ids}},
-                {"$set": {field: None, "status": "waiting_result", "updated_at": now_utc().isoformat()}},
-            )
     await db.f1_lap_times.delete_many({"user_id": user_id})
     await db.team_members.delete_many({"user_id": user_id})
     await db.teams.update_many({}, {"$pull": {"member_ids": user_id, "co_leader_ids": user_id}})
@@ -915,7 +910,11 @@ async def delete_user(user_id: str, me: dict = Depends(require_super())):
         "action": "user.delete",
         "target_id": user_id,
         "actor_id": me["id"],
-        "data": {"email": user.get("email"), "username": user.get("username")},
+        "data": {
+            "email": user.get("email"),
+            "username": user.get("username"),
+            "anonymized_match_references": match_anonymization,
+        },
         "created_at": now_utc().isoformat(),
     })
     return {"ok": True}

--- a/backend/services/competition_privacy.py
+++ b/backend/services/competition_privacy.py
@@ -1,0 +1,127 @@
+"""GDPR-safe competition exports and registration-reference anonymization."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matches
+
+
+TERMINAL_MATCH_STATUSES = {"completed", "forfeit", "cancelled", "archived", "bye"}
+
+
+def _privacy_match_projection(match: dict) -> dict:
+    projected = deepcopy(match)
+    for slot in projected.get("slots") or []:
+        slot["user_id"] = None
+    for result in projected.get("results") or []:
+        result["note"] = None
+    return projected
+
+
+async def registration_match_snapshot(db, registration_ids: list[str], *, limit: int = 5000) -> list[dict]:
+    """Export every canonical match that references one of the registrations."""
+
+    ids = sorted({registration_id for registration_id in registration_ids if registration_id})
+    if not ids:
+        return []
+    legacy_cursor = db.matches.find(
+        {"$or": [
+            {"participant_a_id": {"$in": ids}},
+            {"participant_b_id": {"$in": ids}},
+            {"winner_id": {"$in": ids}},
+            {"loser_id": {"$in": ids}},
+        ]},
+        {"_id": 0},
+    )
+    stage_cursor = db.matches_v2.find(
+        {"$or": [
+            {"slots.registration_id": {"$in": ids}},
+            {"results.registration_id": {"$in": ids}},
+        ]},
+        {"_id": 0},
+    )
+    legacy, stage = await asyncio.gather(
+        legacy_cursor.to_list(limit),
+        stage_cursor.to_list(limit),
+    )
+    return [
+        _privacy_match_projection(match)
+        for match in [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
+    ]
+
+
+def anonymized_legacy_match(match: dict, registration_ids: set[str], updated_at: str) -> dict | None:
+    updates = {}
+    for field in ("participant_a_id", "participant_b_id", "winner_id", "loser_id"):
+        if match.get(field) in registration_ids:
+            updates[field] = None
+    if not updates:
+        return None
+    if match.get("status") not in TERMINAL_MATCH_STATUSES:
+        updates["status"] = "waiting_result"
+    updates["updated_at"] = updated_at
+    return updates
+
+
+def anonymized_stage_match(match: dict, registration_ids: set[str], updated_at: str) -> dict | None:
+    slots = deepcopy(match.get("slots") or [])
+    results = deepcopy(match.get("results") or [])
+    changed = False
+    for slot in slots:
+        if slot.get("registration_id") in registration_ids:
+            slot["registration_id"] = None
+            slot["user_id"] = None
+            slot["status"] = "anonymized"
+            changed = True
+    for result in results:
+        if result.get("registration_id") in registration_ids:
+            result["registration_id"] = None
+            result["note"] = None
+            changed = True
+    if not changed:
+        return None
+    updates = {"slots": slots, "results": results, "updated_at": updated_at}
+    if match.get("status") not in TERMINAL_MATCH_STATUSES:
+        updates["status"] = "waiting_result"
+    return updates
+
+
+async def anonymize_registration_match_references(
+    db,
+    registration_ids: list[str],
+    *,
+    updated_at: str,
+) -> dict:
+    ids = {registration_id for registration_id in registration_ids if registration_id}
+    if not ids:
+        return {"legacy_matches": 0, "stage_matches": 0}
+    query_ids = sorted(ids)
+    legacy_cursor = db.matches.find({"$or": [
+        {"participant_a_id": {"$in": query_ids}},
+        {"participant_b_id": {"$in": query_ids}},
+        {"winner_id": {"$in": query_ids}},
+        {"loser_id": {"$in": query_ids}},
+    ]})
+    stage_cursor = db.matches_v2.find({"$or": [
+        {"slots.registration_id": {"$in": query_ids}},
+        {"results.registration_id": {"$in": query_ids}},
+    ]})
+    legacy, stage = await asyncio.gather(
+        legacy_cursor.to_list(5000),
+        stage_cursor.to_list(5000),
+    )
+    legacy_count = 0
+    stage_count = 0
+    for match in legacy:
+        updates = anonymized_legacy_match(match, ids, updated_at)
+        if updates:
+            await db.matches.update_one({"id": match["id"]}, {"$set": updates})
+            legacy_count += 1
+    for match in stage:
+        updates = anonymized_stage_match(match, ids, updated_at)
+        if updates:
+            await db.matches_v2.update_one({"id": match["id"]}, {"$set": updates})
+            stage_count += 1
+    return {"legacy_matches": legacy_count, "stage_matches": stage_count}

--- a/backend/services/competition_standings.py
+++ b/backend/services/competition_standings.py
@@ -301,3 +301,28 @@ def standings_for_structure(
     if format_key == "groups":
         return group_standings(legacy_matches, registrations, list(groups))
     return elimination_standings(legacy_matches, registrations)
+
+
+def registration_match_summary(matches: list[dict], registration_ids: set[str]) -> dict:
+    """Count terminal matches and wins once across canonical match shapes."""
+
+    played = 0
+    won = 0
+    for match in matches:
+        if match.get("status") not in TERMINAL_MATCH_STATUSES:
+            continue
+        participants = {
+            slot.get("registration_id")
+            for slot in match.get("slots") or []
+            if slot.get("registration_id")
+        }
+        if not participants.intersection(registration_ids):
+            continue
+        played += 1
+        if any(
+            result.get("registration_id") in registration_ids
+            and result.get("outcome") == "winner"
+            for result in match.get("results") or []
+        ):
+            won += 1
+    return {"matches_played": played, "matches_won": won}

--- a/backend/services/profile_references.py
+++ b/backend/services/profile_references.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from database import get_db
+from services.competition_read import load_competition_read_model, observe_structure_read
+from services.competition_standings import standings_for_structure
 from services.visibility import user_can_see
 
 RESULT_TOURNAMENT_STATUSES = {"completed", "results_published", "archived"}
@@ -125,218 +127,6 @@ async def _ranked_fastlap_entries(challenge_id: str, track_id: str, user_id: str
     return None
 
 
-def _v2_standings(matches_v2: list[dict], regs: list[dict]) -> list[dict]:
-    rank_map = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "display_name": r.get("display_name") or r.get("ingame_name") or r.get("user", {}).get("display_name"),
-            "played": 0,
-            "won": 0,
-            "top2": 0,
-            "lost": 0,
-            "points": 0,
-            "rank_sum": 0,
-            "furthest_round": 0,
-            "best_rank": None,
-        }
-        for r in regs
-        if r.get("id")
-    }
-    for match in matches_v2:
-        if match.get("status") not in {"completed", "forfeit"}:
-            continue
-        for result in match.get("results") or []:
-            rid = result.get("registration_id")
-            if rid not in rank_map:
-                continue
-            rank = _safe_int(result.get("rank")) or 999
-            row = rank_map[rid]
-            row["played"] += 1
-            row["rank_sum"] += rank
-            row["furthest_round"] = max(row["furthest_round"], _safe_int(match.get("round")) or 0)
-            row["best_rank"] = rank if row["best_rank"] is None else min(row["best_rank"], rank)
-            if rank == 1:
-                row["won"] += 1
-            if rank <= 2:
-                row["top2"] += 1
-            else:
-                row["lost"] += 1
-            score = result.get("points")
-            if score is None:
-                score = result.get("score")
-            if isinstance(score, (int, float)):
-                row["points"] += score
-    rows = list(rank_map.values())
-    for row in rows:
-        row["avg_rank"] = round(row["rank_sum"] / row["played"], 2) if row["played"] else None
-    rows.sort(
-        key=lambda row: (
-            row["furthest_round"],
-            row["won"],
-            row["top2"],
-            row["points"],
-            -(row["avg_rank"] or 999),
-        ),
-        reverse=True,
-    )
-    for index, row in enumerate(rows, start=1):
-        row["rank"] = index
-    return rows
-
-
-def _legacy_elimination_standings(matches: list[dict], regs: list[dict]) -> list[dict]:
-    rank_map = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "display_name": r.get("display_name") or r.get("ingame_name") or "Teilnehmer",
-            "furthest_round": 0,
-            "wins": 0,
-            "losses": 0,
-        }
-        for r in regs
-        if r.get("id")
-    }
-    for match in matches:
-        a = match.get("participant_a_id")
-        b = match.get("participant_b_id")
-        winner = match.get("winner_id")
-        round_number = _safe_int(match.get("round")) or 0
-        if a in rank_map:
-            rank_map[a]["furthest_round"] = max(rank_map[a]["furthest_round"], round_number)
-        if b in rank_map:
-            rank_map[b]["furthest_round"] = max(rank_map[b]["furthest_round"], round_number)
-        if match.get("status") in {"completed", "forfeit"} and winner:
-            loser = a if winner == b else b
-            if winner in rank_map:
-                rank_map[winner]["wins"] += 1
-            if loser in rank_map:
-                rank_map[loser]["losses"] += 1
-    rows = list(rank_map.values())
-    rows.sort(key=lambda row: (row["furthest_round"], row["wins"], -row["losses"]), reverse=True)
-    for index, row in enumerate(rows, start=1):
-        row["rank"] = index
-    return rows
-
-
-def _round_robin_standings(matches: list[dict], regs: list[dict]) -> list[dict]:
-    stats = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "display_name": r.get("display_name") or r.get("ingame_name") or "Teilnehmer",
-            "played": 0,
-            "won": 0,
-            "lost": 0,
-            "drawn": 0,
-            "score_for": 0,
-            "score_against": 0,
-            "points": 0,
-        }
-        for r in regs
-        if r.get("id")
-    }
-    for match in matches:
-        if match.get("status") != "completed":
-            continue
-        a = match.get("participant_a_id")
-        b = match.get("participant_b_id")
-        score_a = _safe_int(match.get("score_a")) or 0
-        score_b = _safe_int(match.get("score_b")) or 0
-        if a in stats:
-            stats[a]["played"] += 1
-            stats[a]["score_for"] += score_a
-            stats[a]["score_against"] += score_b
-        if b in stats:
-            stats[b]["played"] += 1
-            stats[b]["score_for"] += score_b
-            stats[b]["score_against"] += score_a
-        winner = match.get("winner_id")
-        if winner == a and a in stats:
-            stats[a]["won"] += 1
-            stats[a]["points"] += 3
-            if b in stats:
-                stats[b]["lost"] += 1
-        elif winner == b and b in stats:
-            stats[b]["won"] += 1
-            stats[b]["points"] += 3
-            if a in stats:
-                stats[a]["lost"] += 1
-        else:
-            if a in stats:
-                stats[a]["drawn"] += 1
-                stats[a]["points"] += 1
-            if b in stats:
-                stats[b]["drawn"] += 1
-                stats[b]["points"] += 1
-    rows = list(stats.values())
-    rows.sort(key=lambda row: (row["points"], row["won"], row["score_for"] - row["score_against"]), reverse=True)
-    for index, row in enumerate(rows, start=1):
-        row["rank"] = index
-    return rows
-
-
-def _swiss_standings(regs: list[dict], matches: list[dict]) -> list[dict]:
-    stats = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "display_name": r.get("display_name") or r.get("ingame_name") or "Teilnehmer",
-            "points": 0,
-            "played": 0,
-            "won": 0,
-            "drawn": 0,
-            "lost": 0,
-            "opponents": [],
-        }
-        for r in regs
-        if r.get("id")
-    }
-    for match in matches:
-        if match.get("status") != "completed":
-            continue
-        a = match.get("participant_a_id")
-        b = match.get("participant_b_id")
-        winner = match.get("winner_id")
-        if a not in stats or b not in stats:
-            continue
-        stats[a]["played"] += 1
-        stats[b]["played"] += 1
-        stats[a]["opponents"].append(b)
-        stats[b]["opponents"].append(a)
-        if winner == a:
-            stats[a]["won"] += 1
-            stats[a]["points"] += 1
-            stats[b]["lost"] += 1
-        elif winner == b:
-            stats[b]["won"] += 1
-            stats[b]["points"] += 1
-            stats[a]["lost"] += 1
-        else:
-            stats[a]["drawn"] += 1
-            stats[b]["drawn"] += 1
-            stats[a]["points"] += 0.5
-            stats[b]["points"] += 0.5
-    for row in stats.values():
-        row["buchholz"] = sum(stats[opponent]["points"] for opponent in row["opponents"] if opponent in stats)
-        row.pop("opponents", None)
-    rows = list(stats.values())
-    rows.sort(key=lambda row: (row["points"], row["buchholz"], row["won"]), reverse=True)
-    for index, row in enumerate(rows, start=1):
-        row["rank"] = index
-    return rows
-
-
-def _group_standings(groups: list[dict], matches: list[dict], reg_map: dict) -> list[dict]:
-    rows = []
-    for group in groups:
-        group_key = group.get("group_key")
-        bracket_key = f"group_{group_key}"
-        group_rows = _round_robin_standings(
-            [match for match in matches if match.get("bracket") == bracket_key],
-            [reg_map[pid] for pid in group.get("participant_ids", []) if pid in reg_map],
-        )
-        rows.extend(group_rows)
-    return rows
-
-
 def _rank_from_rows(rows: list[dict], registration_id: str) -> int | None:
     for row in rows:
         if row.get("registration_id") == registration_id:
@@ -377,31 +167,19 @@ async def _tournament_rank_for_user(tournament_id: str, user_id: str, team_ids: 
         if rank is not None:
             return rank, participant_count
 
-    matches_v2 = await db.matches_v2.find({"tournament_id": tournament_id}, {"_id": 0}).to_list(3000)
-    if matches_v2:
-        rows = _v2_standings(matches_v2, regs)
-        for reg_id in reg_ids:
-            rank = _rank_from_rows(rows, reg_id)
-            if rank is not None:
-                return rank, participant_count
-        return None, participant_count
-
-    matches = await db.matches.find({"tournament_id": tournament_id}, {"_id": 0}).to_list(3000)
-    if not matches:
+    read_model = await load_competition_read_model(db, tournament_id)
+    if not read_model.legacy_matches and not read_model.stage_matches:
         return None, participant_count
 
     tournament = await db.tournaments.find_one({"id": tournament_id}, {"_id": 0, "format": 1}) or {}
-    fmt = tournament.get("format")
-    if fmt in {"round_robin", "league"}:
-        rows = _round_robin_standings(matches, regs)
-    elif fmt == "swiss":
-        rows = _swiss_standings(regs, matches)
-    elif fmt == "groups":
+    groups = []
+    if tournament.get("format") == "groups":
         groups = await db.tournament_groups.find({"tournament_id": tournament_id}, {"_id": 0}).to_list(100)
-        reg_map = {reg["id"]: reg for reg in regs if reg.get("id")}
-        rows = _group_standings(groups, matches, reg_map)
-    else:
-        rows = _legacy_elimination_standings(matches, regs)
+    structure = read_model.structure_snapshot()
+    observe_structure_read(structure, surface="profile_references")
+    rows = standings_for_structure(tournament, structure, regs, groups=groups)
+    if tournament.get("format") == "groups":
+        rows = [row for group in rows for row in group.get("standings") or []]
 
     for reg_id in reg_ids:
         rank = _rank_from_rows(rows, reg_id)

--- a/backend/tests/test_competition_privacy_unit.py
+++ b/backend/tests/test_competition_privacy_unit.py
@@ -1,0 +1,99 @@
+import asyncio
+
+from services.competition_privacy import (
+    anonymize_registration_match_references,
+    anonymized_legacy_match,
+    anonymized_stage_match,
+    registration_match_snapshot,
+)
+
+
+LEGACY = {
+    "id": "legacy-1",
+    "tournament_id": "t1",
+    "participant_a_id": "r-delete",
+    "participant_b_id": "r-keep",
+    "winner_id": "r-delete",
+    "loser_id": "r-keep",
+    "status": "completed",
+}
+
+STAGE = {
+    "id": "stage-1",
+    "tournament_id": "t1",
+    "stage_id": "s1",
+    "round": 1,
+    "slots": [
+        {"slot": 1, "registration_id": "r-delete", "user_id": "u-delete", "status": "filled"},
+        {"slot": 2, "registration_id": "r-keep", "user_id": "u-keep", "status": "filled"},
+    ],
+    "results": [
+        {"registration_id": "r-delete", "rank": 1, "score": 2, "note": "private"},
+        {"registration_id": "r-keep", "rank": 2, "score": 1},
+    ],
+    "advancement": [],
+    "status": "in_progress",
+}
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.updates = []
+
+    def find(self, *_args, **_kwargs):
+        return FakeCursor(self.rows)
+
+    async def update_one(self, query, update):
+        self.updates.append((query, update))
+
+
+class FakeDb:
+    def __init__(self):
+        self.matches = FakeCollection([LEGACY])
+        self.matches_v2 = FakeCollection([STAGE])
+
+
+def test_privacy_projection_preserves_terminal_history_and_anonymizes_open_stage():
+    legacy = anonymized_legacy_match(LEGACY, {"r-delete"}, "now")
+    stage = anonymized_stage_match(STAGE, {"r-delete"}, "now")
+
+    assert legacy == {
+        "participant_a_id": None,
+        "winner_id": None,
+        "updated_at": "now",
+    }
+    assert stage["status"] == "waiting_result"
+    assert stage["slots"][0]["registration_id"] is None
+    assert stage["slots"][0]["user_id"] is None
+    assert stage["slots"][0]["status"] == "anonymized"
+    assert stage["slots"][1]["registration_id"] == "r-keep"
+    assert stage["results"][0]["registration_id"] is None
+    assert stage["results"][0]["note"] is None
+
+
+def test_registration_export_and_database_anonymization_cover_both_stores():
+    db = FakeDb()
+
+    snapshot = asyncio.run(registration_match_snapshot(db, ["r-delete"]))
+    counts = asyncio.run(anonymize_registration_match_references(
+        db,
+        ["r-delete"],
+        updated_at="now",
+    ))
+
+    assert {match["source"]["engine"] for match in snapshot} == {"legacy", "stage"}
+    exported_stage = next(match for match in snapshot if match["source"]["engine"] == "stage")
+    assert all(slot["user_id"] is None for slot in exported_stage["slots"])
+    assert all(result["note"] is None for result in exported_stage["results"])
+    assert counts == {"legacy_matches": 1, "stage_matches": 1}
+    assert db.matches.updates[0][1]["$set"]["participant_a_id"] is None
+    assert db.matches_v2.updates[0][1]["$set"]["slots"][0]["status"] == "anonymized"

--- a/backend/tests/test_competition_standings_unit.py
+++ b/backend/tests/test_competition_standings_unit.py
@@ -5,6 +5,7 @@ from services.competition_standings import (
     elimination_standings,
     group_standings,
     round_robin_standings,
+    registration_match_summary,
     stage_standings,
     standings_for_structure,
     swiss_standings,
@@ -109,3 +110,32 @@ def test_group_and_policy_selector_keep_public_shape():
         REGISTRATIONS,
         groups=groups,
     ) == grouped
+
+
+def test_registration_match_summary_counts_legacy_and_stage_wins_once():
+    legacy = adapt_legacy_matches(_legacy_matches())
+    stage = adapt_stage_matches([{
+        "id": "stage-win",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "round": 3,
+        "slots": [
+            {"slot": 1, "registration_id": "r1", "status": "filled"},
+            {"slot": 2, "registration_id": "r2", "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": "r2", "rank": 1},
+            {"registration_id": "r1", "rank": 2},
+        ],
+        "advancement": [],
+        "status": "completed",
+    }])
+
+    assert registration_match_summary([*legacy, *stage], {"r1"}) == {
+        "matches_played": 3,
+        "matches_won": 1,
+    }
+    assert registration_match_summary([*legacy, *stage], {"r2"}) == {
+        "matches_played": 2,
+        "matches_won": 1,
+    }

--- a/backend/tests/test_dsgvo_competition_unit.py
+++ b/backend/tests/test_dsgvo_competition_unit.py
@@ -1,0 +1,73 @@
+import asyncio
+
+from routes import extras_routes
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+
+    def find(self, query=None, _projection=None):
+        if query and "user_id" in query:
+            rows = [row for row in self.rows if row.get("user_id") == query["user_id"]]
+        elif query and "to" in query:
+            rows = [row for row in self.rows if row.get("to") == query["to"]]
+        elif query and "member_ids" in query:
+            rows = [row for row in self.rows if query["member_ids"] in (row.get("member_ids") or [])]
+        else:
+            rows = self.rows
+        return FakeCursor(rows)
+
+    async def find_one(self, query, _projection=None):
+        return next((row for row in self.rows if row.get("id") == query.get("id")), None)
+
+
+class FakeDb:
+    def __init__(self):
+        self.users = FakeCollection([{"id": "u1", "email": "lion@example.at", "display_name": "Lion"}])
+        self.tournament_registrations = FakeCollection([{
+            "id": "r1",
+            "tournament_id": "t1",
+            "user_id": "u1",
+            "display_name": "Lion",
+        }])
+        self.matches = FakeCollection([{
+            "id": "legacy-1",
+            "tournament_id": "t1",
+            "participant_a_id": "r1",
+            "participant_b_id": "r2",
+            "winner_id": "r1",
+            "loser_id": "r2",
+            "status": "completed",
+        }])
+        self.matches_v2 = FakeCollection([{
+            "id": "stage-1",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "slots": [{"slot": 1, "registration_id": "r1", "status": "filled"}],
+            "results": [{"registration_id": "r1", "rank": 1}],
+            "advancement": [],
+            "status": "completed",
+        }])
+        self.f1_lap_times = FakeCollection()
+        self.teams = FakeCollection()
+        self.email_logs = FakeCollection([{"id": "mail-1", "to": "lion@example.at"}])
+
+
+def test_dsgvo_export_includes_canonical_legacy_and_stage_match_references(monkeypatch):
+    monkeypatch.setattr(extras_routes, "get_db", FakeDb)
+
+    payload = asyncio.run(extras_routes.export_my_data({"id": "u1"}))
+
+    assert payload["user"]["id"] == "u1"
+    assert [registration["id"] for registration in payload["tournament_registrations"]] == ["r1"]
+    assert {match["source"]["engine"] for match in payload["competition_matches"]} == {"legacy", "stage"}
+    assert payload["email_logs"][0]["id"] == "mail-1"

--- a/backend/tests/test_profile_references_unit.py
+++ b/backend/tests/test_profile_references_unit.py
@@ -46,9 +46,11 @@ class FakeCursor:
     def __init__(self, docs):
         self.docs = list(docs)
 
-    def sort(self, field, direction):
-        reverse = direction < 0
-        self.docs = sorted(self.docs, key=lambda doc: doc.get(field) or "", reverse=reverse)
+    def sort(self, field, direction=None):
+        fields = field if isinstance(field, list) else [(field, direction)]
+        for sort_field, sort_direction in reversed(fields):
+            reverse = sort_direction < 0
+            self.docs = sorted(self.docs, key=lambda doc: doc.get(sort_field) or "", reverse=reverse)
         return self
 
     async def to_list(self, limit):
@@ -80,6 +82,7 @@ class FakeDb:
             "tournament_registrations",
             "matches",
             "matches_v2",
+            "tournament_stages",
             "tournament_groups",
             "f1_lap_times",
         ]


### PR DESCRIPTION
## Zusammenfassung

Vierter Nebenverbraucher-Schritt aus Paket 2 von #120:

- entfernt rund 240 Zeilen duplizierte Profil-Standings-Logik;
- berechnet persönliche Turnierplatzierungen über den zentralen kanonischen Read-/Standings-Service;
- zählt öffentliche Matchstatistiken einmalig über Legacy- und Stage-/FFA-Matches;
- ergänzt den DSGVO-Selbstauskunftsexport um kanonische Matchreferenzen aus beiden Stores;
- entfernt aus dem Export fremde Stage-`user_id`- und Resultatnotiz-Felder;
- anonymisiert bei einer echten Benutzerlöschung Legacy-A/B- sowie Stage-Slot-/Resultat-Referenzen;
- erhält abgeschlossene Historie als terminal und setzt nur offene betroffene Matches auf `waiting_result`;
- protokolliert im Lösch-Audit die Anzahl anonymisierter Legacy-/Stage-Matches.

Keine Bestandsmigration und kein Engine-Cutover. Schreibzugriffe erfolgen ausschließlich im bereits vorhandenen, expliziten Benutzerlösch-Workflow.

## Verifikation

- `python -m pytest -q`
- Ergebnis: `286 passed, 282 skipped, 1 warning`
- `git diff --check`

Refs #120
Teil von #95