### PR TITLE
Package 2: Unify competition operations reads

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -178,7 +178,7 @@ geschrieben.
 | Badges / Admin-Zaehler | kanonische Match-/Platzierungsreads bzw. beide Stores aktiv | keine Legacy-Sonderlogik mehr hinzufuegen |
 | Penalty-Transparenz | Legacy- und Stage-/FFA-Forfeits kanonisch sichtbar | Schreibregeln bleiben getrennt |
 | Disputes / Forfeit-Schreibpfad | weiterhin Legacy-lastig | in Package 3 fachlich vereinheitlichen |
-| Reminder / Notifications / Stationen | beide Formen mit Sonderzweigen | gemeinsame Match-Projektion verwenden |
+| Reminder / Notifications / Stationen | kanonische Match-Reads aktiv | Collection-spezifische Writes bleiben bis zum Schreibkern erhalten |
 
 Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,
 Zielversion, ID-Mapping, Hash/Diff und Rollback-ID. Ein Fehler darf nie durch

--- a/backend/routes/station_routes.py
+++ b/backend/routes/station_routes.py
@@ -11,6 +11,7 @@ from services.tournament_permissions import (
     require_tournament_staff_permission,
 )
 from services.station_runtime import notify_match_started
+from services.competition_read import find_match_source, load_competition_read_model
 
 router = APIRouter(prefix="/api/stations", tags=["stations"])
 TOURNAMENT_MUTATION_LOCKED_DETAIL = "Turnier ist gesperrt und kann nur noch angesehen oder geloescht werden."
@@ -33,13 +34,8 @@ async def _require_station_permission(user: dict, tournament_id: str, station_id
 
 
 async def _find_match_for_station(db, match_id: str) -> tuple[str, dict | None]:
-    match = await db.matches.find_one({"id": match_id}, {"_id": 0})
-    if match:
-        return "matches", match
-    match = await db.matches_v2.find_one({"id": match_id}, {"_id": 0})
-    if match:
-        return "matches_v2", match
-    return "", None
+    source = await find_match_source(db, match_id)
+    return (source.collection, source.match) if source else ("", None)
 
 
 def _station_match_status(match: dict, start_now: bool) -> str:
@@ -252,17 +248,14 @@ async def auto_assign_stations(tournament_id: str, start_now: bool = False,
         return {"assigned": 0, "items": [], "planned": bool(plan and not start_now)}
     status_filter = ["ready", "scheduled"] if start_now else ["preview", "pending", "ready", "scheduled"]
     station_filter = {"$in": [None, ""]} if not start_now else {"$in": [None, "", *[station["id"] for station in stations]]}
-    matches = await db.matches.find({
-        "tournament_id": tournament_id,
-        "station_id": station_filter,
-        "status": {"$in": status_filter},
-    }, {"_id": 0}).to_list(1000)
-    matches_v2 = await db.matches_v2.find({
-        "tournament_id": tournament_id,
-        "station_id": station_filter,
-        "status": {"$in": status_filter},
-    }, {"_id": 0}).to_list(3000)
-    candidates = [("matches", m) for m in matches] + [("matches_v2", m) for m in matches_v2]
+    allowed_station_ids = set(station_filter["$in"])
+    read_model = await load_competition_read_model(db, tournament_id)
+    candidates = [
+        (match["collection"], match)
+        for match in read_model.structure_snapshot()["matches"]
+        if match.get("station_id") in allowed_station_ids
+        and match.get("status") in status_filter
+    ]
     candidates = [item for item in candidates if _match_has_minimum_participants(item[1])]
     candidates.sort(key=lambda item: _match_sort_key(item[1]))
 

--- a/backend/services/competition_read.py
+++ b/backend/services/competition_read.py
@@ -145,6 +145,33 @@ async def count_matches_by_status(db, statuses: set[str]) -> int:
     return legacy_count + stage_count
 
 
+async def load_scheduled_matches(
+    db,
+    *,
+    scheduled_from: str,
+    scheduled_until: str,
+    statuses: set[str],
+    per_store_limit: int = 5000,
+) -> list[dict]:
+    """Load upcoming canonical matches for reminder and operations readers."""
+
+    query = {
+        "scheduled_at": {"$gte": scheduled_from, "$lte": scheduled_until},
+        "status": {"$in": sorted(statuses)},
+    }
+    legacy_cursor = db.matches.find(query, {"_id": 0})
+    stage_cursor = db.matches_v2.find(query, {"_id": 0})
+    legacy, stage = await asyncio.gather(
+        legacy_cursor.to_list(per_store_limit),
+        stage_cursor.to_list(per_store_limit),
+    )
+    matches = [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
+    return sorted(matches, key=lambda match: (
+        str(match.get("scheduled_at") or ""),
+        str(match.get("id") or ""),
+    ))
+
+
 async def find_match_source(db, match_id: str) -> MatchSourceRecord | None:
     """Resolve a stable match ID while preserving the backing collection."""
 

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -243,6 +243,7 @@ def _common_match_fields(match: dict, collection: str, engine: str) -> dict:
         "order": match.get("order") if match.get("order") is not None else match.get("match_index"),
         "is_preview": bool(match.get("is_preview") or match.get("status") == "preview"),
         "generation_mode": match.get("generation_mode"),
+        "settings": deepcopy(match.get("settings") or {}),
         "collection": collection,
         "source": {"engine": engine, "collection": collection},
     }

--- a/backend/services/match_notifications.py
+++ b/backend/services/match_notifications.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from match_rules import participant_source_ids
+from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matches
 from services.user_notifications import create_user_notification
 
 
@@ -29,18 +30,21 @@ async def _participant_user_ids(db, registrations: list[dict]) -> set[str]:
     return {user_id for user_id in user_ids if user_id}
 
 
-def _classic_result_summary(match: dict, regs_by_id: dict[str, dict]) -> str:
-    a = _registration_name(regs_by_id.get(match.get("participant_a_id")), "Teilnehmer A")
-    b = _registration_name(regs_by_id.get(match.get("participant_b_id")), "Teilnehmer B")
-    score = f"{match.get('score_a', 0)}:{match.get('score_b', 0)}"
-    winner = _registration_name(regs_by_id.get(match.get("winner_id")), "Unentschieden")
-    if match.get("status") == "forfeit":
-        return f"{a} gegen {b} wurde per Forfeit gewertet. Gewinner: {winner}."
-    return f"{a} gegen {b} ist bestätigt: {score}. Gewinner: {winner}."
+def _canonical_match(match: dict, collection_name: str) -> dict:
+    adapter = adapt_stage_matches if collection_name == "matches_v2" or match.get("slots") else adapt_legacy_matches
+    return adapter([match])[0]
 
 
-def _v2_result_summary(match: dict, regs_by_id: dict[str, dict]) -> str:
-    results = sorted(match.get("results") or [], key=lambda row: int(row.get("rank") or 999))
+def _rank_sort_key(result: dict) -> tuple[int, str]:
+    try:
+        rank = int(result.get("rank") or 999)
+    except (TypeError, ValueError):
+        rank = 999
+    return rank, str(result.get("registration_id") or "")
+
+
+def _ranking_result_summary(match: dict, regs_by_id: dict[str, dict]) -> str:
+    results = sorted(match.get("results") or [], key=_rank_sort_key)
     if not results:
         return "Das Ergebnis wurde bestätigt."
     parts = []
@@ -51,8 +55,42 @@ def _v2_result_summary(match: dict, regs_by_id: dict[str, dict]) -> str:
     return "Ergebnis bestätigt: " + ", ".join(parts) + suffix + "."
 
 
+def _duel_result_summary(match: dict, regs_by_id: dict[str, dict]) -> str:
+    results = match.get("results") or []
+    if not results:
+        return "Das Ergebnis wurde bestätigt."
+    slots = sorted(match.get("slots") or [], key=lambda slot: int(slot.get("position") or 999))
+    participants = [slot.get("registration_id") for slot in slots[:2]]
+    while len(participants) < 2:
+        participants.append(None)
+    a_id, b_id = participants
+    a = _registration_name(regs_by_id.get(a_id), "Teilnehmer A")
+    b = _registration_name(regs_by_id.get(b_id), "Teilnehmer B")
+    results_by_id = {result.get("registration_id"): result for result in results}
+    score_a = results_by_id.get(a_id, {}).get("score")
+    score_b = results_by_id.get(b_id, {}).get("score")
+    score = f"{score_a if score_a is not None else 0}:{score_b if score_b is not None else 0}"
+    winner_results = [result for result in results if result.get("outcome") == "winner"]
+    winner_result = winner_results[0] if len(winner_results) == 1 else None
+    winner = _registration_name(
+        regs_by_id.get((winner_result or {}).get("registration_id")),
+        "Unentschieden",
+    )
+    if match.get("status") == "forfeit" or any(result.get("forfeit") for result in results):
+        return f"{a} gegen {b} wurde per Forfeit gewertet. Gewinner: {winner}."
+    return f"{a} gegen {b} ist bestätigt: {score}. Gewinner: {winner}."
+
+
+def _result_summary(match: dict, regs_by_id: dict[str, dict]) -> str:
+    if match.get("match_type") == "duel" and len(match.get("slots") or []) <= 2:
+        return _duel_result_summary(match, regs_by_id)
+    return _ranking_result_summary(match, regs_by_id)
+
+
 async def notify_match_result_confirmed(db, match: dict, collection_name: str = "matches", force: bool = False) -> int:
     """Create in-app notifications for all users involved in a confirmed match result."""
+    source_match = match
+    match = _canonical_match(source_match, collection_name)
     reg_ids = participant_source_ids(match)
     if not reg_ids:
         return 0
@@ -71,10 +109,7 @@ async def notify_match_result_confirmed(db, match: dict, collection_name: str = 
     ) or {}
     title = "Ergebnis korrigiert" if force else "Ergebnis bestätigt"
     tournament_title = tournament.get("title") or "Turnier"
-    if collection_name == "matches_v2" or match.get("slots"):
-        body = f"{tournament_title}: {_v2_result_summary(match, regs_by_id)}"
-    else:
-        body = f"{tournament_title}: {_classic_result_summary(match, regs_by_id)}"
+    body = f"{tournament_title}: {_result_summary(match, regs_by_id)}"
     meta = {
         "match_id": match.get("id"),
         "tournament_id": match.get("tournament_id"),
@@ -82,9 +117,9 @@ async def notify_match_result_confirmed(db, match: dict, collection_name: str = 
         "force": bool(force),
     }
     result_token = (
-        (match.get("result_meta") or {}).get("report_id")
-        or match.get("admin_decision_at")
-        or match.get("updated_at")
+        (source_match.get("result_meta") or {}).get("report_id")
+        or source_match.get("admin_decision_at")
+        or source_match.get("updated_at")
     )
     if result_token:
         meta["dedupe_key"] = f"match-result:{match.get('id')}:{result_token}"

--- a/backend/services/match_reminder.py
+++ b/backend/services/match_reminder.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 from database import get_db
 from match_rules import participant_source_ids
 from models import now_utc
+from services.competition_read import load_scheduled_matches
 from services.user_notifications import build_public_url, create_user_notification
 
 logger = logging.getLogger("tls.match_reminders")
@@ -99,102 +100,97 @@ async def schedule_match_reminders() -> dict:
     db = get_db()
     now = now_utc()
     horizon = now + timedelta(hours=25)
-    queries = [
-        ("matches", db.matches.find({
-            "scheduled_at": {"$gte": now.isoformat(), "$lte": horizon.isoformat()},
-            "status": {"$in": ["pending", "scheduled", "ready", "in_progress"]},
-        })),
-        ("matches_v2", db.matches_v2.find({
-            "scheduled_at": {"$gte": now.isoformat(), "$lte": horizon.isoformat()},
-            "status": {"$in": ["pending", "scheduled", "ready", "in_progress"]},
-        })),
-    ]
+    matches = await load_scheduled_matches(
+        db,
+        scheduled_from=now.isoformat(),
+        scheduled_until=horizon.isoformat(),
+        statuses={"pending", "scheduled", "ready", "in_progress"},
+    )
     queued = 0
     notifications = 0
     actual_start_only = 0
-    for _collection_name, cursor in queries:
-        async for m in cursor:
-            try:
-                scheduled = datetime.fromisoformat(m["scheduled_at"].replace("Z", "+00:00"))
-            except Exception:
-                continue
-            if scheduled.tzinfo is None:
-                scheduled = scheduled.replace(tzinfo=timezone.utc)
-            diff_min = (scheduled - now).total_seconds() / 60
-            # Tournament + opponent context
-            t = await db.tournaments.find_one(
-                {"id": m.get("tournament_id")},
-                {
-                    "title": 1,
-                    "slug": 1,
-                    "event_mode": 1,
-                    "schedule_mode": 1,
-                    "location": 1,
-                    "stream_link": 1,
-                },
-            ) or {}
-            if _uses_actual_start_notifications(t):
-                actual_start_only += 1
-                continue
-            url = f"/matches/{m.get('id')}"
-            mail_url = await build_public_url(url)
-            when_str = scheduled.astimezone(ZoneInfo("Europe/Vienna")).strftime("%d.%m. %H:%M Uhr")
-            station = await _station_label(m)
+    for m in matches:
+        try:
+            scheduled = datetime.fromisoformat(m["scheduled_at"].replace("Z", "+00:00"))
+        except Exception:
+            continue
+        if scheduled.tzinfo is None:
+            scheduled = scheduled.replace(tzinfo=timezone.utc)
+        diff_min = (scheduled - now).total_seconds() / 60
+        # Tournament + opponent context
+        t = await db.tournaments.find_one(
+            {"id": m.get("tournament_id")},
+            {
+                "title": 1,
+                "slug": 1,
+                "event_mode": 1,
+                "schedule_mode": 1,
+                "location": 1,
+                "stream_link": 1,
+            },
+        ) or {}
+        if _uses_actual_start_notifications(t):
+            actual_start_only += 1
+            continue
+        url = f"/matches/{m.get('id')}"
+        mail_url = await build_public_url(url)
+        when_str = scheduled.astimezone(ZoneInfo("Europe/Vienna")).strftime("%d.%m. %H:%M Uhr")
+        station = await _station_label(m)
 
-            participants = await _participants_for_match(m)
-            if len(participants) < 1:
-                continue
-            for p in participants:
-                opp_name = _opponent_label(participants, p)
-                for tpl_key, label, lead_min, window in LEAD_TIMES:
-                    # Match this lead time? (within ±window)
-                    if abs(diff_min - lead_min) > window:
-                        continue
-                    if label == "10m":
-                        dedupe_notification = f"match_reminder:{m.get('id')}:{p.get('id')}:web:{label}"
-                        exists = await db.notifications.find_one(
-                            {
-                                "user_id": p.get("id"),
-                                "kind": "match_reminder",
-                                "meta.dedupe_key": dedupe_notification,
-                            },
-                            {"_id": 1},
-                        )
-                        if not exists:
-                            station_part = f" an {station}" if station else ""
-                            await create_user_notification(
-                                p.get("id"),
-                                "Match startet in 10 Minuten",
-                                f"{t.get('title', 'Turnier')} gegen {opp_name} um {when_str}{station_part}.",
-                                url=url,
-                                kind="match_reminder",
-                                meta={
-                                    "category": "match_reminders",
-                                    "dedupe_key": dedupe_notification,
-                                    "match_id": m.get("id"),
-                                    "tournament_id": m.get("tournament_id"),
-                                    "lead_time": label,
-                                    "station": station,
-                                },
-                            )
-                            notifications += 1
-                    if label not in EMAIL_LEAD_LABELS:
-                        continue
-                    if not p.get("email"):
-                        continue
-                    from services.notification_preferences import send_user_template
-                    dedupe = f"match_reminder:{m.get('id')}:{p.get('id')}:{label}"
-                    result = await send_user_template(
-                        p, tpl_key,
-                        tournament_title=t.get("title", "Turnier"),
-                        opponent=opp_name,
-                        when=when_str,
-                        url=mail_url,
-                        station=station,
-                        dedupe_key=dedupe,
+        participants = await _participants_for_match(m)
+        if len(participants) < 1:
+            continue
+        for p in participants:
+            opp_name = _opponent_label(participants, p)
+            for tpl_key, label, lead_min, window in LEAD_TIMES:
+                # Match this lead time? (within ±window)
+                if abs(diff_min - lead_min) > window:
+                    continue
+                if label == "10m":
+                    dedupe_notification = f"match_reminder:{m.get('id')}:{p.get('id')}:web:{label}"
+                    exists = await db.notifications.find_one(
+                        {
+                            "user_id": p.get("id"),
+                            "kind": "match_reminder",
+                            "meta.dedupe_key": dedupe_notification,
+                        },
+                        {"_id": 1},
                     )
-                    if result.get("ok") and not result.get("skipped") and not result.get("deduped"):
-                        queued += 1
+                    if not exists:
+                        station_part = f" an {station}" if station else ""
+                        await create_user_notification(
+                            p.get("id"),
+                            "Match startet in 10 Minuten",
+                            f"{t.get('title', 'Turnier')} gegen {opp_name} um {when_str}{station_part}.",
+                            url=url,
+                            kind="match_reminder",
+                            meta={
+                                "category": "match_reminders",
+                                "dedupe_key": dedupe_notification,
+                                "match_id": m.get("id"),
+                                "tournament_id": m.get("tournament_id"),
+                                "lead_time": label,
+                                "station": station,
+                            },
+                        )
+                        notifications += 1
+                if label not in EMAIL_LEAD_LABELS:
+                    continue
+                if not p.get("email"):
+                    continue
+                from services.notification_preferences import send_user_template
+                dedupe = f"match_reminder:{m.get('id')}:{p.get('id')}:{label}"
+                result = await send_user_template(
+                    p, tpl_key,
+                    tournament_title=t.get("title", "Turnier"),
+                    opponent=opp_name,
+                    when=when_str,
+                    url=mail_url,
+                    station=station,
+                    dedupe_key=dedupe,
+                )
+                if result.get("ok") and not result.get("skipped") and not result.get("deduped"):
+                    queued += 1
     if queued or notifications:
         logger.info(f"[match-reminders] queued {queued} mails, created {notifications} web notifications")
     return {

--- a/backend/tests/test_competition_read_unit.py
+++ b/backend/tests/test_competition_read_unit.py
@@ -6,6 +6,7 @@ from services.competition_read import (
     find_match_source,
     load_competition_read_model,
     load_registration_matches,
+    load_scheduled_matches,
     observe_structure_read,
 )
 
@@ -48,8 +49,12 @@ class FakeCollection:
                     return False
                 continue
             values = self._values(row, key)
-            if isinstance(expected, dict) and "$in" in expected:
-                if not any(value in expected["$in"] for value in values):
+            if isinstance(expected, dict):
+                if "$in" in expected and not any(value in expected["$in"] for value in values):
+                    return False
+                if "$gte" in expected and not any(value is not None and value >= expected["$gte"] for value in values):
+                    return False
+                if "$lte" in expected and not any(value is not None and value <= expected["$lte"] for value in values):
                     return False
             elif expected not in values:
                 return False
@@ -74,6 +79,7 @@ class FakeDb:
             "participant_a_id": "r1",
             "participant_b_id": "r2",
             "status": "ready",
+            "scheduled_at": "2026-08-17T12:00:00+00:00",
         }])
         self.matches_v2 = FakeCollection([{
             "id": "stage-1",
@@ -84,6 +90,7 @@ class FakeDb:
             "results": [],
             "advancement": [],
             "status": "pending",
+            "scheduled_at": "2026-08-17T11:00:00+00:00",
         }])
         self.tournament_stages = FakeCollection([{
             "id": "s1",
@@ -136,3 +143,15 @@ def test_registration_read_and_status_counts_cover_both_stores():
     assert {match["id"] for match in matches} == {"legacy-1", "stage-1"}
     assert asyncio.run(count_matches_by_status(db, {"ready", "pending"})) == 2
     assert asyncio.run(count_matches_by_status(db, {"disputed"})) == 0
+
+
+def test_scheduled_match_read_covers_both_stores_and_sorts_canonically():
+    matches = asyncio.run(load_scheduled_matches(
+        FakeDb(),
+        scheduled_from="2026-08-17T10:00:00+00:00",
+        scheduled_until="2026-08-17T13:00:00+00:00",
+        statuses={"pending", "ready"},
+    ))
+
+    assert [match["id"] for match in matches] == ["stage-1", "legacy-1"]
+    assert [match["collection"] for match in matches] == ["matches_v2", "matches"]

--- a/backend/tests/test_competition_snapshot_unit.py
+++ b/backend/tests/test_competition_snapshot_unit.py
@@ -72,6 +72,7 @@ def _stage_fixture():
             "match_key": "A",
             "section": "WB",
             "match_type": "duel",
+            "settings": {"min_players": 2, "duration_minutes": 45},
             "slots": [
                 {"slot": 1, "source": {"type": "seed", "seed": 1}, "registration_id": "r1", "status": "filled"},
                 {"slot": 2, "source": {"type": "seed", "seed": 2}, "registration_id": "r2", "status": "filled"},
@@ -164,6 +165,7 @@ def test_stage_adapter_resolves_match_key_sources_to_stable_match_ids():
     final = adapted[2]
 
     assert adapted[0]["source"] == {"engine": "stage", "collection": "matches_v2"}
+    assert adapted[0]["settings"] == {"min_players": 2, "duration_minutes": 45}
     assert final["slots"][0]["source"]["match_id"] == "m1"
     assert final["slots"][1]["source"]["match_id"] == "m2"
     assert final["slots"][0]["source"]["outcome"] == "winner"

--- a/backend/tests/test_match_notifications_unit.py
+++ b/backend/tests/test_match_notifications_unit.py
@@ -1,0 +1,78 @@
+from services.match_notifications import _canonical_match, _result_summary
+
+
+REGISTRATIONS = {
+    "r1": {"id": "r1", "display_name": "Alice"},
+    "r2": {"id": "r2", "display_name": "Bob"},
+}
+
+
+def test_legacy_and_stage_duels_use_the_same_result_summary():
+    legacy = _canonical_match({
+        "id": "legacy-1",
+        "tournament_id": "t1",
+        "participant_a_id": "r1",
+        "participant_b_id": "r2",
+        "score_a": 3,
+        "score_b": 1,
+        "winner_id": "r1",
+        "status": "completed",
+    }, "matches")
+    stage = _canonical_match({
+        "id": "stage-1",
+        "tournament_id": "t1",
+        "match_type": "duel",
+        "slots": [
+            {"slot": 1, "registration_id": "r1", "status": "filled"},
+            {"slot": 2, "registration_id": "r2", "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": "r1", "rank": 1, "score": 3},
+            {"registration_id": "r2", "rank": 2, "score": 1},
+        ],
+        "status": "completed",
+    }, "matches_v2")
+
+    expected = "Alice gegen Bob ist bestätigt: 3:1. Gewinner: Alice."
+    assert _result_summary(legacy, REGISTRATIONS) == expected
+    assert _result_summary(stage, REGISTRATIONS) == expected
+
+
+def test_stage_placement_match_keeps_ranked_result_summary():
+    match = _canonical_match({
+        "id": "stage-ffa",
+        "tournament_id": "t1",
+        "match_type": "placement",
+        "slots": [
+            {"slot": 1, "registration_id": "r1", "status": "filled"},
+            {"slot": 2, "registration_id": "r2", "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": "r2", "rank": 2},
+            {"registration_id": "r1", "rank": 1},
+        ],
+        "status": "completed",
+    }, "matches_v2")
+
+    assert _result_summary(match, REGISTRATIONS) == "Ergebnis bestätigt: 1. Alice, 2. Bob."
+
+
+def test_stage_duel_with_shared_first_rank_is_reported_as_draw():
+    match = _canonical_match({
+        "id": "stage-draw",
+        "tournament_id": "t1",
+        "match_type": "duel",
+        "slots": [
+            {"slot": 1, "registration_id": "r1", "status": "filled"},
+            {"slot": 2, "registration_id": "r2", "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": "r1", "rank": 1, "score": 2},
+            {"registration_id": "r2", "rank": 1, "score": 2},
+        ],
+        "status": "completed",
+    }, "matches_v2")
+
+    assert _result_summary(match, REGISTRATIONS) == (
+        "Alice gegen Bob ist bestätigt: 2:2. Gewinner: Unentschieden."
+    )


### PR DESCRIPTION
## Was sich ändert

- lädt geplante Matches für Reminder zentral und kanonisch aus Legacy- und Stage-Speicher
- nutzt für Stationssuche und automatische Stationsplanung das gemeinsame Read Model
- vereinheitlicht Ergebnisbenachrichtigungen für Duel- und Placement-Matches
- erhält bei Stationsaktionen bewusst den tatsächlichen Collection-Schreibpfad
- ergänzt Scheduling-/Settings-Felder und dokumentiert den Consumer-Status

## Warum

Package 2 aus #120 soll alle Nebenverbraucher vom konkreten Match-Speicher entkoppeln, bevor der versionierte Schreibkern entsteht. So bleiben Bestandsmatches und IDs unverändert, während beide Engines dieselbe Lesesemantik liefern.

## Auswirkung

Reminder, Match-Ergebnisbenachrichtigungen und Stationsplanung funktionieren für Legacy- sowie Stage-/FFA-Matches über denselben Read-Vertrag. Es findet keine Migration, Neugenerierung oder Dual-Write-Änderung statt.

## Prüfung

- `python -m compileall -q services routes tests/test_competition_read_unit.py tests/test_match_notifications_unit.py`
- gezielte Operations-/Contract-Tests: 34 bestanden
- vollständige Backend-Suite: 298 bestanden, 282 übersprungen
- `git diff --check`

Refs #120