### PR TITLE
refactor: unify competition prize placements

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -173,7 +173,7 @@ geschrieben.
 | Match-Detail | `canonical_match` zusaetzlich aktiv | UI nach Paritaet umstellen |
 | Turnier-Standings | kanonisch aktiv | konfigurierbare RankingPolicy folgt im Schreibkern |
 | Profile / DSGVO | kanonische Standings, Match-Stats, Export und Referenz-Anonymisierung aktiv | weitere Chat-/Termin-/Audit-Referenzen separat pruefen |
-| Preise / Saisonwertung | beide Stores, aber eigene Projektionen | kanonische Standings konsumieren |
+| Preise / Saisonwertung | kanonische Platzierungsprojektion aktiv | RankingPolicy bleibt Teil des spaeteren Schreibkerns |
 | Widget / Match-PDF | kanonische Struktur bzw. variable Slots aktiv | alte Widget-Felder bis zum Frontend-Cutover behalten |
 | Badges / Admin-Zaehler / Penalties | weiterhin Legacy-lastig | vor Engine-Cutover migrieren |
 | Reminder / Notifications / Stationen | beide Formen mit Sonderzweigen | gemeinsame Match-Projektion verwenden |

--- a/backend/routes/extras_routes.py
+++ b/backend/routes/extras_routes.py
@@ -16,6 +16,7 @@ from services.slug_utils import apply_slug_history, find_by_slug_or_history, slu
 from services.access_links import validate_access_link
 from services.competition_privacy import registration_match_snapshot
 from services.competition_read import load_competition_read_model, observe_structure_read
+from services.competition_standings import standings_for_structure
 from services.public_site_settings import PUBLIC_LEGAL_SOURCE_FIELDS, build_public_legal_settings
 from models import now_utc, new_id
 from email_service import send_template, _get_email_config
@@ -1320,62 +1321,6 @@ async def _resolve_season_sources(s: dict) -> tuple[list[str], list[str]]:
     return (explicit_t or auto_t), (explicit_f or auto_f)
 
 
-def _season_v2_standings(matches_v2: list[dict], regs: list[dict]) -> list[dict]:
-    rank_map = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "played": 0,
-            "won": 0,
-            "top2": 0,
-            "points": 0,
-            "rank_sum": 0,
-            "furthest_round": 0,
-        }
-        for r in regs
-        if r.get("id")
-    }
-    for match in matches_v2:
-        if match.get("status") not in {"completed", "forfeit"}:
-            continue
-        for result in match.get("results") or []:
-            rid = result.get("registration_id")
-            if rid not in rank_map:
-                continue
-            try:
-                rank = int(result.get("rank") or 999)
-            except (TypeError, ValueError):
-                rank = 999
-            row = rank_map[rid]
-            row["played"] += 1
-            row["rank_sum"] += rank
-            row["furthest_round"] = max(row["furthest_round"], int(match.get("round") or 0))
-            if rank == 1:
-                row["won"] += 1
-            if rank <= 2:
-                row["top2"] += 1
-            score = result.get("points")
-            if score is None:
-                score = result.get("score")
-            if isinstance(score, (int, float)):
-                row["points"] += score
-    rows = list(rank_map.values())
-    for row in rows:
-        row["avg_rank"] = round(row["rank_sum"] / row["played"], 2) if row["played"] else None
-    rows.sort(
-        key=lambda row: (
-            row["furthest_round"],
-            row["won"],
-            row["top2"],
-            row["points"],
-            -(row["avg_rank"] or 999),
-        ),
-        reverse=True,
-    )
-    for index, row in enumerate(rows, start=1):
-        row["rank"] = index
-    return rows
-
-
 @season_router.get("/{slug_or_id}/standings")
 async def season_standings(slug_or_id: str):
     """Aggregate standings over all season point sources."""
@@ -1411,42 +1356,36 @@ async def season_standings(slug_or_id: str):
 
     tournament_ids, f1_ids = await _resolve_season_sources(s)
 
-    # Tournaments: use standings endpoint results (rank -> points)
+    # Tournaments: use the same canonical placement/standings projections.
     for tid in tournament_ids:
-        matches = await db.matches.find({"tournament_id": tid}, {"_id": 0}).to_list(2000)
         regs = await db.tournament_registrations.find(
             {"tournament_id": tid, "status": {"$in": ["approved", "checked_in"]}},
             {"_id": 0},
         ).to_list(500)
         reg_user_map = {r["id"]: r.get("user_id") for r in regs}
-        matches_v2 = await db.matches_v2.find({"tournament_id": tid}, {"_id": 0}).to_list(3000)
-        if matches_v2:
-            for row in _season_v2_standings(matches_v2, regs):
-                uid = reg_user_map.get(row.get("registration_id"))
-                if not uid or not row.get("played"):
-                    continue
-                pos = int(row.get("rank") or 999) - 1
-                pts = points_system[pos] if 0 <= pos < len(points_system) else 0
-                add_points(uid, pts, pos == 0)
-            continue
-        # compute rank via furthest round + wins
-        rank_map = {}
-        for r in regs:
-            rank_map[r["id"]] = {"rid": r["id"], "furthest_round": 0, "wins": 0}
-        for m in matches:
-            a, b, w = m.get("participant_a_id"), m.get("participant_b_id"), m.get("winner_id")
-            if a in rank_map and m.get("round"):
-                rank_map[a]["furthest_round"] = max(rank_map[a]["furthest_round"], m["round"])
-            if b in rank_map and m.get("round"):
-                rank_map[b]["furthest_round"] = max(rank_map[b]["furthest_round"], m["round"])
-            if m.get("status") == "completed" and w:
-                if w in rank_map: rank_map[w]["wins"] += 1
-        sorted_rs = sorted(rank_map.values(), key=lambda x: (x["furthest_round"], x["wins"]), reverse=True)
-        for pos, r in enumerate(sorted_rs):
-            uid = reg_user_map.get(r["rid"])
+        read_model = await load_competition_read_model(db, tid)
+        snapshot = read_model.structure_snapshot()
+        observe_structure_read(snapshot, surface="season_fallback")
+        tournament = await db.tournaments.find_one({"id": tid}, {"_id": 0, "format": 1}) or {}
+        groups = []
+        if tournament.get("format") == "groups":
+            groups = await db.tournament_groups.find(
+                {"tournament_id": tid}, {"_id": 0}
+            ).sort("order_index", 1).to_list(100)
+        standings = standings_for_structure(tournament, snapshot, regs, groups=groups)
+        rows = [
+            group_row
+            for item in standings
+            for group_row in (item.get("standings") or [])
+        ] if tournament.get("format") == "groups" else standings
+        for row in rows:
+            if "played" in row and not row.get("played"):
+                continue
+            uid = reg_user_map.get(row.get("registration_id"))
             if not uid:
                 continue
-            pts = points_system[pos] if pos < len(points_system) else 0
+            pos = int(row.get("rank") or 999) - 1
+            pts = points_system[pos] if 0 <= pos < len(points_system) else 0
             add_points(uid, pts, pos == 0)
 
     # F1 Challenges: aggregate per-track then championship-style

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -32,8 +32,7 @@ from services.tournament_permissions import (
 from services.custom_bracket import BracketSchemaError, build_matches_v2_from_schema
 from services.competition_formats import find_format_capability
 from services.competition_read import load_competition_read_model, observe_structure_read
-from services.competition_snapshot import adapt_stage_matches
-from services.competition_standings import stage_standings, standings_for_structure
+from services.competition_standings import placement_rows_for_structure, standings_for_structure
 from services.match_v2_results import (
     MatchV2ResultError,
     build_v2_result_application,
@@ -3006,40 +3005,21 @@ async def set_status(tid: str, body: dict, me: dict = Depends(get_current_user),
         try:
             from services.season_service import award_points
             from badges import on_tournament_completed
-            # Build placements from published legacy finals or stage-engine results.
+            # Build placements once through the canonical Legacy/Stage projection.
             regs = await db.tournament_registrations.find(
                 {"tournament_id": tid, "status": {"$in": ["approved", "checked_in"]}},
                 {"_id": 0},
             ).to_list(500)
-            reg_map = {r["id"]: r for r in regs}
             num_participants = len(regs)
-            matches = await db.matches.find({"tournament_id": tid, "final_position": {"$ne": None}}, {"_id": 0}).to_list(200)
-            placements = []
-            placed_reg_ids = set()
-            for m in matches:
-                rid = m.get("winner_id")
-                if rid and rid in reg_map and rid not in placed_reg_ids:
-                    reg = reg_map[rid]
-                    placements.append({
-                        "user_id": reg.get("user_id"),
-                        "team_id": reg.get("team_id"),
-                        "rank": m["final_position"],
-                    })
-                    placed_reg_ids.add(rid)
-            if not placements:
-                matches_v2 = await db.matches_v2.find({"tournament_id": tid}, {"_id": 0}).to_list(3000)
-                if matches_v2:
-                    for row in stage_standings(adapt_stage_matches(matches_v2), regs):
-                        rid = row.get("registration_id")
-                        if not rid or rid not in reg_map or rid in placed_reg_ids or not row.get("played"):
-                            continue
-                        reg = reg_map[rid]
-                        placements.append({
-                            "user_id": reg.get("user_id"),
-                            "team_id": reg.get("team_id"),
-                            "rank": row.get("rank"),
-                        })
-                        placed_reg_ids.add(rid)
+            read_model = await load_competition_read_model(db, tid)
+            snapshot = read_model.structure_snapshot()
+            observe_structure_read(snapshot, surface="season_points")
+            placements = placement_rows_for_structure(snapshot, regs)
+            placed_reg_ids = {
+                placement["registration_id"]
+                for placement in placements
+                if placement.get("registration_id")
+            }
             # Source type by season weight: <=1.5 mini, <=2.5 normal, else major
             weight = float(t.get("season_weight") or 2.0)
             source_type = "mini" if weight < 1.5 else ("major" if weight >= 2.5 else "tournament")

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -228,6 +228,7 @@ def _common_match_fields(match: dict, collection: str, engine: str) -> dict:
         "round_name": match.get("round_name") or match.get("matchday_label"),
         "match_key": match.get("match_key"),
         "section": match.get("section") or match.get("bracket"),
+        "final_position": match.get("final_position"),
         "match_type": match.get("match_type") or "duel",
         "status": match.get("status") or "pending",
         "scheduled_at": match.get("scheduled_at"),

--- a/backend/services/competition_standings.py
+++ b/backend/services/competition_standings.py
@@ -303,6 +303,101 @@ def standings_for_structure(
     return elimination_standings(legacy_matches, registrations)
 
 
+def _section_key(value) -> str:
+    return str(value or "").strip().lower()
+
+
+def placements_for_structure(
+    snapshot: dict,
+    registrations: list[dict],
+    *,
+    sections: set[str] | None = None,
+) -> dict[int, dict]:
+    """Resolve prize/season placements through the canonical read contract.
+
+    Explicit legacy ``final_position`` values remain authoritative for historical
+    tournaments.  If none exist, Stage/FFA results use the shared standings
+    projection.  This preserves the old fallback behaviour while giving every
+    downstream consumer one engine-independent entry point.
+    """
+
+    registration_map = {
+        registration["id"]: registration
+        for registration in registrations
+        if registration.get("id")
+    }
+    wanted_sections = {
+        _section_key(section)
+        for section in sections or set()
+        if section
+    }
+
+    def wanted(match: dict) -> bool:
+        return not wanted_sections or _section_key(match.get("section")) in wanted_sections
+
+    legacy_matches = [
+        match
+        for match in snapshot.get("matches") or []
+        if match.get("source", {}).get("engine") == "legacy" and wanted(match)
+    ]
+    placements: dict[int, dict] = {}
+    placed_registration_ids: set[str] = set()
+    for match in legacy_matches:
+        registration_id = next(
+            (
+                result.get("registration_id")
+                for result in match.get("results") or []
+                if result.get("outcome") == "winner"
+            ),
+            None,
+        )
+        rank = _safe_int(match.get("final_position"))
+        registration = registration_map.get(registration_id)
+        if (
+            not registration_id
+            or not rank
+            or not registration
+            or rank in placements
+            or registration_id in placed_registration_ids
+        ):
+            continue
+        placements[rank] = {
+            "registration_id": registration_id,
+            "user_id": registration.get("user_id"),
+            "team_id": registration.get("team_id"),
+        }
+        placed_registration_ids.add(registration_id)
+    if placements:
+        return placements
+
+    stage_matches = [
+        match
+        for match in snapshot.get("matches") or []
+        if match.get("source", {}).get("engine") == "stage" and wanted(match)
+    ]
+    for row in stage_standings(stage_matches, registrations):
+        registration_id = row.get("registration_id")
+        rank = _safe_int(row.get("rank"))
+        registration = registration_map.get(registration_id)
+        if not registration_id or not rank or not row.get("played") or not registration or rank in placements:
+            continue
+        placements[rank] = {
+            "registration_id": registration_id,
+            "user_id": registration.get("user_id"),
+            "team_id": registration.get("team_id"),
+        }
+    return placements
+
+
+def placement_rows_for_structure(snapshot: dict, registrations: list[dict]) -> list[dict]:
+    """Return ordered placement rows suitable for season-point awards."""
+
+    return [
+        {**placement, "rank": rank}
+        for rank, placement in sorted(placements_for_structure(snapshot, registrations).items())
+    ]
+
+
 def registration_match_summary(matches: list[dict], registration_ids: set[str]) -> dict:
     """Count terminal matches and wins once across canonical match shapes."""
 

--- a/backend/services/prize_service.py
+++ b/backend/services/prize_service.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 from database import get_db
 from models import new_id, now_utc
+from services.competition_read import load_competition_read_model, observe_structure_read
+from services.competition_standings import placements_for_structure
 
 logger = logging.getLogger("tls.prizes")
 
@@ -22,110 +24,6 @@ def _log_safe(value, limit: int = 160) -> str:
 
 def _ordinal(rank: int) -> str:
     return f"{rank}."
-
-
-def _section_key(value) -> str:
-    return str(value or "").strip().lower()
-
-
-def _match_section(match: dict) -> str:
-    return _section_key(match.get("section") or match.get("bracket"))
-
-
-def _stage_standings(matches_v2: list[dict], regs: list[dict], sections: set[str] | None = None) -> list[dict]:
-    """Rank stage-engine registrations using the same public standings signals."""
-    rank_map = {
-        r["id"]: {
-            "registration_id": r["id"],
-            "played": 0,
-            "won": 0,
-            "top2": 0,
-            "lost": 0,
-            "points": 0,
-            "rank_sum": 0,
-            "furthest_round": 0,
-            "best_rank": None,
-        }
-        for r in regs
-        if r.get("id")
-    }
-    wanted_sections = {_section_key(section) for section in sections or set() if section}
-    for match in matches_v2:
-        if wanted_sections and _match_section(match) not in wanted_sections:
-            continue
-        if match.get("status") not in {"completed", "forfeit"}:
-            continue
-        for result in match.get("results") or []:
-            rid = result.get("registration_id")
-            if rid not in rank_map:
-                continue
-            rank = int(result.get("rank") or 999)
-            row = rank_map[rid]
-            row["played"] += 1
-            row["rank_sum"] += rank
-            row["furthest_round"] = max(row["furthest_round"], int(match.get("round") or 0))
-            row["best_rank"] = rank if row["best_rank"] is None else min(row["best_rank"], rank)
-            if rank == 1:
-                row["won"] += 1
-            if rank <= 2:
-                row["top2"] += 1
-            else:
-                row["lost"] += 1
-            score = result.get("points")
-            if score is None:
-                score = result.get("score")
-            if isinstance(score, (int, float)):
-                row["points"] += score
-    rows = list(rank_map.values())
-    for row in rows:
-        row["avg_rank"] = round(row["rank_sum"] / row["played"], 2) if row["played"] else None
-    rows.sort(key=lambda row: (
-        row["furthest_round"],
-        row["won"],
-        row["top2"],
-        row["points"],
-        -(row["avg_rank"] or 999),
-    ), reverse=True)
-    for index, row in enumerate(rows, start=1):
-        row["rank"] = index
-    return [row for row in rows if row.get("played")]
-
-
-def _placements_from_stage(matches_v2: list[dict], regs: list[dict], sections: set[str] | None = None) -> dict[int, dict]:
-    reg_map = {r["id"]: r for r in regs if r.get("id")}
-    placements: dict[int, dict] = {}
-    for row in _stage_standings(matches_v2, regs, sections):
-        rid = row.get("registration_id")
-        rank = row.get("rank")
-        reg = reg_map.get(rid)
-        if not rid or not rank or not reg or rank in placements:
-            continue
-        placements[int(rank)] = {
-            "user_id": reg.get("user_id"),
-            "team_id": reg.get("team_id"),
-        }
-    return placements
-
-
-def _placements_from_legacy(matches: list[dict], reg_map: dict[str, dict], sections: set[str] | None = None) -> dict[int, dict]:
-    placements: dict[int, dict] = {}
-    wanted_sections = {_section_key(section) for section in sections or set() if section}
-    for match in matches:
-        if wanted_sections and _match_section(match) not in wanted_sections:
-            continue
-        rid = match.get("winner_id")
-        rank = match.get("final_position")
-        if not rid or not rank or rid not in reg_map:
-            continue
-        rank = int(rank)
-        if rank in placements:
-            continue
-        reg = reg_map[rid]
-        placements[rank] = {
-            "user_id": reg.get("user_id"),
-            "team_id": reg.get("team_id"),
-        }
-    return placements
 
 
 def _resolve_prize_place(raw_place, placements: dict[int, dict]) -> int | None:
@@ -152,26 +50,18 @@ async def auto_create_for_tournament(tid: str) -> int:
         return 0
 
     regs = await db.tournament_registrations.find({"tournament_id": tid}, {"_id": 0}).to_list(500)
-    reg_map = {r["id"]: r for r in regs}
-    matches = await db.matches.find(
-        {"tournament_id": tid, "final_position": {"$ne": None}}, {"_id": 0}
-    ).to_list(500)
-    matches_v2 = await db.matches_v2.find({"tournament_id": tid}, {"_id": 0}).to_list(3000)
+    read_model = await load_competition_read_model(db, tid)
+    snapshot = read_model.structure_snapshot()
+    observe_structure_read(snapshot, surface="prize_pickups")
 
-    overall = _placements_from_legacy(matches, reg_map)
-    if not overall and matches_v2:
-        overall = _placements_from_stage(matches_v2, regs)
+    overall = placements_for_structure(snapshot, regs)
 
     winner_sections = {"wb", "winner", "main", "final", "gf", "grand_final"}
     loser_sections = {"lb", "loser"}
-    winner = _placements_from_legacy(matches, reg_map, winner_sections)
-    if not winner and matches_v2:
-        winner = _placements_from_stage(matches_v2, regs, winner_sections)
+    winner = placements_for_structure(snapshot, regs, sections=winner_sections)
     if not winner:
         winner = overall
-    loser = _placements_from_legacy(matches, reg_map, loser_sections)
-    if not loser and matches_v2:
-        loser = _placements_from_stage(matches_v2, regs, loser_sections)
+    loser = placements_for_structure(snapshot, regs, sections=loser_sections)
     placements_by_group = {
         "overall": overall,
         "winner": winner,

--- a/backend/tests/test_competition_snapshot_unit.py
+++ b/backend/tests/test_competition_snapshot_unit.py
@@ -24,6 +24,7 @@ def _legacy_fixture():
             "score_b": 1,
             "winner_id": "r1",
             "loser_id": "r2",
+            "final_position": 1,
             "status": "completed",
             "scheduled_at": "2026-08-17T18:00:00+00:00",
             "station_id": "station-1",
@@ -135,6 +136,7 @@ def test_legacy_adapter_builds_slots_results_and_graph_sources_without_mutation(
 
     assert first["schema_version"] == STRUCTURE_SNAPSHOT_VERSION
     assert first["source"] == {"engine": "legacy", "collection": "matches"}
+    assert first["final_position"] == 1
     assert [slot["registration_id"] for slot in first["slots"]] == ["r1", "r2"]
     assert [(result["registration_id"], result["rank"], result["score"]) for result in first["results"]] == [
         ("r1", 1, 2),

--- a/backend/tests/test_competition_standings_unit.py
+++ b/backend/tests/test_competition_standings_unit.py
@@ -4,6 +4,8 @@ from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matc
 from services.competition_standings import (
     elimination_standings,
     group_standings,
+    placement_rows_for_structure,
+    placements_for_structure,
     round_robin_standings,
     registration_match_summary,
     stage_standings,
@@ -139,3 +141,102 @@ def test_registration_match_summary_counts_legacy_and_stage_wins_once():
         "matches_played": 2,
         "matches_won": 1,
     }
+
+
+def test_placements_keep_explicit_legacy_final_positions_authoritative():
+    legacy = [
+        {
+            "id": "legacy-first",
+            "tournament_id": "t1",
+            "round": 2,
+            "bracket": "winner",
+            "participant_a_id": "r1",
+            "participant_b_id": "r2",
+            "winner_id": "r1",
+            "loser_id": "r2",
+            "final_position": 1,
+            "status": "completed",
+        },
+        {
+            "id": "legacy-second",
+            "tournament_id": "t1",
+            "round": 2,
+            "bracket": "winner",
+            "participant_a_id": "r2",
+            "participant_b_id": "r3",
+            "winner_id": "r2",
+            "loser_id": "r3",
+            "final_position": 2,
+            "status": "completed",
+        },
+    ]
+    stage = [{
+        "id": "stage-conflict",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "round": 3,
+        "slots": [
+            {"slot": 1, "registration_id": "r3", "status": "filled"},
+            {"slot": 2, "registration_id": "r1", "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": "r3", "rank": 1},
+            {"registration_id": "r1", "rank": 2},
+        ],
+        "status": "completed",
+    }]
+    snapshot = build_structure_snapshot("t1", legacy_matches=legacy, stage_matches=stage)
+
+    placements = placements_for_structure(snapshot, REGISTRATIONS)
+
+    assert placements[1]["registration_id"] == "r1"
+    assert placements[1]["user_id"] == "u1"
+    assert placements[2]["registration_id"] == "r2"
+    assert placement_rows_for_structure(snapshot, REGISTRATIONS) == [
+        {"registration_id": "r1", "user_id": "u1", "team_id": None, "rank": 1},
+        {"registration_id": "r2", "user_id": "u2", "team_id": None, "rank": 2},
+    ]
+
+
+def test_placements_filter_stage_bracket_sections_through_canonical_fields():
+    stage = [
+        {
+            "id": "winner-bracket",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "round": 2,
+            "section": "WB",
+            "slots": [
+                {"slot": 1, "registration_id": "r1", "status": "filled"},
+                {"slot": 2, "registration_id": "r2", "status": "filled"},
+            ],
+            "results": [
+                {"registration_id": "r1", "rank": 1},
+                {"registration_id": "r2", "rank": 2},
+            ],
+            "status": "completed",
+        },
+        {
+            "id": "loser-bracket",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "round": 1,
+            "section": "LB",
+            "slots": [
+                {"slot": 1, "registration_id": "r3", "status": "filled"},
+                {"slot": 2, "registration_id": "r2", "status": "filled"},
+            ],
+            "results": [
+                {"registration_id": "r3", "rank": 1},
+                {"registration_id": "r2", "rank": 2},
+            ],
+            "status": "completed",
+        },
+    ]
+    snapshot = build_structure_snapshot("t1", stage_matches=stage)
+
+    winner = placements_for_structure(snapshot, REGISTRATIONS, sections={"winner", "wb"})
+    loser = placements_for_structure(snapshot, REGISTRATIONS, sections={"loser", "lb"})
+
+    assert winner[1]["registration_id"] == "r1"
+    assert loser[1]["registration_id"] == "r3"

--- a/backend/tests/test_prize_service_unit.py
+++ b/backend/tests/test_prize_service_unit.py
@@ -8,9 +8,12 @@ class FakeCursor:
     def __init__(self, items):
         self.items = list(items)
 
-    def sort(self, key, direction):
-        reverse = direction < 0
-        return FakeCursor(sorted(self.items, key=lambda item: item.get(key, 0), reverse=reverse))
+    def sort(self, key, direction=None):
+        specs = key if isinstance(key, list) else [(key, direction)]
+        items = list(self.items)
+        for field, sort_direction in reversed(specs):
+            items.sort(key=lambda item: item.get(field) or 0, reverse=sort_direction < 0)
+        return FakeCursor(items)
 
     async def to_list(self, _limit):
         return list(self.items)
@@ -56,6 +59,7 @@ class FakeDb:
         registrations=None,
         matches=None,
         matches_v2=None,
+        tournament_stages=None,
         prize_pickups=None,
         f1_challenges=None,
         f1_tracks=None,
@@ -68,6 +72,7 @@ class FakeDb:
         self.tournament_registrations = FakeCollection(registrations or [])
         self.matches = FakeCollection(matches or [])
         self.matches_v2 = FakeCollection(matches_v2 or [])
+        self.tournament_stages = FakeCollection(tournament_stages or [])
         self.prize_pickups = FakeCollection(prize_pickups or [])
 
 


### PR DESCRIPTION
## Zusammenfassung

Nächster Nebenverbraucher-Schritt aus Paket 2 von #120:

- erweitert den kanonischen Matchvertrag um die historische `final_position`;
- führt eine gemeinsame Platzierungsprojektion für Legacy-, Stage- und FFA-Turniere ein;
- behält explizite Legacy-Endplatzierungen als maßgebliche Quelle und nutzt Stage-Standings als kompatiblen Fallback;
- unterstützt weiterhin getrennte Winner-/Loser-Bracket-Preise;
- stellt automatische Preisabholungen und Saisonpunkte auf dieselbe Projektion um;
- stellt auch die öffentliche Saison-Fallbackwertung auf den zentralen, formatabhängigen Standings-Service um;
- entfernt rund 230 Zeilen doppelte Legacy-/V2-Platzierungs- und Saisonwertungslogik;
- ergänzt Paritätstests für gemischte Bestände, Legacy-Priorität und Stage-Sektionen.

Keine Bestandsmigration und kein Engine-Cutover. Der Schritt ändert nur lesende Projektionen; die bestehenden Preis- und Saisonpunkt-Schreibvorgänge bleiben erhalten.

## Verifikation

- `python -m pytest -q --basetemp=...`
- Ergebnis: `288 passed, 282 skipped, 1 warning`
- `python -m compileall -q services routes`
- `git diff --check`

Refs #120
Teil von #95