### PR TITLE
fix: include stage forfeits in penalty history

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -176,7 +176,8 @@ geschrieben.
 | Preise / Saisonwertung | kanonische Platzierungsprojektion aktiv | RankingPolicy bleibt Teil des spaeteren Schreibkerns |
 | Widget / Match-PDF | kanonische Struktur bzw. variable Slots aktiv | alte Widget-Felder bis zum Frontend-Cutover behalten |
 | Badges / Admin-Zaehler | kanonische Match-/Platzierungsreads bzw. beide Stores aktiv | keine Legacy-Sonderlogik mehr hinzufuegen |
-| Penalties / Disputes | weiterhin Legacy-lastig | vor Engine-Cutover fachlich vereinheitlichen |
+| Penalty-Transparenz | Legacy- und Stage-/FFA-Forfeits kanonisch sichtbar | Schreibregeln bleiben getrennt |
+| Disputes / Forfeit-Schreibpfad | weiterhin Legacy-lastig | in Package 3 fachlich vereinheitlichen |
 | Reminder / Notifications / Stationen | beide Formen mit Sonderzweigen | gemeinsame Match-Projektion verwenden |
 
 Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,

--- a/backend/routes/penalty_routes.py
+++ b/backend/routes/penalty_routes.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 from database import get_db
 from auth import get_current_user, require_admin
+from services.competition_penalties import load_forfeit_penalties
 
 router = APIRouter(prefix="/api/penalties", tags=["penalties"])
 admin_router = APIRouter(prefix="/api/admin/penalties", tags=["penalties-admin"])
@@ -71,36 +72,29 @@ async def _collect_user_penalties(user_id: str) -> list[dict]:
             "ref_id": l.get("id"),
         })
 
-    # --- Tournament forfeits where this user is loser ---
-    # Find tournament_registrations where user_id matches, then find matches with that registration as loser
+    # --- Tournament forfeits across Legacy and Stage/FFA ---
     regs = await db.tournament_registrations.find(
         {"user_id": user_id}, {"_id": 0, "id": 1, "tournament_id": 1}
     ).to_list(500)
     reg_ids = [r["id"] for r in regs]
     if reg_ids:
-        matches = await db.matches.find(
-            {
-                "loser_id": {"$in": reg_ids},
-                "status": "forfeit",
-                "admin_decision_note": {"$exists": True, "$ne": None},
-            },
-            {"_id": 0},
-        ).sort("admin_decision_at", -1).to_list(500)
-        tour_ids = list({m["tournament_id"] for m in matches if m.get("tournament_id")})
+        forfeits = await load_forfeit_penalties(db, reg_ids, limit=500)
+        tour_ids = list({item["tournament_id"] for item in forfeits if item.get("tournament_id")})
         tours = {t["id"]: t for t in await db.tournaments.find(
             {"id": {"$in": tour_ids}}, {"_id": 0, "id": 1, "title": 1, "slug": 1}).to_list(200)}
-        for m in matches:
-            t = tours.get(m.get("tournament_id"), {})
+        for item in forfeits:
+            t = tours.get(item.get("tournament_id"), {})
             out.append({
                 "kind": "match_forfeit",
                 "label": "Match verloren (Forfeit)",
-                "reason": m.get("admin_decision_note") or "(keine Begründung)",
+                "reason": item.get("reason") or "(keine Begründung)",
                 "context_title": t.get("title") or "Turnier",
                 "context_url": f"/tournaments/{t.get('slug') or t.get('id') or ''}",
-                "context_subtitle": f"Match #{m.get('match_number') or m.get('id', '')[:6]}",
-                "issued_by": m.get("admin_decision_by"),
-                "issued_at": m.get("admin_decision_at") or m.get("updated_at"),
-                "ref_id": m.get("id"),
+                "context_subtitle": f"Match #{item.get('match_label') or ''}",
+                "issued_by": item.get("issued_by"),
+                "issued_at": item.get("issued_at"),
+                "ref_id": item.get("match_id"),
+                "match_source": item.get("source"),
             })
 
     # --- Negative achievement awards (admin-issued incidents) ---
@@ -161,16 +155,20 @@ async def all_penalties(
         ):
             if l.get("user_id"):
                 user_ids.add(l["user_id"])
-        # forfeit matches → loser registration → user
-        async for m in db.matches.find(
-            {"status": "forfeit", "admin_decision_note": {"$exists": True}},
-            {"_id": 0, "loser_id": 1},
-        ):
-            if m.get("loser_id"):
-                reg = await db.tournament_registrations.find_one(
-                    {"id": m["loser_id"]}, {"_id": 0, "user_id": 1})
-                if reg and reg.get("user_id"):
-                    user_ids.add(reg["user_id"])
+        # forfeit results → registrations → users, for both match stores
+        forfeits = await load_forfeit_penalties(db)
+        forfeit_registration_ids = sorted({
+            item["registration_id"]
+            for item in forfeits
+            if item.get("registration_id")
+        })
+        if forfeit_registration_ids:
+            for registration in await db.tournament_registrations.find(
+                {"id": {"$in": forfeit_registration_ids}},
+                {"_id": 0, "user_id": 1},
+            ).to_list(5000):
+                if registration.get("user_id"):
+                    user_ids.add(registration["user_id"])
         async for a in db.user_achievements.find({"is_negative": True}, {"_id": 0, "user_id": 1}):
             if a.get("user_id"):
                 user_ids.add(a["user_id"])

--- a/backend/services/competition_penalties.py
+++ b/backend/services/competition_penalties.py
@@ -1,0 +1,74 @@
+"""Canonical read projection for tournament forfeit penalties."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def load_forfeit_penalties(
+    db,
+    registration_ids: list[str] | set[str] | None = None,
+    *,
+    limit: int = 5000,
+) -> list[dict]:
+    """Load player-visible Legacy and Stage/FFA forfeit decisions."""
+
+    filter_supplied = registration_ids is not None
+    wanted_ids = {
+        registration_id
+        for registration_id in registration_ids or []
+        if registration_id
+    }
+    if filter_supplied and not wanted_ids:
+        return []
+    legacy_query: dict = {
+        "status": "forfeit",
+        "admin_decision_note": {"$exists": True, "$ne": None},
+    }
+    if filter_supplied:
+        legacy_query["loser_id"] = {"$in": sorted(wanted_ids)}
+    stage_query: dict = {"results.forfeit": True}
+    if filter_supplied:
+        stage_query["results.registration_id"] = {"$in": sorted(wanted_ids)}
+
+    legacy_cursor = db.matches.find(legacy_query, {"_id": 0})
+    stage_cursor = db.matches_v2.find(stage_query, {"_id": 0})
+    legacy_matches, stage_matches = await asyncio.gather(
+        legacy_cursor.to_list(limit),
+        stage_cursor.to_list(limit),
+    )
+
+    penalties = [
+        {
+            "registration_id": match.get("loser_id"),
+            "tournament_id": match.get("tournament_id"),
+            "match_id": match.get("id"),
+            "match_label": match.get("match_number") or str(match.get("id") or "")[:6],
+            "reason": match.get("admin_decision_note") or "(keine Begründung)",
+            "issued_by": match.get("admin_decision_by"),
+            "issued_at": match.get("admin_decision_at") or match.get("updated_at"),
+            "source": {"engine": "legacy", "collection": "matches"},
+        }
+        for match in legacy_matches
+        if match.get("loser_id") and (not filter_supplied or match.get("loser_id") in wanted_ids)
+    ]
+    for match in stage_matches:
+        result_meta = match.get("result_meta") or {}
+        for result in match.get("results") or []:
+            registration_id = result.get("registration_id")
+            if not result.get("forfeit") or not registration_id:
+                continue
+            if filter_supplied and registration_id not in wanted_ids:
+                continue
+            penalties.append({
+                "registration_id": registration_id,
+                "tournament_id": match.get("tournament_id"),
+                "match_id": match.get("id"),
+                "match_label": match.get("match_key") or match.get("order") or str(match.get("id") or "")[:6],
+                "reason": result.get("note") or result_meta.get("note") or "(keine Begründung)",
+                "issued_by": match.get("completed_by") or result_meta.get("confirmed_by"),
+                "issued_at": match.get("completed_at") or result_meta.get("confirmed_at") or match.get("updated_at"),
+                "source": {"engine": "stage", "collection": "matches_v2"},
+            })
+    penalties.sort(key=lambda item: item.get("issued_at") or "", reverse=True)
+    return penalties

--- a/backend/tests/test_competition_penalties_unit.py
+++ b/backend/tests/test_competition_penalties_unit.py
@@ -1,0 +1,93 @@
+import asyncio
+from types import SimpleNamespace
+
+from services.competition_penalties import load_forfeit_penalties
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    @staticmethod
+    def _values(row, path):
+        values = [row]
+        for part in path.split("."):
+            next_values = []
+            for value in values:
+                if isinstance(value, list):
+                    next_values.extend(item.get(part) for item in value if isinstance(item, dict))
+                elif isinstance(value, dict):
+                    next_values.append(value.get(part))
+            values = next_values
+        return values
+
+    def _matches(self, row, query):
+        for key, expected in query.items():
+            values = self._values(row, key)
+            if isinstance(expected, dict):
+                if expected.get("$exists") is True and not values:
+                    return False
+                if "$ne" in expected and any(value == expected["$ne"] for value in values):
+                    return False
+                if "$in" in expected and not any(value in expected["$in"] for value in values):
+                    return False
+            elif expected not in values:
+                return False
+        return True
+
+    def find(self, query, _projection=None):
+        return FakeCursor(row for row in self.rows if self._matches(row, query))
+
+
+def _db():
+    return SimpleNamespace(
+        matches=FakeCollection([{
+            "id": "legacy-forfeit",
+            "tournament_id": "t1",
+            "loser_id": "r2",
+            "status": "forfeit",
+            "admin_decision_note": "Legacy no-show",
+            "admin_decision_by": "admin-1",
+            "admin_decision_at": "2026-08-17T10:00:00+00:00",
+        }]),
+        matches_v2=FakeCollection([{
+            "id": "stage-forfeit",
+            "tournament_id": "t2",
+            "match_key": "FFA-1",
+            "status": "completed",
+            "results": [
+                {"registration_id": "r1", "rank": 1, "forfeit": False},
+                {"registration_id": "r2", "rank": 2, "forfeit": True, "note": "Stage no-show"},
+            ],
+            "result_meta": {
+                "note": "Staff decision",
+                "confirmed_by": "admin-2",
+                "confirmed_at": "2026-08-17T11:00:00+00:00",
+            },
+        }]),
+    )
+
+
+def test_forfeit_penalties_normalize_legacy_and_stage_results():
+    penalties = asyncio.run(load_forfeit_penalties(_db(), {"r2"}))
+
+    assert [item["match_id"] for item in penalties] == ["stage-forfeit", "legacy-forfeit"]
+    assert penalties[0]["reason"] == "Stage no-show"
+    assert penalties[0]["issued_by"] == "admin-2"
+    assert penalties[0]["source"] == {"engine": "stage", "collection": "matches_v2"}
+    assert penalties[1]["reason"] == "Legacy no-show"
+    assert penalties[1]["source"] == {"engine": "legacy", "collection": "matches"}
+
+
+def test_forfeit_penalties_filter_the_exact_forfeiting_result():
+    assert asyncio.run(load_forfeit_penalties(_db(), {"r1"})) == []
+    assert asyncio.run(load_forfeit_penalties(_db(), [])) == []
+    assert len(asyncio.run(load_forfeit_penalties(_db()))) == 2


### PR DESCRIPTION
## Zusammenfassung

Nächster Nebenverbraucher-Schritt aus Paket 2 von #120:

- zentrale Forfeit-Penalty-Projektion für Legacy und Stage/FFA;
- Legacy-Pflichtbegründung, Admin und Entscheidungszeit bleiben unverändert;
- vorhandene Stage-/FFA-Forfeits werden am exakt betroffenen `results[]`-Eintrag erkannt;
- persönliches Strafprotokoll zeigt Grund, Zeitpunkt und Matchquelle;
- Admin-Penalty-Inbox berücksichtigt Stage-Registrierungen;
- explizit leerer Registrierungsfilter liefert sicher keine Ergebnisse.

Keine neuen Forfeit-/Dispute-Schreibfunktionen und kein Engine-Cutover; dieser PR vereinheitlicht nur die Transparenz vorhandener Entscheidungen.

## Verifikation

- `294 passed, 282 skipped, 1 warning`
- `python -m compileall -q services routes`
- `git diff --check`

Refs #120
Teil von #95