### PR TITLE
fix: include stage matches in badges and dashboard

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -175,7 +175,8 @@ geschrieben.
 | Profile / DSGVO | kanonische Standings, Match-Stats, Export und Referenz-Anonymisierung aktiv | weitere Chat-/Termin-/Audit-Referenzen separat pruefen |
 | Preise / Saisonwertung | kanonische Platzierungsprojektion aktiv | RankingPolicy bleibt Teil des spaeteren Schreibkerns |
 | Widget / Match-PDF | kanonische Struktur bzw. variable Slots aktiv | alte Widget-Felder bis zum Frontend-Cutover behalten |
-| Badges / Admin-Zaehler / Penalties | weiterhin Legacy-lastig | vor Engine-Cutover migrieren |
+| Badges / Admin-Zaehler | kanonische Match-/Platzierungsreads bzw. beide Stores aktiv | keine Legacy-Sonderlogik mehr hinzufuegen |
+| Penalties / Disputes | weiterhin Legacy-lastig | vor Engine-Cutover fachlich vereinheitlichen |
 | Reminder / Notifications / Stationen | beide Formen mit Sonderzweigen | gemeinsame Match-Projektion verwenden |
 
 Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,

--- a/backend/badges.py
+++ b/backend/badges.py
@@ -23,6 +23,11 @@ from achievement_catalog import (
     CONDITION_KEY_STATUS,
 )
 from services.membership_service import get_membership, is_active_member
+from services.competition_read import load_competition_read_model, load_registration_matches
+from services.competition_standings import (
+    registration_badge_match_progress,
+    registration_tournament_achievement_progress,
+)
 
 logger = logging.getLogger("tls.achievements")
 
@@ -185,35 +190,39 @@ async def compute_user_progress(user_id: str) -> dict[str, int]:
     formats = await db.tournaments.distinct("format", {"id": {"$in": tids}}) if tids else []
     p["distinct_formats"] = len([f for f in formats if f])
 
-    p["matches_played"] = await db.matches.count_documents({"$or": [{"winner_id": {"$in": list(reg_ids)}}, {"loser_id": {"$in": list(reg_ids)}}], "status": "completed"}) if reg_ids else 0
-    p["matches_won"] = await db.matches.count_documents({"winner_id": {"$in": list(reg_ids)}, "status": "completed"}) if reg_ids else 0
+    canonical_matches = await load_registration_matches(db, reg_ids)
+    p.update(registration_badge_match_progress(canonical_matches, reg_ids))
 
-    streak_max = 0
-    if reg_ids:
-        recent = await db.matches.find(
-            {"status": "completed", "$or": [{"winner_id": {"$in": list(reg_ids)}}, {"loser_id": {"$in": list(reg_ids)}}]},
-            {"_id": 0, "winner_id": 1, "loser_id": 1, "updated_at": 1},
-        ).sort("updated_at", 1).to_list(2000)
-        cur = 0
-        for m in recent:
-            if m.get("winner_id") in reg_ids:
-                cur += 1
-                streak_max = max(streak_max, cur)
-            else:
-                cur = 0
-    p["match_streak_max"] = streak_max
-
-    wins = podium = rank4 = 0
-    for r in regs:
-        if await db.matches.find_one({"tournament_id": r.get("tournament_id"), "winner_id": r["id"], "final_position": 1}):
-            wins += 1
-        if await db.matches.find_one({"tournament_id": r.get("tournament_id"), "winner_id": r["id"], "final_position": {"$lte": 3}}):
-            podium += 1
-        if await db.matches.find_one({"tournament_id": r.get("tournament_id"), "loser_id": r["id"], "final_position": 4}):
-            rank4 += 1
-    p["tournaments_won"] = wins
-    p["podium_finishes"] = podium
-    p["rank_4_count"] = rank4
+    placement_progress = {
+        "tournaments_won": 0,
+        "podium_finishes": 0,
+        "rank_4_count": 0,
+    }
+    registrations_by_tournament: dict[str, list[dict]] = {}
+    if tids:
+        all_registrations = await db.tournament_registrations.find(
+            {"tournament_id": {"$in": tids}},
+            {"_id": 0, "id": 1, "tournament_id": 1, "user_id": 1, "team_id": 1},
+        ).to_list(10000)
+        for registration in all_registrations:
+            tournament_id = registration.get("tournament_id")
+            if tournament_id:
+                registrations_by_tournament.setdefault(tournament_id, []).append(registration)
+    own_registration_ids_by_tournament: dict[str, set[str]] = {}
+    for registration in regs:
+        tournament_id = registration.get("tournament_id")
+        if tournament_id and registration.get("id"):
+            own_registration_ids_by_tournament.setdefault(tournament_id, set()).add(registration["id"])
+    for tournament_id, own_registration_ids in own_registration_ids_by_tournament.items():
+        read_model = await load_competition_read_model(db, tournament_id)
+        summary = registration_tournament_achievement_progress(
+            read_model.structure_snapshot(),
+            registrations_by_tournament.get(tournament_id) or [],
+            own_registration_ids,
+        )
+        for key, value in summary.items():
+            placement_progress[key] += value
+    p.update(placement_progress)
 
     official_lap_query = {
         "user_id": user_id,

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from database import get_db
 from auth import require_admin, get_current_user
 from models import now_utc
+from services.competition_read import count_matches_by_status
 from services.user_notifications import create_user_notification
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -114,13 +115,15 @@ async def dashboard(me: dict = Depends(require_admin())):
     tournament_registrations = {
         "pending": await db.tournament_registrations.count_documents({"status": "pending"}),
     }
+    today_matches = await count_matches_by_status(db, {"ready", "in_progress"})
+    open_disputes = await count_matches_by_status(db, {"disputed"})
     return {
         "player_count": await db.users.count_documents({"is_active": True}),
         "team_count": await db.teams.count_documents({}),
         "active_tournaments": await db.tournaments.count_documents({"status": {"$in": ["live", "check_in"]}}),
         "registration_open": await db.tournaments.count_documents({"status": "registration_open"}),
-        "today_matches": await db.matches.count_documents({"status": {"$in": ["ready", "in_progress"]}}),
-        "open_disputes": await db.matches.count_documents({"status": "disputed"}),
+        "today_matches": today_matches,
+        "open_disputes": open_disputes,
         "active_f1": await db.f1_challenges.count_documents({"status": "live"}),
         "total_tournaments": await db.tournaments.count_documents({}),
         "total_f1_challenges": await db.f1_challenges.count_documents({}),

--- a/backend/services/competition_privacy.py
+++ b/backend/services/competition_privacy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 
-from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matches
+from services.competition_read import load_registration_matches
 
 
 TERMINAL_MATCH_STATUSES = {"completed", "forfeit", "cancelled", "archived", "bye"}
@@ -23,32 +23,9 @@ def _privacy_match_projection(match: dict) -> dict:
 async def registration_match_snapshot(db, registration_ids: list[str], *, limit: int = 5000) -> list[dict]:
     """Export every canonical match that references one of the registrations."""
 
-    ids = sorted({registration_id for registration_id in registration_ids if registration_id})
-    if not ids:
-        return []
-    legacy_cursor = db.matches.find(
-        {"$or": [
-            {"participant_a_id": {"$in": ids}},
-            {"participant_b_id": {"$in": ids}},
-            {"winner_id": {"$in": ids}},
-            {"loser_id": {"$in": ids}},
-        ]},
-        {"_id": 0},
-    )
-    stage_cursor = db.matches_v2.find(
-        {"$or": [
-            {"slots.registration_id": {"$in": ids}},
-            {"results.registration_id": {"$in": ids}},
-        ]},
-        {"_id": 0},
-    )
-    legacy, stage = await asyncio.gather(
-        legacy_cursor.to_list(limit),
-        stage_cursor.to_list(limit),
-    )
     return [
         _privacy_match_projection(match)
-        for match in [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
+        for match in await load_registration_matches(db, registration_ids, limit=limit)
     ]
 
 

--- a/backend/services/competition_read.py
+++ b/backend/services/competition_read.py
@@ -11,7 +11,12 @@ import asyncio
 from dataclasses import dataclass
 import logging
 
-from services.competition_snapshot import build_structure_snapshot, structure_snapshot_metrics
+from services.competition_snapshot import (
+    adapt_legacy_matches,
+    adapt_stage_matches,
+    build_structure_snapshot,
+    structure_snapshot_metrics,
+)
 
 
 logger = logging.getLogger("tls.competition_read")
@@ -90,6 +95,54 @@ async def load_competition_read_model(
         stage_matches=stage_matches,
         stages=stages,
     )
+
+
+async def load_registration_matches(
+    db,
+    registration_ids: list[str] | set[str],
+    *,
+    limit: int = 5000,
+) -> list[dict]:
+    """Load canonical matches referencing any supplied registration."""
+
+    ids = sorted({registration_id for registration_id in registration_ids if registration_id})
+    if not ids:
+        return []
+    legacy_cursor = db.matches.find(
+        {"$or": [
+            {"participant_a_id": {"$in": ids}},
+            {"participant_b_id": {"$in": ids}},
+            {"winner_id": {"$in": ids}},
+            {"loser_id": {"$in": ids}},
+        ]},
+        {"_id": 0},
+    )
+    stage_cursor = db.matches_v2.find(
+        {"$or": [
+            {"slots.registration_id": {"$in": ids}},
+            {"results.registration_id": {"$in": ids}},
+        ]},
+        {"_id": 0},
+    )
+    legacy, stage = await asyncio.gather(
+        legacy_cursor.to_list(limit),
+        stage_cursor.to_list(limit),
+    )
+    return [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
+
+
+async def count_matches_by_status(db, statuses: set[str]) -> int:
+    """Count operational matches across both stores for dashboard surfaces."""
+
+    wanted = sorted({status for status in statuses if status})
+    if not wanted:
+        return 0
+    query = {"status": {"$in": wanted}}
+    legacy_count, stage_count = await asyncio.gather(
+        db.matches.count_documents(query),
+        db.matches_v2.count_documents(query),
+    )
+    return legacy_count + stage_count
 
 
 async def find_match_source(db, match_id: str) -> MatchSourceRecord | None:

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -232,6 +232,7 @@ def _common_match_fields(match: dict, collection: str, engine: str) -> dict:
         "match_type": match.get("match_type") or "duel",
         "status": match.get("status") or "pending",
         "scheduled_at": match.get("scheduled_at"),
+        "updated_at": match.get("updated_at"),
         "duration_minutes": match.get("duration_minutes"),
         "station_id": match.get("station_id"),
         "station": deepcopy(match.get("station")),

--- a/backend/services/competition_standings.py
+++ b/backend/services/competition_standings.py
@@ -398,6 +398,83 @@ def placement_rows_for_structure(snapshot: dict, registrations: list[dict]) -> l
     ]
 
 
+def registration_badge_match_progress(matches: list[dict], registration_ids: set[str]) -> dict:
+    """Return completed-match badge counters over canonical match shapes."""
+
+    relevant = []
+    for match in matches:
+        if match.get("status") != "completed":
+            continue
+        participants = {
+            slot.get("registration_id")
+            for slot in match.get("slots") or []
+            if slot.get("registration_id")
+        } | {
+            result.get("registration_id")
+            for result in match.get("results") or []
+            if result.get("registration_id")
+        }
+        if participants.intersection(registration_ids):
+            relevant.append(match)
+    relevant.sort(key=lambda match: (
+        str(match.get("updated_at") or match.get("scheduled_at") or ""),
+        _safe_int(match.get("stage_number")),
+        _safe_int(match.get("round")),
+        _safe_int(match.get("order")),
+        str(match.get("id") or ""),
+    ))
+
+    won = 0
+    streak = 0
+    streak_max = 0
+    for match in relevant:
+        is_win = any(
+            result.get("registration_id") in registration_ids
+            and result.get("outcome") == "winner"
+            for result in match.get("results") or []
+        )
+        if is_win:
+            won += 1
+            streak += 1
+            streak_max = max(streak_max, streak)
+        else:
+            streak = 0
+    return {
+        "matches_played": len(relevant),
+        "matches_won": won,
+        "match_streak_max": streak_max,
+    }
+
+
+def registration_tournament_achievement_progress(
+    snapshot: dict,
+    registrations: list[dict],
+    registration_ids: set[str],
+) -> dict:
+    """Return one tournament's win/podium/fourth-place badge flags."""
+
+    ranks = {
+        rank
+        for rank, placement in placements_for_structure(snapshot, registrations).items()
+        if placement.get("registration_id") in registration_ids
+    }
+    legacy_fourth = any(
+        _safe_int(match.get("final_position")) == 4
+        and any(
+            result.get("registration_id") in registration_ids
+            and result.get("outcome") == "loser"
+            for result in match.get("results") or []
+        )
+        for match in snapshot.get("matches") or []
+        if match.get("source", {}).get("engine") == "legacy"
+    )
+    return {
+        "tournaments_won": int(1 in ranks),
+        "podium_finishes": int(any(1 <= rank <= 3 for rank in ranks)),
+        "rank_4_count": int(4 in ranks or legacy_fourth),
+    }
+
+
 def registration_match_summary(matches: list[dict], registration_ids: set[str]) -> dict:
     """Count terminal matches and wins once across canonical match shapes."""
 

--- a/backend/tests/test_competition_read_unit.py
+++ b/backend/tests/test_competition_read_unit.py
@@ -2,8 +2,10 @@ import asyncio
 
 from services.competition_read import (
     canonical_match_for_source,
+    count_matches_by_status,
     find_match_source,
     load_competition_read_model,
+    load_registration_matches,
     observe_structure_read,
 )
 
@@ -23,23 +25,45 @@ class FakeCollection:
     def __init__(self, rows=()):
         self.rows = list(rows)
 
+    @staticmethod
+    def _values(row, key):
+        values = [row]
+        for part in key.split("."):
+            values = [
+                child
+                for value in values
+                for child in (
+                    [item.get(part) for item in value if isinstance(item, dict)]
+                    if isinstance(value, list)
+                    else [value.get(part)] if isinstance(value, dict)
+                    else []
+                )
+            ]
+        return values
+
+    def _matches(self, row, query):
+        for key, expected in query.items():
+            if key == "$or":
+                if not any(self._matches(row, option) for option in expected):
+                    return False
+                continue
+            values = self._values(row, key)
+            if isinstance(expected, dict) and "$in" in expected:
+                if not any(value in expected["$in"] for value in values):
+                    return False
+            elif expected not in values:
+                return False
+        return True
+
     def find(self, query, _projection=None):
-        rows = [
-            row
-            for row in self.rows
-            if all(row.get(key) == value for key, value in query.items())
-        ]
+        rows = [row for row in self.rows if self._matches(row, query)]
         return FakeCursor(rows)
 
     async def find_one(self, query, _projection=None):
-        return next(
-            (
-                row
-                for row in self.rows
-                if all(row.get(key) == value for key, value in query.items())
-            ),
-            None,
-        )
+        return next((row for row in self.rows if self._matches(row, query)), None)
+
+    async def count_documents(self, query):
+        return sum(1 for row in self.rows if self._matches(row, query))
 
 
 class FakeDb:
@@ -56,7 +80,7 @@ class FakeDb:
             "tournament_id": "t1",
             "stage_id": "s1",
             "match_key": "A",
-            "slots": [],
+            "slots": [{"slot": 1, "registration_id": "r1", "status": "filled"}],
             "results": [],
             "advancement": [],
             "status": "pending",
@@ -102,3 +126,13 @@ def test_structure_read_observation_emits_bounded_metrics(caplog):
     assert metrics["source_counts"] == {"legacy": 1, "stage": 1}
     assert metrics["integrity_issue_count"] == 0
     assert "surface=unit" in caplog.text
+
+
+def test_registration_read_and_status_counts_cover_both_stores():
+    db = FakeDb()
+
+    matches = asyncio.run(load_registration_matches(db, {"r1"}))
+
+    assert {match["id"] for match in matches} == {"legacy-1", "stage-1"}
+    assert asyncio.run(count_matches_by_status(db, {"ready", "pending"})) == 2
+    assert asyncio.run(count_matches_by_status(db, {"disputed"})) == 0

--- a/backend/tests/test_competition_standings_unit.py
+++ b/backend/tests/test_competition_standings_unit.py
@@ -6,8 +6,10 @@ from services.competition_standings import (
     group_standings,
     placement_rows_for_structure,
     placements_for_structure,
+    registration_badge_match_progress,
     round_robin_standings,
     registration_match_summary,
+    registration_tournament_achievement_progress,
     stage_standings,
     standings_for_structure,
     swiss_standings,
@@ -240,3 +242,119 @@ def test_placements_filter_stage_bracket_sections_through_canonical_fields():
 
     assert winner[1]["registration_id"] == "r1"
     assert loser[1]["registration_id"] == "r3"
+
+
+def test_badge_match_progress_combines_engines_and_keeps_chronological_streak():
+    legacy = adapt_legacy_matches([{
+        "id": "legacy-win",
+        "tournament_id": "t1",
+        "round": 1,
+        "participant_a_id": "r1",
+        "participant_b_id": "r2",
+        "winner_id": "r1",
+        "loser_id": "r2",
+        "status": "completed",
+        "updated_at": "2026-08-17T10:00:00+00:00",
+    }])
+    stage = adapt_stage_matches([
+        {
+            "id": "stage-win",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "round": 2,
+            "slots": [
+                {"slot": 1, "registration_id": "r1", "status": "filled"},
+                {"slot": 2, "registration_id": "r3", "status": "filled"},
+            ],
+            "results": [
+                {"registration_id": "r1", "rank": 1},
+                {"registration_id": "r3", "rank": 2},
+            ],
+            "status": "completed",
+            "updated_at": "2026-08-17T11:00:00+00:00",
+        },
+        {
+            "id": "stage-loss",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "round": 3,
+            "slots": [
+                {"slot": 1, "registration_id": "r1", "status": "filled"},
+                {"slot": 2, "registration_id": "r2", "status": "filled"},
+            ],
+            "results": [
+                {"registration_id": "r2", "rank": 1},
+                {"registration_id": "r1", "rank": 2},
+            ],
+            "status": "completed",
+            "updated_at": "2026-08-17T12:00:00+00:00",
+        },
+    ])
+
+    assert registration_badge_match_progress([*legacy, *stage], {"r1"}) == {
+        "matches_played": 3,
+        "matches_won": 2,
+        "match_streak_max": 2,
+    }
+
+
+def test_tournament_achievement_progress_keeps_legacy_fourth_place_semantics():
+    snapshot = build_structure_snapshot("t1", legacy_matches=[
+        {
+            "id": "final",
+            "tournament_id": "t1",
+            "participant_a_id": "r1",
+            "participant_b_id": "r2",
+            "winner_id": "r1",
+            "loser_id": "r2",
+            "final_position": 1,
+            "status": "completed",
+        },
+        {
+            "id": "fourth-place",
+            "tournament_id": "t1",
+            "participant_a_id": "r3",
+            "participant_b_id": "r2",
+            "winner_id": "r3",
+            "loser_id": "r2",
+            "final_position": 4,
+            "status": "completed",
+        },
+    ])
+
+    assert registration_tournament_achievement_progress(snapshot, REGISTRATIONS, {"r1"}) == {
+        "tournaments_won": 1,
+        "podium_finishes": 1,
+        "rank_4_count": 0,
+    }
+    assert registration_tournament_achievement_progress(snapshot, REGISTRATIONS, {"r2"}) == {
+        "tournaments_won": 0,
+        "podium_finishes": 0,
+        "rank_4_count": 1,
+    }
+
+
+def test_tournament_achievement_progress_counts_stage_champion():
+    snapshot = build_structure_snapshot("t1", stage_matches=[{
+        "id": "stage-final",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "round": 3,
+        "slots": [
+            {"slot": 1, "registration_id": "r1", "status": "filled"},
+            {"slot": 2, "registration_id": "r2", "status": "filled"},
+            {"slot": 3, "registration_id": "r3", "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": "r1", "rank": 1},
+            {"registration_id": "r2", "rank": 2},
+            {"registration_id": "r3", "rank": 3},
+        ],
+        "status": "completed",
+    }])
+
+    assert registration_tournament_achievement_progress(snapshot, REGISTRATIONS, {"r1"}) == {
+        "tournaments_won": 1,
+        "podium_finishes": 1,
+        "rank_4_count": 0,
+    }


### PR DESCRIPTION
## Zusammenfassung

Nächster Nebenverbraucher-Schritt aus Paket 2 von #120:

- zentraler registrierungsbezogener Match-Read über Legacy und Stage;
- DSGVO-Export nutzt denselben Read ohne doppelte Query-/Adapterlogik;
- Badge-Fortschritt, Siege und Siegesserien berücksichtigen beide Engines;
- Turniersiege, Podien und vierte Plätze funktionieren für Stage/FFA;
- historische Legacy-Regel für Platz 4 bleibt erhalten;
- Admin-Match- und Dispute-Zähler berücksichtigen beide Stores;
- Penalty-/Forfeit-Regeln bleiben ein eigener nächster Fachschritt.

Keine Bestandsmigration, kein Engine-Cutover, keine geänderten Match-Schreibpfade.

## Verifikation

- `python -m pytest -q --basetemp=...`
- `292 passed, 282 skipped, 1 warning`
- `python -m compileall -q services routes badges.py`
- `git diff --check`

Refs #120
Teil von #95