### PR TITLE
Package 3: Persist competition version contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.pytest_tmp_*/
 .mypy_cache/
 .ruff_cache/
 .coverage

--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -185,6 +185,23 @@ Jede Datenmigration benoetigt Backup-/Restore-Nachweis, Migration-Ledger,
 Zielversion, ID-Mapping, Hash/Diff und Rollback-ID. Ein Fehler darf nie durch
 erneute Bracket-Generierung "repariert" werden.
 
+## Persistierter Versionsvertrag
+
+Neue Wettbewerbe speichern `engine_version` und `ruleset_version` im
+Turnierdokument. Die Engine-Namen beschreiben intern das aktuelle Schreibmodell,
+ohne neue oeffentliche Legacy-/V2-Produkte einzufuehren:
+
+- `competition.classic.v1`: aktuelles festes Duel-/Runden-Schreibmodell;
+- `competition.graph.v1`: aktuelles Slot-/Result-/Advancement-Graphmodell;
+- `competition.external.v1`: Wettbewerbsauswertung ausserhalb der Match-Engine;
+- `competition.ruleset.v1`: Schema des derzeitigen Turnier-Regelvertrags.
+
+Ein erfolgreicher Struktur-Write pinnt das tatsaechlich verwendete Schreibmodell.
+Historische Turniere ohne persistierte Angabe werden im Read-Vertrag bewusst als
+`competition.unversioned` bzw. `competition.ruleset.unversioned` gekennzeichnet;
+das Format allein darf die Engine nicht erraten. Eine persistierende
+Bestandszuordnung bleibt Teil des spaeteren Dry Runs mit Hash/Diff und Rollback.
+
 ## Abnahmematrix
 
 - Teilnehmerzahlen 0/1 sowie 3/5/63/64/65 und grosse Strukturen;

--- a/backend/database.py
+++ b/backend/database.py
@@ -56,6 +56,8 @@ async def init_indexes():
     await db.tournaments.create_index("status")
     await db.tournaments.create_index("game_id")
     await db.tournaments.create_index("event_id")
+    await db.tournaments.create_index("engine_version")
+    await db.tournaments.create_index("ruleset_version")
     # Registrations
     await db.tournament_registrations.create_index("id", unique=True)
     await db.tournament_registrations.create_index([("tournament_id", 1), ("user_id", 1)])

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -33,6 +33,11 @@ from services.custom_bracket import BracketSchemaError, build_matches_v2_from_sc
 from services.competition_formats import find_format_capability
 from services.competition_read import load_competition_read_model, observe_structure_read
 from services.competition_standings import placement_rows_for_structure, standings_for_structure
+from services.competition_versions import (
+    apply_competition_version_read_defaults,
+    new_competition_version_fields,
+    persist_competition_versions,
+)
 from services.match_v2_results import (
     MatchV2ResultError,
     build_v2_result_application,
@@ -100,6 +105,9 @@ def _compact_tournament(t: dict) -> dict:
         "registration_open_from": t.get("registration_open_from"),
         "registration_open_until": t.get("registration_open_until"),
         "is_invite_only": t.get("is_invite_only"),
+        "engine_version": t.get("engine_version"),
+        "ruleset_version": t.get("ruleset_version"),
+        "version_inferred": bool(t.get("version_inferred")),
         "game": {
             "id": game.get("id"),
             "name": game.get("name"),
@@ -874,6 +882,7 @@ async def _generate_legacy_bracket_docs(db, tournament: dict, actor_id: str | No
     if existing_matches:
         await db.matches.delete_many({"tournament_id": tid})
     await db.matches.insert_many(matches)
+    await persist_competition_versions(db, tournament, "classic")
     if set_live and not preview:
         await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live", "updated_at": now_utc().isoformat()}})
     await _audit_tournament_action(
@@ -926,6 +935,7 @@ async def _create_initial_stage_bracket_preview(db, tournament: dict, actor_id: 
 
     await db.tournament_stages.insert_one(stage)
     await db.matches_v2.insert_many(matches)
+    await persist_competition_versions(db, tournament, "graph")
     await _audit_tournament_action(
         db,
         "tournament.stage.preview_create",
@@ -991,6 +1001,7 @@ async def _refresh_preview_bracket_after_registration(db, tournament: dict, acto
     if existing_matches:
         await db.matches.delete_many({"tournament_id": tid})
     await db.matches.insert_many(matches)
+    await persist_competition_versions(db, tournament, "classic")
     await _audit_tournament_action(
         db,
         "tournament.bracket.preview_refresh",
@@ -1058,6 +1069,7 @@ async def _refresh_stage_previews_after_registration(db, tournament: dict, actor
     if not changed_stages:
         return None
 
+    await persist_competition_versions(db, tournament, "graph")
     await _audit_tournament_action(
         db,
         "tournament.stage.preview_refresh",
@@ -1150,6 +1162,7 @@ async def _finalize_stage_previews_for_checkin(db, tournament: dict, actor_id: s
 
     if not changed_stages:
         return None
+    await persist_competition_versions(db, tournament, "graph")
     await _audit_tournament_action(
         db,
         "tournament.stage.finalize_checkin",
@@ -1307,6 +1320,7 @@ async def _rebuild_checkin_bracket_after_staff_change(db, tournament: dict, acto
 
         if not changed_stages:
             return None
+        await persist_competition_versions(db, tournament, "graph")
         await _audit_tournament_action(
             db,
             "tournament.stage.checkin_rebuild_after_registration",
@@ -1456,6 +1470,7 @@ async def _apply_checked_in_badges(user_id: str, tid: str) -> None:
 async def _enrich_tournament(t: dict, user: dict | None = None) -> dict:
     db = get_db()
     t.pop("creation_key", None)
+    apply_competition_version_read_defaults(t)
     t["public_phase"] = derive_public_phase(t, "tournament")
     if t.get("game_id"):
         g = await db.games.find_one({"id": t["game_id"]}, {"_id": 0})
@@ -1683,6 +1698,7 @@ async def create_tournament(body: TournamentCreate, me: dict = Depends(require_a
             existing = await db.tournaments.find_one({"creation_key": creation_key}, {"_id": 0})
             if existing:
                 existing.pop("creation_key", None)
+                apply_competition_version_read_defaults(existing)
                 return {**existing, "auto_generated_bracket": None, "idempotent_replay": True}
             # Validate game
             if not await db.games.find_one({"id": body.game_id}):
@@ -1698,6 +1714,7 @@ async def create_tournament(body: TournamentCreate, me: dict = Depends(require_a
                       "check_in_until", "start_date", "end_date"]:
                 doc[k] = _iso(doc.get(k))
             doc["id"] = new_id()
+            doc.update(new_competition_version_fields(doc.get("format")))
             # Allow scheduling directly (announced) — fall back to draft.
             if not doc.get("status"):
                 doc["status"] = "draft"
@@ -1711,10 +1728,12 @@ async def create_tournament(body: TournamentCreate, me: dict = Depends(require_a
                 if not existing:
                     raise HTTPException(status_code=409, detail="Turnier konnte wegen einer parallelen Erstellung nicht angelegt werden")
                 existing.pop("creation_key", None)
+                apply_competition_version_read_defaults(existing)
                 return {**existing, "auto_generated_bracket": None, "idempotent_replay": True}
             auto_preview = await _create_initial_bracket_preview(db, doc, me.get("id"))
             doc.pop("_id", None)
             doc.pop("creation_key", None)
+            apply_competition_version_read_defaults(doc)
             doc["auto_generated_bracket"] = auto_preview
             doc["idempotent_replay"] = False
             return doc
@@ -1765,6 +1784,7 @@ async def update_tournament(tid: str, body: TournamentUpdate, me: dict = Depends
     await db.tournaments.update_one({"id": tid}, {"$set": updates})
     t = await db.tournaments.find_one({"id": tid}, {"_id": 0})
     t.pop("creation_key", None)
+    apply_competition_version_read_defaults(t)
     return t
 
 
@@ -2680,6 +2700,7 @@ async def generate_tournament_stage_matches(tid: str, stage_id: str, force: bool
         {"id": stage_id},
         {"$set": {"status": "pending" if preview else "ready", "updated_at": now_utc().isoformat()}},
     )
+    await persist_competition_versions(db, tournament, "graph")
     await _audit_tournament_action(
         db,
         "tournament.stage.generate",
@@ -2843,6 +2864,7 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
             "tournament_id": tid,
             "id": {"$ne": stage["id"]},
         })
+        await persist_competition_versions(db, tournament, "graph")
         await _audit_tournament_action(
             db,
             "tournament.bracket.rebuild_from_structure",
@@ -3281,6 +3303,7 @@ async def swiss_next_round(tid: str, me: dict = Depends(require_admin()),
     matches = generate_swiss_round(tid, regs, prev, next_round_num, t.get("best_of", 1))
     if matches:
         await db.matches.insert_many(matches)
+        await persist_competition_versions(db, t, "classic")
     if t.get("status") == "draft":
         await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live"}})
     return {"ok": True, "round": next_round_num, "match_count": len(matches)}
@@ -3310,6 +3333,7 @@ async def groups_generate(tid: str, body: dict, me: dict = Depends(require_admin
         await db.tournament_groups.insert_many(res["groups"])
     if res["matches"]:
         await db.matches.insert_many(res["matches"])
+        await persist_competition_versions(db, t, "classic")
     await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live"}})
     return {"ok": True, "group_count": len(res["groups"]), "match_count": len(res["matches"])}
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -5,6 +5,7 @@ from database import get_db
 from auth import hash_password
 from models import new_id, now_utc
 from runtime_config import resolve_app_environment
+from services.competition_versions import new_competition_version_fields
 
 
 async def seed_admin(admin_email: str, admin_password: str) -> bool:
@@ -234,6 +235,7 @@ async def seed_demo_data(demo_password: str):
     # Mario Kart Tournament (Single Elim, 16 players)
     mk_tid = new_id()
     await db.tournaments.insert_one({
+        **new_competition_version_fields("single_elim"),
         "id": mk_tid, "slug": "mario-kart-winter-cup",
         "title": "Mario Kart Winter Cup",
         "description": "Das klassische Mario Kart Turnier. Single Elimination, Best of 3.",
@@ -275,6 +277,7 @@ async def seed_demo_data(demo_password: str):
     # Smash Tournament - Double Elim, Draft
     smash_tid = new_id()
     await db.tournaments.insert_one({
+        **new_competition_version_fields("double_elim"),
         "id": smash_tid, "slug": "smash-showdown-q1",
         "title": "Smash Showdown Q1",
         "description": "Super Smash Bros. Ultimate. Double Elimination, Best of 5 im Finale.",

--- a/backend/services/competition_formats.py
+++ b/backend/services/competition_formats.py
@@ -17,6 +17,7 @@ CanonicalMatchType = Literal["duel", "ffa"]
 ResultModel = Literal["duel_score", "ranking", "standings", "time"]
 PairingMode = Literal["static_graph", "scheduled_rounds", "dynamic_rounds", "ranking_series"]
 AutoMatchLimit = Literal["legacy_estimate", "none"]
+CurrentWriteModel = Literal["classic", "graph", "external"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +35,7 @@ class TournamentFormatCapability:
     canonical_match_type: CanonicalMatchType
     result_model: ResultModel
     pairing_mode: PairingMode
+    current_write_model: CurrentWriteModel
     initial_preview_engine: InitialPreviewEngine
     rebuild_engine: RebuildEngine
     stage_generator_available: bool
@@ -53,6 +55,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="duel_score",
         pairing_mode="static_graph",
+        current_write_model="classic",
         initial_preview_engine="legacy",
         rebuild_engine="stage",
         stage_generator_available=True,
@@ -67,6 +70,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="duel_score",
         pairing_mode="static_graph",
+        current_write_model="classic",
         initial_preview_engine="legacy",
         rebuild_engine="stage",
         stage_generator_available=True,
@@ -81,6 +85,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="standings",
         pairing_mode="scheduled_rounds",
+        current_write_model="classic",
         initial_preview_engine="legacy",
         rebuild_engine="legacy",
         stage_generator_available=False,
@@ -95,6 +100,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="standings",
         pairing_mode="dynamic_rounds",
+        current_write_model="classic",
         initial_preview_engine="none",
         rebuild_engine="none",
         stage_generator_available=False,
@@ -109,6 +115,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="standings",
         pairing_mode="scheduled_rounds",
+        current_write_model="classic",
         initial_preview_engine="none",
         rebuild_engine="none",
         stage_generator_available=False,
@@ -123,6 +130,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="ffa",
         result_model="ranking",
         pairing_mode="ranking_series",
+        current_write_model="graph",
         initial_preview_engine="stage",
         rebuild_engine="stage",
         stage_generator_available=True,
@@ -137,6 +145,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="ffa",
         result_model="ranking",
         pairing_mode="ranking_series",
+        current_write_model="graph",
         initial_preview_engine="stage",
         rebuild_engine="stage",
         stage_generator_available=True,
@@ -151,6 +160,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="standings",
         pairing_mode="scheduled_rounds",
+        current_write_model="classic",
         initial_preview_engine="legacy",
         rebuild_engine="legacy",
         stage_generator_available=False,
@@ -165,6 +175,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="ffa",
         result_model="time",
         pairing_mode="ranking_series",
+        current_write_model="external",
         initial_preview_engine="none",
         rebuild_engine="none",
         stage_generator_available=False,
@@ -179,6 +190,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="ffa",
         result_model="ranking",
         pairing_mode="ranking_series",
+        current_write_model="external",
         initial_preview_engine="none",
         rebuild_engine="none",
         stage_generator_available=False,
@@ -193,6 +205,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="duel",
         result_model="duel_score",
         pairing_mode="static_graph",
+        current_write_model="graph",
         initial_preview_engine="stage",
         rebuild_engine="stage",
         stage_generator_available=True,
@@ -207,6 +220,7 @@ _FORMAT_CAPABILITIES = {
         canonical_match_type="ffa",
         result_model="ranking",
         pairing_mode="static_graph",
+        current_write_model="graph",
         initial_preview_engine="stage",
         rebuild_engine="stage",
         stage_generator_available=True,

--- a/backend/services/competition_versions.py
+++ b/backend/services/competition_versions.py
@@ -1,0 +1,73 @@
+"""Persisted version contract for competition write models and rulesets."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from services.competition_formats import find_format_capability
+
+
+CompetitionWriteModel = Literal["classic", "graph", "external"]
+
+ENGINE_VERSION_BY_WRITE_MODEL = {
+    "classic": "competition.classic.v1",
+    "graph": "competition.graph.v1",
+    "external": "competition.external.v1",
+}
+CURRENT_RULESET_VERSION = "competition.ruleset.v1"
+UNVERSIONED_ENGINE_VERSION = "competition.unversioned"
+UNVERSIONED_RULESET_VERSION = "competition.ruleset.unversioned"
+
+
+def new_competition_version_fields(format_key: str | None) -> dict[str, str]:
+    """Return explicit versions for a newly created competition."""
+
+    capability = find_format_capability(format_key)
+    engine_version = (
+        ENGINE_VERSION_BY_WRITE_MODEL[capability.current_write_model]
+        if capability
+        else UNVERSIONED_ENGINE_VERSION
+    )
+    return {
+        "engine_version": engine_version,
+        "ruleset_version": CURRENT_RULESET_VERSION,
+    }
+
+
+def competition_version_fields_for_write(
+    tournament: dict,
+    write_model: CompetitionWriteModel,
+) -> dict[str, str]:
+    """Resolve versions after a concrete write model successfully produced data."""
+
+    return {
+        "engine_version": ENGINE_VERSION_BY_WRITE_MODEL[write_model],
+        "ruleset_version": tournament.get("ruleset_version") or CURRENT_RULESET_VERSION,
+    }
+
+
+def apply_competition_version_read_defaults(tournament: dict) -> dict:
+    """Expose missing historical versions without pretending that they were inferred."""
+
+    inferred = not tournament.get("engine_version") or not tournament.get("ruleset_version")
+    if not tournament.get("engine_version"):
+        tournament["engine_version"] = UNVERSIONED_ENGINE_VERSION
+    if not tournament.get("ruleset_version"):
+        tournament["ruleset_version"] = UNVERSIONED_RULESET_VERSION
+    tournament["version_inferred"] = inferred
+    return tournament
+
+
+async def persist_competition_versions(
+    db,
+    tournament: dict,
+    write_model: CompetitionWriteModel,
+) -> dict[str, str]:
+    """Pin the actual write model after a successful structure write."""
+
+    fields = competition_version_fields_for_write(tournament, write_model)
+    changes = {key: value for key, value in fields.items() if tournament.get(key) != value}
+    if changes:
+        await db.tournaments.update_one({"id": tournament["id"]}, {"$set": changes})
+        tournament.update(changes)
+    return fields

--- a/backend/tests/test_competition_formats_unit.py
+++ b/backend/tests/test_competition_formats_unit.py
@@ -36,24 +36,25 @@ def test_catalog_only_targets_known_stage_and_match_types():
 
 
 @pytest.mark.parametrize(
-    ("format_key", "initial_engine", "rebuild_engine", "stage_type", "match_type"),
+    ("format_key", "write_model", "initial_engine", "rebuild_engine", "stage_type", "match_type"),
     [
-        ("single_elim", "legacy", "stage", "single_elimination", "duel"),
-        ("double_elim", "legacy", "stage", "double_elimination", "duel"),
-        ("round_robin", "legacy", "legacy", "round_robin_groups", "duel"),
-        ("swiss", "none", "none", "swiss", "duel"),
-        ("groups", "none", "none", "round_robin_groups", "duel"),
-        ("ffa", "stage", "stage", "simple", "ffa"),
-        ("battle_royale", "stage", "stage", "simple", "ffa"),
-        ("league", "legacy", "legacy", "league", "duel"),
-        ("time_trial", "none", "none", "simple", "ffa"),
-        ("grand_prix", "none", "none", "ffa_league", "ffa"),
-        ("custom_bracket", "stage", "stage", "custom_bracket", "duel"),
-        ("ffa_custom_bracket", "stage", "stage", "ffa_custom_bracket", "ffa"),
+        ("single_elim", "classic", "legacy", "stage", "single_elimination", "duel"),
+        ("double_elim", "classic", "legacy", "stage", "double_elimination", "duel"),
+        ("round_robin", "classic", "legacy", "legacy", "round_robin_groups", "duel"),
+        ("swiss", "classic", "none", "none", "swiss", "duel"),
+        ("groups", "classic", "none", "none", "round_robin_groups", "duel"),
+        ("ffa", "graph", "stage", "stage", "simple", "ffa"),
+        ("battle_royale", "graph", "stage", "stage", "simple", "ffa"),
+        ("league", "classic", "legacy", "legacy", "league", "duel"),
+        ("time_trial", "external", "none", "none", "simple", "ffa"),
+        ("grand_prix", "external", "none", "none", "ffa_league", "ffa"),
+        ("custom_bracket", "graph", "stage", "stage", "custom_bracket", "duel"),
+        ("ffa_custom_bracket", "graph", "stage", "stage", "ffa_custom_bracket", "ffa"),
     ],
 )
 def test_catalog_records_current_routing_and_canonical_target(
     format_key,
+    write_model,
     initial_engine,
     rebuild_engine,
     stage_type,
@@ -61,6 +62,7 @@ def test_catalog_records_current_routing_and_canonical_target(
 ):
     entry = get_format_capability(format_key)
 
+    assert entry.current_write_model == write_model
     assert entry.initial_preview_engine == initial_engine
     assert entry.rebuild_engine == rebuild_engine
     assert entry.canonical_stage_type == stage_type

--- a/backend/tests/test_competition_versions_unit.py
+++ b/backend/tests/test_competition_versions_unit.py
@@ -1,0 +1,75 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from services.competition_versions import (
+    CURRENT_RULESET_VERSION,
+    ENGINE_VERSION_BY_WRITE_MODEL,
+    UNVERSIONED_ENGINE_VERSION,
+    UNVERSIONED_RULESET_VERSION,
+    apply_competition_version_read_defaults,
+    new_competition_version_fields,
+    persist_competition_versions,
+)
+
+
+def test_new_competitions_pin_the_catalog_write_model():
+    assert new_competition_version_fields("single_elim") == {
+        "engine_version": ENGINE_VERSION_BY_WRITE_MODEL["classic"],
+        "ruleset_version": CURRENT_RULESET_VERSION,
+    }
+    assert new_competition_version_fields("ffa_custom_bracket")["engine_version"] == (
+        ENGINE_VERSION_BY_WRITE_MODEL["graph"]
+    )
+    assert new_competition_version_fields("time_trial")["engine_version"] == (
+        ENGINE_VERSION_BY_WRITE_MODEL["external"]
+    )
+
+
+def test_historical_missing_versions_are_marked_unversioned_without_guessing():
+    tournament = {
+        "id": "historical",
+        "format": "single_elim",
+        "engine_version": None,
+        "ruleset_version": "",
+    }
+
+    assert apply_competition_version_read_defaults(tournament) == {
+        "id": "historical",
+        "format": "single_elim",
+        "engine_version": UNVERSIONED_ENGINE_VERSION,
+        "ruleset_version": UNVERSIONED_RULESET_VERSION,
+        "version_inferred": True,
+    }
+
+
+def test_explicit_versions_are_not_reported_as_inferred():
+    tournament = {
+        "engine_version": ENGINE_VERSION_BY_WRITE_MODEL["graph"],
+        "ruleset_version": CURRENT_RULESET_VERSION,
+    }
+
+    apply_competition_version_read_defaults(tournament)
+
+    assert tournament["version_inferred"] is False
+
+
+def test_successful_write_pins_actual_engine_and_preserves_ruleset_version():
+    update_one = AsyncMock()
+    db = SimpleNamespace(tournaments=SimpleNamespace(update_one=update_one))
+    tournament = {
+        "id": "t1",
+        "engine_version": ENGINE_VERSION_BY_WRITE_MODEL["classic"],
+        "ruleset_version": "competition.ruleset.custom-v7",
+    }
+
+    fields = asyncio.run(persist_competition_versions(db, tournament, "graph"))
+
+    assert fields == {
+        "engine_version": ENGINE_VERSION_BY_WRITE_MODEL["graph"],
+        "ruleset_version": "competition.ruleset.custom-v7",
+    }
+    update_one.assert_awaited_once_with(
+        {"id": "t1"},
+        {"$set": {"engine_version": ENGINE_VERSION_BY_WRITE_MODEL["graph"]}},
+    )

--- a/backend/tests/test_tournament_initial_preview_unit.py
+++ b/backend/tests/test_tournament_initial_preview_unit.py
@@ -72,6 +72,7 @@ class FakeCollection:
 
 class FakeDb:
     def __init__(self, registrations=None):
+        self.tournaments = FakeCollection([{"id": "t1"}])
         self.tournament_stages = FakeCollection()
         self.matches_v2 = FakeCollection()
         self.matches = FakeCollection()
@@ -151,6 +152,8 @@ def test_initial_preview_creates_stage_for_custom_bracket():
         assert len(db.tournament_stages.rows) == 1
         assert len(db.matches_v2.rows) == 3
         assert all(match["is_preview"] for match in db.matches_v2.rows)
+        assert db.tournaments.rows[0]["engine_version"] == "competition.graph.v1"
+        assert db.tournaments.rows[0]["ruleset_version"] == "competition.ruleset.v1"
 
     anyio.run(run)
 
@@ -256,6 +259,8 @@ def test_registration_refresh_replaces_legacy_preview_with_real_players():
         assert {"r1", "r2", "preview-seed-3", "preview-seed-4"} <= participant_ids
         assert "wait" not in participant_ids
         assert all(match["is_preview"] for match in db.matches.rows)
+        assert db.tournaments.rows[0]["engine_version"] == "competition.classic.v1"
+        assert db.tournaments.rows[0]["ruleset_version"] == "competition.ruleset.v1"
 
     anyio.run(run)
 

--- a/backend/tests/test_tournament_operations_unit.py
+++ b/backend/tests/test_tournament_operations_unit.py
@@ -362,10 +362,40 @@ def test_tournament_creation_replay_reuses_existing_document(monkeypatch):
 
     assert result["id"] == "t1"
     assert result["idempotent_replay"] is True
+    assert result["engine_version"] == "competition.unversioned"
+    assert result["ruleset_version"] == "competition.ruleset.unversioned"
+    assert result["version_inferred"] is True
     assert "creation_key" not in result
     games.find_one.assert_not_awaited()
     tournaments.insert_one.assert_not_awaited()
     preview.assert_not_awaited()
+
+
+def test_tournament_creation_persists_engine_and_ruleset_versions(monkeypatch):
+    tournaments = SimpleNamespace(
+        find_one=AsyncMock(return_value=None),
+        insert_one=AsyncMock(),
+    )
+    games = SimpleNamespace(find_one=AsyncMock(return_value={"id": "game-1"}))
+    db = SimpleNamespace(tournaments=tournaments, games=games)
+    preview = AsyncMock(return_value={"ok": True, "engine": "legacy"})
+
+    monkeypatch.setattr(tournament_routes, "get_db", lambda: db)
+    monkeypatch.setattr(tournament_routes, "mutation_lock", _uncontended_lock)
+    monkeypatch.setattr(tournament_routes, "_create_initial_bracket_preview", preview)
+
+    result = asyncio.run(tournament_routes.create_tournament(
+        TournamentCreate(title="Sommer-Cup", game_id="game-1", format="single_elim"),
+        {"id": "admin-1"},
+    ))
+
+    inserted = tournaments.insert_one.await_args.args[0]
+    assert inserted["engine_version"] == "competition.classic.v1"
+    assert inserted["ruleset_version"] == "competition.ruleset.v1"
+    assert result["engine_version"] == "competition.classic.v1"
+    assert result["ruleset_version"] == "competition.ruleset.v1"
+    assert result["version_inferred"] is False
+    preview.assert_awaited_once()
 
 
 def test_tournament_stage_creation_replay_reuses_existing_document(monkeypatch):
@@ -426,7 +456,10 @@ def _bracket_rebuild_db(*, tournament, legacy_matches=None, v2_matches=None,
         find=Mock(return_value=_Cursor(registrations or [])),
     )
     return SimpleNamespace(
-        tournaments=SimpleNamespace(find_one=AsyncMock(return_value=tournament)),
+        tournaments=SimpleNamespace(
+            find_one=AsyncMock(return_value=tournament),
+            update_one=AsyncMock(),
+        ),
         matches=matches,
         matches_v2=matches_v2,
         tournament_stages=stages,


### PR DESCRIPTION
## Was sich ändert

- ergänzt semantische Write-Modelle `classic`, `graph` und `external` im zentralen Capability-Katalog
- persistiert `engine_version` und `ruleset_version` bei neuen Turnieren
- pinnt nach erfolgreicher Classic-/Graph-Strukturerzeugung das tatsächlich verwendete Schreibmodell
- liefert für historische Datensätze ohne Version ausdrücklich `competition.unversioned` statt einer unsicheren Format-Inferenz
- ergänzt API-Felder, Indizes, Demo-Daten, Dokumentation und Versionsvertragstests
- ignoriert lokale `.pytest_tmp_*`-Verzeichnisse

## Warum

Package 3 aus #120 braucht vor Validator und Schreibtransaktionen eine belastbare Versionsgrenze. Das Format allein reicht zur Engine-Erkennung nicht aus, weil bestehende Single-/Double-Elimination-Turniere je nach Aufbau in unterschiedlichen Speichern liegen können.

## Sicherheit und Bestand

- keine Datenmigration und kein Backfill
- keine Neugenerierung bestehender Turniere
- keine Änderung von Match-IDs, Resultaten oder Schreibregeln
- Altbestand bleibt bewusst `unversioned`, bis ein separater Dry Run mit Hash/Diff und Rollback existiert

## Prüfung

- Versions-/Katalog-/Generator-Zieltests: 50 bestanden
- vollständige Backend-Suite vor finaler Nullwert-Härtung: 307 bestanden, 282 übersprungen
- betroffene Zieltests nach finaler Härtung erneut grün
- Backend-Kompilierung und `git diff --check`

Refs #120