### PR TITLE
Package 2: Complete canonical competition reads

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -179,6 +179,7 @@ geschrieben.
 | Penalty-Transparenz | Legacy- und Stage-/FFA-Forfeits kanonisch sichtbar | Schreibregeln bleiben getrennt |
 | Disputes / Forfeit-Schreibpfad | weiterhin Legacy-lastig | in Package 3 fachlich vereinheitlichen |
 | Reminder / Notifications / Stationen | kanonische Match-Reads aktiv | Collection-spezifische Writes bleiben bis zum Schreibkern erhalten |
+| Event-Rekapitulation / Profilreferenzen | kanonische Standings- und Platzierungsprojektion aktiv | RankingPolicy folgt im Schreibkern |
 
 Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,
 Zielversion, ID-Mapping, Hash/Diff und Rollback-ID. Ein Fehler darf nie durch

--- a/backend/routes/event_routes.py
+++ b/backend/routes/event_routes.py
@@ -10,6 +10,8 @@ from services.visibility import user_can_see
 from services.access_links import public_access_link_payload, record_access_link_use, touch_access_link, validate_access_link
 from services.content_embed_service import resolve_content_embeds
 from services.public_phase import derive_public_phase
+from services.competition_read import load_competition_read_model, observe_structure_read
+from services.competition_standings import standings_for_structure
 from services.sponsor_utils import dedupe_public_sponsors
 from services.notification_preferences import enqueue_newsletter_for_item
 from services.slug_utils import apply_slug_history, find_by_slug_or_history, slug_source_for_update, unique_slug
@@ -217,56 +219,38 @@ async def _event_registration_summary(event: dict, exclude_registration_id: str 
 async def _tournament_recap_podium(db, tournament: dict) -> list[dict]:
     regs = await db.tournament_registrations.find({"tournament_id": tournament["id"]}, {"_id": 0}).to_list(1000)
     reg_map = {reg["id"]: reg for reg in regs}
-    matches_v2 = await db.matches_v2.find({"tournament_id": tournament["id"]}, {"_id": 0}).to_list(3000)
-    scores: dict[str, dict] = {}
-    if matches_v2:
-        for match in matches_v2:
-            if match.get("status") not in {"completed", "forfeit"}:
-                continue
-            for result in match.get("results") or []:
-                reg_id = result.get("registration_id")
-                if not reg_id:
-                    continue
-                row = scores.setdefault(reg_id, {"registration_id": reg_id, "wins": 0, "top2": 0, "points": 0, "played": 0, "rank_sum": 0})
-                rank = int(result.get("rank") or 999)
-                row["played"] += 1
-                row["rank_sum"] += rank
-                row["wins"] += 1 if rank == 1 else 0
-                row["top2"] += 1 if rank <= 2 else 0
-                points = result.get("points")
-                if points is None:
-                    points = result.get("score")
-                if isinstance(points, (int, float)):
-                    row["points"] += points
-        rows = list(scores.values())
-        rows.sort(key=lambda row: (row["wins"], row["top2"], row["points"], -row["rank_sum"]), reverse=True)
-    else:
-        matches = await db.matches.find({"tournament_id": tournament["id"]}, {"_id": 0}).to_list(1000)
-        for match in matches:
-            for reg_id in (match.get("participant_a_id"), match.get("participant_b_id")):
-                if reg_id:
-                    scores.setdefault(reg_id, {"registration_id": reg_id, "wins": 0, "losses": 0, "furthest_round": 0})
-                    scores[reg_id]["furthest_round"] = max(scores[reg_id]["furthest_round"], int(match.get("round") or 0))
-            if match.get("status") in {"completed", "forfeit"} and match.get("winner_id"):
-                winner_id = match.get("winner_id")
-                loser_id = match.get("participant_a_id") if winner_id == match.get("participant_b_id") else match.get("participant_b_id")
-                scores.setdefault(winner_id, {"registration_id": winner_id, "wins": 0, "losses": 0, "furthest_round": 0})
-                scores[winner_id]["wins"] += 1
-                if loser_id:
-                    scores.setdefault(loser_id, {"registration_id": loser_id, "wins": 0, "losses": 0, "furthest_round": 0})
-                    scores[loser_id]["losses"] += 1
-        rows = list(scores.values())
-        rows.sort(key=lambda row: (row.get("furthest_round") or 0, row.get("wins") or 0, -(row.get("losses") or 0)), reverse=True)
+    read_model = await load_competition_read_model(db, tournament["id"])
+    structure = read_model.structure_snapshot()
+    observe_structure_read(structure, surface="event_recap")
+    groups = []
+    if tournament.get("format") == "groups":
+        groups = await db.tournament_groups.find(
+            {"tournament_id": tournament["id"]},
+            {"_id": 0},
+        ).to_list(100)
+    rows = standings_for_structure(tournament, structure, regs, groups=groups)
+    if tournament.get("format") == "groups":
+        rows = [row for group in rows for row in group.get("standings") or []]
+    rows = [
+        row for row in rows
+        if row.get("played")
+        or row.get("furthest_round")
+        or row.get("wins")
+        or row.get("won")
+        or row.get("losses")
+    ]
     podium = []
     for index, row in enumerate(rows[:3], start=1):
         reg = reg_map.get(row.get("registration_id"))
         if not reg:
             continue
         detail_bits = []
-        if row.get("wins"):
-            detail_bits.append(f"{row['wins']} Siege")
-        if row.get("points"):
-            detail_bits.append(f"{row['points']} Punkte")
+        wins = row.get("wins") if row.get("wins") is not None else row.get("won")
+        if wins:
+            detail_bits.append(f"{wins} {'Sieg' if wins == 1 else 'Siege'}")
+        points = row.get("points")
+        if points:
+            detail_bits.append(f"{points} {'Punkt' if points == 1 else 'Punkte'}")
         podium.append({"rank": index, "name": _registration_name(reg), "detail": ", ".join(detail_bits)})
     return podium
 

--- a/backend/services/competition_read.py
+++ b/backend/services/competition_read.py
@@ -131,6 +131,23 @@ async def load_registration_matches(
     return [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
 
 
+async def load_matches_by_query(
+    db,
+    query: dict,
+    *,
+    per_store_limit: int = 5000,
+) -> list[dict]:
+    """Run one compatible filter against both stores and return canonical matches."""
+
+    legacy_cursor = db.matches.find(query, {"_id": 0})
+    stage_cursor = db.matches_v2.find(query, {"_id": 0})
+    legacy, stage = await asyncio.gather(
+        legacy_cursor.to_list(per_store_limit),
+        stage_cursor.to_list(per_store_limit),
+    )
+    return [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
+
+
 async def count_matches_by_status(db, statuses: set[str]) -> int:
     """Count operational matches across both stores for dashboard surfaces."""
 
@@ -159,13 +176,7 @@ async def load_scheduled_matches(
         "scheduled_at": {"$gte": scheduled_from, "$lte": scheduled_until},
         "status": {"$in": sorted(statuses)},
     }
-    legacy_cursor = db.matches.find(query, {"_id": 0})
-    stage_cursor = db.matches_v2.find(query, {"_id": 0})
-    legacy, stage = await asyncio.gather(
-        legacy_cursor.to_list(per_store_limit),
-        stage_cursor.to_list(per_store_limit),
-    )
-    matches = [*adapt_legacy_matches(legacy), *adapt_stage_matches(stage)]
+    matches = await load_matches_by_query(db, query, per_store_limit=per_store_limit)
     return sorted(matches, key=lambda match: (
         str(match.get("scheduled_at") or ""),
         str(match.get("id") or ""),

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -78,6 +78,12 @@ def _legacy_results(match: dict) -> list[dict]:
         (match.get("participant_a_id"), match.get("score_a")),
         (match.get("participant_b_id"), match.get("score_b")),
     ]
+    participant_ids = {registration_id for registration_id, _score in participants if registration_id}
+    if winner_id and winner_id not in participant_ids:
+        participants.append((winner_id, None))
+        participant_ids.add(winner_id)
+    if loser_id and loser_id not in participant_ids:
+        participants.append((loser_id, None))
     score_by_id = {registration_id: score for registration_id, score in participants if registration_id}
     if not winner_id and len(score_by_id) == 2:
         ordered = list(score_by_id.items())

--- a/backend/services/match_overview.py
+++ b/backend/services/match_overview.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from services.competition_snapshot import adapt_legacy_matches, adapt_stage_matches
+from services.competition_read import load_matches_by_query
 from services.station_labels import attach_station_info
 from services.tournament_permissions import RESULT_STAFF_ROLES, is_global_tournament_staff
 
@@ -72,9 +72,7 @@ async def _active_registrations_for_user(db, user: dict) -> list[dict]:
 
 
 async def _matches_for_query(db, query: dict, per_collection_limit: int = 240) -> list[dict]:
-    legacy = await db.matches.find(query, {"_id": 0}).to_list(per_collection_limit)
-    v2 = await db.matches_v2.find(query, {"_id": 0}).to_list(per_collection_limit)
-    return [*adapt_legacy_matches(legacy), *adapt_stage_matches(v2)]
+    return await load_matches_by_query(db, query, per_store_limit=per_collection_limit)
 
 
 def _registration_label(registration: dict | None, team_map: dict[str, dict]) -> str:

--- a/backend/services/profile_references.py
+++ b/backend/services/profile_references.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from database import get_db
 from services.competition_read import load_competition_read_model, observe_structure_read
-from services.competition_standings import standings_for_structure
+from services.competition_standings import placements_for_structure, standings_for_structure
 from services.visibility import user_can_see
 
 RESULT_TOURNAMENT_STATUSES = {"completed", "results_published", "archived"}
@@ -158,15 +158,6 @@ async def _tournament_rank_for_user(tournament_id: str, user_id: str, team_ids: 
         if rank is not None:
             return rank, participant_count
 
-    placements = await db.matches.find(
-        {"tournament_id": tournament_id, "winner_id": {"$in": reg_ids}, "final_position": {"$ne": None}},
-        {"_id": 0, "winner_id": 1, "final_position": 1},
-    ).to_list(20)
-    for placement in placements:
-        rank = _safe_int(placement.get("final_position"))
-        if rank is not None:
-            return rank, participant_count
-
     read_model = await load_competition_read_model(db, tournament_id)
     if not read_model.legacy_matches and not read_model.stage_matches:
         return None, participant_count
@@ -177,6 +168,11 @@ async def _tournament_rank_for_user(tournament_id: str, user_id: str, team_ids: 
         groups = await db.tournament_groups.find({"tournament_id": tournament_id}, {"_id": 0}).to_list(100)
     structure = read_model.structure_snapshot()
     observe_structure_read(structure, surface="profile_references")
+    placements = placements_for_structure(structure, regs)
+    for rank, placement in sorted(placements.items()):
+        if placement.get("registration_id") in reg_ids:
+            return rank, participant_count
+
     rows = standings_for_structure(tournament, structure, regs, groups=groups)
     if tournament.get("format") == "groups":
         rows = [row for group in rows for row in group.get("standings") or []]

--- a/backend/tests/test_competition_consumer_boundary_unit.py
+++ b/backend/tests/test_competition_consumer_boundary_unit.py
@@ -1,0 +1,29 @@
+import pathlib
+import re
+
+
+BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
+READ_CONSUMERS = (
+    "badges.py",
+    "pdf_service.py",
+    "routes/event_routes.py",
+    "routes/extras_routes.py",
+    "routes/station_routes.py",
+    "services/match_notifications.py",
+    "services/match_overview.py",
+    "services/match_reminder.py",
+    "services/profile_references.py",
+)
+DIRECT_MATCH_READ = re.compile(
+    r"db\.(?:matches|matches_v2)\.(?:find|find_one|count_documents|aggregate|distinct)\s*\("
+)
+
+
+def test_read_consumers_do_not_bypass_competition_projection_boundary():
+    violations = []
+    for relative_path in READ_CONSUMERS:
+        source = (BACKEND_ROOT / relative_path).read_text(encoding="utf-8")
+        if DIRECT_MATCH_READ.search(source):
+            violations.append(relative_path)
+
+    assert violations == []

--- a/backend/tests/test_competition_read_unit.py
+++ b/backend/tests/test_competition_read_unit.py
@@ -5,6 +5,7 @@ from services.competition_read import (
     count_matches_by_status,
     find_match_source,
     load_competition_read_model,
+    load_matches_by_query,
     load_registration_matches,
     load_scheduled_matches,
     observe_structure_read,
@@ -155,3 +156,12 @@ def test_scheduled_match_read_covers_both_stores_and_sorts_canonically():
 
     assert [match["id"] for match in matches] == ["stage-1", "legacy-1"]
     assert [match["collection"] for match in matches] == ["matches_v2", "matches"]
+
+
+def test_compatible_query_read_is_centralized_for_both_stores():
+    matches = asyncio.run(load_matches_by_query(
+        FakeDb(),
+        {"tournament_id": "t1", "status": {"$in": ["pending", "ready"]}},
+    ))
+
+    assert {match["id"] for match in matches} == {"legacy-1", "stage-1"}

--- a/backend/tests/test_competition_snapshot_unit.py
+++ b/backend/tests/test_competition_snapshot_unit.py
@@ -187,6 +187,28 @@ def test_adapter_tolerates_unset_scores_and_non_numeric_sort_fields():
     assert [result["outcome"] for result in legacy[0]["results"]] == [None, None]
 
 
+def test_legacy_adapter_preserves_orphaned_historical_winner_placement():
+    adapted = adapt_legacy_matches([{
+        "id": "historical-placement",
+        "tournament_id": "t1",
+        "winner_id": "r1",
+        "final_position": 2,
+        "status": "completed",
+    }])
+
+    assert adapted[0]["results"] == [{
+        "registration_id": "r1",
+        "rank": 1,
+        "score": None,
+        "points": None,
+        "time_ms": None,
+        "outcome": "winner",
+        "dnf": False,
+        "forfeit": False,
+        "note": None,
+    }]
+
+
 def test_legacy_and_stage_fixtures_have_equal_engine_independent_semantics():
     legacy = adapt_legacy_matches(_legacy_fixture())
     stage = adapt_stage_matches(_stage_fixture())

--- a/backend/tests/test_event_recap_competition_unit.py
+++ b/backend/tests/test_event_recap_competition_unit.py
@@ -1,0 +1,70 @@
+import asyncio
+
+from routes.event_routes import _tournament_recap_podium
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, *_args):
+        return self
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+
+    def find(self, query, _projection=None):
+        rows = [
+            row for row in self.rows
+            if all(row.get(key) == value for key, value in query.items())
+        ]
+        return FakeCursor(rows)
+
+
+class FakeDb:
+    def __init__(self):
+        self.tournament_registrations = FakeCollection([
+            {"id": "r1", "tournament_id": "t1", "display_name": "Alice"},
+            {"id": "r2", "tournament_id": "t1", "display_name": "Bob"},
+        ])
+        self.matches = FakeCollection()
+        self.matches_v2 = FakeCollection([{
+            "id": "stage-final",
+            "tournament_id": "t1",
+            "stage_id": "s1",
+            "stage_number": 1,
+            "round": 1,
+            "match_type": "duel",
+            "status": "completed",
+            "slots": [
+                {"slot": 1, "registration_id": "r1", "status": "filled"},
+                {"slot": 2, "registration_id": "r2", "status": "filled"},
+            ],
+            "results": [
+                {"registration_id": "r1", "rank": 1, "score": 3},
+                {"registration_id": "r2", "rank": 2, "score": 1},
+            ],
+        }])
+        self.tournament_stages = FakeCollection([{
+            "id": "s1",
+            "tournament_id": "t1",
+            "number": 1,
+            "stage_type": "single_elimination",
+        }])
+
+
+def test_event_recap_uses_canonical_stage_standings():
+    podium = asyncio.run(_tournament_recap_podium(FakeDb(), {
+        "id": "t1",
+        "format": "single_elim",
+    }))
+
+    assert podium == [
+        {"rank": 1, "name": "Alice", "detail": "1 Sieg, 3 Punkte"},
+        {"rank": 2, "name": "Bob", "detail": "1 Punkt"},
+    ]


### PR DESCRIPTION
## Was sich ändert

- führt kompatible Match-Queries über die zentrale Competition-Read-Grenze aus
- erzeugt Event-Rückblick-Podien aus kanonischen Standings statt einer Legacy/V2-Verzweigung
- liest historische Profilplatzierungen über die kanonische Placement-Projektion
- erhält auch alte `winner_id`-/`final_position`-Datensätze ohne vollständige A/B-Slots verlustfrei
- verhindert per Architekturtest neue direkte Match-Collection-Reads in fachlichen Nebenverbrauchern

## Warum

Der Abschluss-Audit nach #129 fand noch zwei fachliche Nebenverbraucher mit Collection-spezifischen Reads. Dieser PR schließt den letzten offenen Punkt aus Package 2 von #120, ohne einen Schreibpfad oder Bestandsdatensatz zu migrieren.

## Auswirkung

Event-Rekapitulation, Profilreferenzen und Match-Übersichten folgen jetzt derselben Read-Semantik wie Bracket, Standings, Preise, Badges, PDF/Widget, Reminder, Notifications und Stationen. Mutation-nahe Match-/Turnierrouten bleiben bewusst Package 3 vorbehalten.

## Prüfung

- gezielte Read-/Profil-/Recap-/Overview-Tests: 33 bestanden
- vollständige Backend-Suite: 302 bestanden, 282 übersprungen
- Backend-Kompilierung
- `git diff --check`

Refs #120