### PR TITLE
Package 3: Validate canonical competition graphs

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -202,6 +202,27 @@ Historische Turniere ohne persistierte Angabe werden im Read-Vertrag bewusst als
 das Format allein darf die Engine nicht erraten. Eine persistierende
 Bestandszuordnung bleibt Teil des spaeteren Dry Runs mit Hash/Diff und Rollback.
 
+## Kanonischer Graphvalidator v1
+
+`backend/services/competition_graph_validation.py` validiert ausschliesslich den
+kanonischen Read-Vertrag und schreibt oder repariert keine Quelldaten. Der
+maschinenlesbare Bericht `competition.graph-validation.v1` enthaelt stabile
+Fehlercodes, Counts und Kontext fuer Preview, Shadow Read und Migrations-Dry-Run.
+
+Geprueft werden Match- und Slot-IDs, beide Seiten jeder
+Slot-Quelle/Advancement-Kante, fehlende Ziele und Quellen, Zyklen, unerreichbare
+Matches, doppelte Slot- oder Teilnehmerbelegung sowie Resultat-, Quell- und
+Advancement-Raenge. Mehrere unabhaengige Entry-Matches bleiben erlaubt, damit
+Round Robin, Liga, Gruppen und mehrere Bracket-Wurzeln keine falschen Fehler
+erzeugen. Als unerreichbar gilt nur ein Match, dessen deklarierte
+Match-Result-Abhaengigkeiten nicht bis zu einem Entry-Match aufgeloest werden
+koennen.
+
+Der bestehende `structure_snapshot_issues`-Adapter liefert dieselben Issues fuer
+Read-Metriken und Kompatibilitaet. Der Validator ist noch keine Schreibfreigabe:
+die folgende Preview/Validate/Apply-Transaktion muss einen fehlerfreien Report
+verlangen und ihre Schreibwirkung separat absichern.
+
 ## Abnahmematrix
 
 - Teilnehmerzahlen 0/1 sowie 3/5/63/64/65 und grosse Strukturen;

--- a/backend/services/competition_graph_validation.py
+++ b/backend/services/competition_graph_validation.py
@@ -1,0 +1,339 @@
+"""Pure validation for the canonical competition structure graph.
+
+The validator deliberately operates on ``competition.structure.v1`` snapshots.
+It neither repairs source documents nor decides which collection should win.
+That makes it safe for previews, shadow reads, and migration dry runs.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict, deque
+from typing import Any
+
+
+GRAPH_VALIDATION_VERSION = "competition.graph-validation.v1"
+MATCH_RESULT_SOURCE = "match_result"
+VALID_ADVANCEMENT_OUTCOMES = {"winner", "loser", "rank"}
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        return int(value) if value.is_integer() and value > 0 else None
+    try:
+        normalized = str(value).strip()
+        if not normalized or not normalized.isdigit():
+            return None
+        parsed = int(normalized)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _issue_sort_key(issue: dict) -> tuple:
+    return (
+        issue.get("severity") or "",
+        issue.get("code") or "",
+        str(issue.get("match_id") or ""),
+        str(issue.get("target_id") or ""),
+        _positive_int(issue.get("position")) or 0,
+        str(issue.get("registration_id") or ""),
+    )
+
+
+def validate_competition_graph(snapshot: dict) -> dict:
+    """Return a deterministic validation report for a canonical snapshot.
+
+    Multiple independent entry matches are valid. A match is unreachable only
+    when its declared match-result dependencies cannot be traced back to an
+    entry match (for example because of a missing source or a closed cycle).
+    """
+
+    issues: list[dict] = []
+
+    def add_issue(code: str, *, severity: str = "error", **context: Any) -> None:
+        issues.append({"severity": severity, "code": code, **context})
+
+    matches = snapshot.get("matches") or []
+    by_id: dict[str, dict] = {}
+    for match in matches:
+        match_id = match.get("id")
+        if not match_id:
+            add_issue("missing_match_id")
+            continue
+        if match_id in by_id:
+            add_issue("duplicate_match_id", match_id=match_id)
+            continue
+        by_id[match_id] = match
+
+    slots_by_match: dict[str, dict[int, dict]] = {}
+    declared_dependencies: dict[str, set[str]] = defaultdict(set)
+    missing_dependencies: set[str] = set()
+
+    for match_id, match in by_id.items():
+        slots = match.get("slots") or []
+        slot_positions: dict[int, dict] = {}
+        registrations: Counter[str] = Counter()
+        for slot in slots:
+            position = _positive_int(slot.get("position"))
+            if position is None:
+                add_issue(
+                    "invalid_slot_position",
+                    match_id=match_id,
+                    position=slot.get("position"),
+                )
+            elif position in slot_positions:
+                add_issue("duplicate_slot_position", match_id=match_id, position=position)
+            else:
+                slot_positions[position] = slot
+
+            registration_id = slot.get("registration_id")
+            if registration_id:
+                registrations[str(registration_id)] += 1
+
+            source = slot.get("source") or {}
+            if source.get("type") != MATCH_RESULT_SOURCE:
+                continue
+            source_id = source.get("match_id")
+            if not source_id or source_id not in by_id:
+                add_issue(
+                    "missing_slot_source_match",
+                    match_id=match_id,
+                    position=position,
+                    source_match_id=source_id,
+                )
+                missing_dependencies.add(match_id)
+                continue
+            declared_dependencies[match_id].add(source_id)
+            source_rank = _positive_int(source.get("rank"))
+            source_slot_count = len(by_id[source_id].get("slots") or [])
+            if (
+                source_rank is None
+                or source_slot_count == 0
+                or source_rank > source_slot_count
+            ):
+                add_issue(
+                    "invalid_slot_source_rank",
+                    match_id=match_id,
+                    position=position,
+                    source_match_id=source_id,
+                    rank=source.get("rank"),
+                    max_rank=source_slot_count,
+                )
+            if source.get("outcome") not in VALID_ADVANCEMENT_OUTCOMES:
+                add_issue(
+                    "invalid_slot_source_outcome",
+                    match_id=match_id,
+                    position=position,
+                    source_match_id=source_id,
+                    outcome=source.get("outcome"),
+                )
+
+        slots_by_match[match_id] = slot_positions
+        for registration_id, count in registrations.items():
+            if count > 1:
+                add_issue(
+                    "duplicate_match_participant",
+                    match_id=match_id,
+                    registration_id=registration_id,
+                    count=count,
+                )
+
+        result_registrations: Counter[str] = Counter()
+        result_rank_limit = max(len(slots), len(match.get("results") or []))
+        for result in match.get("results") or []:
+            registration_id = result.get("registration_id")
+            if registration_id:
+                result_registrations[str(registration_id)] += 1
+            rank = _positive_int(result.get("rank"))
+            if rank is None or (result_rank_limit and rank > result_rank_limit):
+                add_issue(
+                    "invalid_result_rank",
+                    match_id=match_id,
+                    registration_id=registration_id,
+                    rank=result.get("rank"),
+                    max_rank=result_rank_limit,
+                )
+        for registration_id, count in result_registrations.items():
+            if count > 1:
+                add_issue(
+                    "duplicate_result_participant",
+                    match_id=match_id,
+                    registration_id=registration_id,
+                    count=count,
+                )
+
+    graph: dict[str, set[str]] = {match_id: set() for match_id in by_id}
+    incoming_edges: dict[tuple[str, int], list[dict]] = defaultdict(list)
+    for source_id, match in by_id.items():
+        source_slot_count = len(match.get("slots") or [])
+        for edge in match.get("advancement") or []:
+            target_id = edge.get("to_match_id")
+            position = _positive_int(edge.get("to_position"))
+            rank = _positive_int(edge.get("rank"))
+            if rank is None or source_slot_count == 0 or rank > source_slot_count:
+                add_issue(
+                    "invalid_advancement_rank",
+                    match_id=source_id,
+                    target_id=target_id,
+                    rank=edge.get("rank"),
+                    max_rank=source_slot_count,
+                )
+            if edge.get("outcome") not in VALID_ADVANCEMENT_OUTCOMES:
+                add_issue(
+                    "invalid_advancement_outcome",
+                    match_id=source_id,
+                    target_id=target_id,
+                    outcome=edge.get("outcome"),
+                )
+            if not target_id or target_id not in by_id:
+                add_issue(
+                    "missing_advancement_target",
+                    match_id=source_id,
+                    target_id=target_id,
+                )
+                continue
+            graph[source_id].add(target_id)
+            declared_dependencies[target_id].add(source_id)
+            if position is None or position not in slots_by_match.get(target_id, {}):
+                add_issue(
+                    "missing_target_slot",
+                    match_id=source_id,
+                    target_id=target_id,
+                    position=edge.get("to_position"),
+                )
+                continue
+            incoming_edges[(target_id, position)].append({
+                "source_id": source_id,
+                "outcome": edge.get("outcome"),
+                "rank": rank,
+            })
+
+    for (target_id, position), edges in incoming_edges.items():
+        if len(edges) > 1:
+            add_issue(
+                "duplicate_target_slot_source",
+                target_id=target_id,
+                position=position,
+                source_match_ids=sorted(str(edge["source_id"]) for edge in edges),
+            )
+        slot_source = (slots_by_match[target_id][position].get("source") or {})
+        if slot_source.get("type") != MATCH_RESULT_SOURCE:
+            add_issue("missing_target_slot_source", target_id=target_id, position=position)
+            continue
+        expected_source_id = slot_source.get("match_id")
+        expected_rank = _positive_int(slot_source.get("rank"))
+        expected_outcome = slot_source.get("outcome")
+        if not any(edge["source_id"] == expected_source_id for edge in edges):
+            add_issue(
+                "target_slot_source_mismatch",
+                target_id=target_id,
+                position=position,
+                source_match_id=expected_source_id,
+            )
+        elif not any(
+            edge["source_id"] == expected_source_id
+            and edge["rank"] == expected_rank
+            and edge["outcome"] == expected_outcome
+            for edge in edges
+        ):
+            add_issue(
+                "target_slot_contract_mismatch",
+                target_id=target_id,
+                position=position,
+                source_match_id=expected_source_id,
+            )
+
+    for target_id, slots in slots_by_match.items():
+        for position, slot in slots.items():
+            source = slot.get("source") or {}
+            if source.get("type") != MATCH_RESULT_SOURCE:
+                continue
+            source_id = source.get("match_id")
+            if source_id in by_id and not any(
+                edge["source_id"] == source_id
+                for edge in incoming_edges.get((target_id, position), [])
+            ):
+                add_issue(
+                    "missing_source_advancement",
+                    match_id=target_id,
+                    position=position,
+                    source_match_id=source_id,
+                )
+
+    # Slot declarations are dependencies too, even if the mirrored advancement
+    # edge is damaged. Including both views catches cycles before apply.
+    dependency_graph: dict[str, set[str]] = {
+        match_id: set(targets) for match_id, targets in graph.items()
+    }
+    for target_id, source_ids in declared_dependencies.items():
+        for source_id in source_ids:
+            if source_id in by_id:
+                dependency_graph.setdefault(source_id, set()).add(target_id)
+
+    # Kahn's algorithm avoids recursion limits for large custom brackets. Any
+    # nodes left after all zero-indegree nodes are removed contain or depend on
+    # a cycle, which is sufficient to reject the graph before apply.
+    indegree = {match_id: 0 for match_id in by_id}
+    for targets in dependency_graph.values():
+        for target_id in targets:
+            indegree[target_id] += 1
+    ready = deque(match_id for match_id, count in indegree.items() if count == 0)
+    acyclic_nodes: set[str] = set()
+    while ready:
+        match_id = ready.popleft()
+        acyclic_nodes.add(match_id)
+        for target_id in dependency_graph.get(match_id, set()):
+            indegree[target_id] -= 1
+            if indegree[target_id] == 0:
+                ready.append(target_id)
+    cycle_blocked_nodes = sorted(set(by_id) - acyclic_nodes)
+    if cycle_blocked_nodes:
+        add_issue("advancement_cycle", match_ids=cycle_blocked_nodes)
+
+    remaining_dependencies = {
+        match_id: len(declared_dependencies.get(match_id, set()))
+        for match_id in by_id
+    }
+    dependents: dict[str, set[str]] = defaultdict(set)
+    for target_id, source_ids in declared_dependencies.items():
+        for source_id in source_ids:
+            dependents[source_id].add(target_id)
+    entry_matches = deque(
+        match_id
+        for match_id, count in remaining_dependencies.items()
+        if count == 0 and match_id not in missing_dependencies
+    )
+    reachable: set[str] = set()
+    while entry_matches:
+        match_id = entry_matches.popleft()
+        if match_id in reachable:
+            continue
+        reachable.add(match_id)
+        for target_id in dependents.get(match_id, set()):
+            remaining_dependencies[target_id] -= 1
+            if (
+                remaining_dependencies[target_id] == 0
+                and target_id not in missing_dependencies
+            ):
+                entry_matches.append(target_id)
+    for match_id in sorted(set(by_id) - reachable):
+        add_issue("unreachable_match", match_id=match_id)
+
+    issues.sort(key=_issue_sort_key)
+    severity_counts = Counter(issue["severity"] for issue in issues)
+    issue_counts = Counter(issue["code"] for issue in issues)
+    return {
+        "validation_version": GRAPH_VALIDATION_VERSION,
+        "valid": severity_counts.get("error", 0) == 0,
+        "match_count": len(matches),
+        "validated_match_count": len(by_id),
+        "issue_count": len(issues),
+        "error_count": severity_counts.get("error", 0),
+        "warning_count": severity_counts.get("warning", 0),
+        "issue_counts": dict(sorted(issue_counts.items())),
+        "issues": issues,
+    }

--- a/backend/services/competition_snapshot.py
+++ b/backend/services/competition_snapshot.py
@@ -11,6 +11,8 @@ from collections import Counter
 from copy import deepcopy
 from typing import Iterable
 
+from services.competition_graph_validation import validate_competition_graph
+
 
 STRUCTURE_SNAPSHOT_VERSION = "competition.structure.v1"
 
@@ -30,6 +32,11 @@ def _slot_position(value) -> int | None:
     if normalized in {"b", "2"}:
         return 2
     return _positive_int(normalized)
+
+
+def _stage_outcome(value) -> str:
+    flow = str(value or "R").strip().upper()
+    return {"W": "winner", "L": "loser", "R": "rank"}.get(flow, flow.lower())
 
 
 def _legacy_advancement(match: dict) -> list[dict]:
@@ -54,11 +61,9 @@ def _legacy_advancement(match: dict) -> list[dict]:
 def _stage_advancement(match: dict) -> list[dict]:
     edges: list[dict] = []
     for edge in match.get("advancement") or []:
-        flow = str(edge.get("flow") or "R").upper()
-        outcome = {"W": "winner", "L": "loser", "R": "rank"}.get(flow, "rank")
         edges.append({
-            "outcome": outcome,
-            "rank": _positive_int(edge.get("rank"), 1),
+            "outcome": _stage_outcome(edge.get("flow")),
+            "rank": 1 if edge.get("rank") in (None, "") else edge.get("rank"),
             "to_match_id": edge.get("to_match_id"),
             "to_match_key": edge.get("to_match_key"),
             "to_position": _slot_position(edge.get("to_slot")),
@@ -209,15 +214,14 @@ def _stage_source(source: dict, match_ids_by_key: dict[tuple[str | None, str], s
     if source_type == "bye":
         return {"type": "bye"}
     if source_type == "rank":
-        flow = str(source.get("flow") or "R").upper()
         match_key = source.get("match_key")
         stage_id = source.get("stage_id")
         return {
             "type": "match_result",
             "match_id": source.get("match_id") or match_ids_by_key.get((stage_id, match_key)),
             "match_key": match_key,
-            "outcome": {"W": "winner", "L": "loser", "R": "rank"}.get(flow, "rank"),
-            "rank": _positive_int(source.get("rank"), 1),
+            "outcome": _stage_outcome(source.get("flow")),
+            "rank": 1 if source.get("rank") in (None, "") else source.get("rank"),
         }
     return deepcopy(source) if source else {"type": "unassigned"}
 
@@ -422,70 +426,9 @@ def compare_structure_snapshots(reference: dict, candidate: dict) -> dict:
 
 
 def structure_snapshot_issues(snapshot: dict) -> list[dict]:
-    """Validate read-side graph references without changing source data."""
+    """Return canonical graph issues without changing source data."""
 
-    issues: list[dict] = []
-    matches = snapshot.get("matches") or []
-    by_id: dict[str, dict] = {}
-    for match in matches:
-        match_id = match.get("id")
-        if not match_id:
-            issues.append({"code": "missing_match_id"})
-            continue
-        if match_id in by_id:
-            issues.append({"code": "duplicate_match_id", "match_id": match_id})
-            continue
-        by_id[match_id] = match
-
-    graph: dict[str, set[str]] = {match_id: set() for match_id in by_id}
-    incoming_slots: set[tuple[str, int]] = set()
-    for source_id, match in by_id.items():
-        for edge in match.get("advancement") or []:
-            target_id = edge.get("to_match_id")
-            position = edge.get("to_position")
-            if not target_id or target_id not in by_id:
-                issues.append({
-                    "code": "missing_advancement_target",
-                    "match_id": source_id,
-                    "target_id": target_id,
-                })
-                continue
-            valid_positions = {slot.get("position") for slot in by_id[target_id].get("slots") or []}
-            if position not in valid_positions:
-                issues.append({
-                    "code": "missing_target_slot",
-                    "match_id": source_id,
-                    "target_id": target_id,
-                    "position": position,
-                })
-                continue
-            slot_key = (target_id, position)
-            if slot_key in incoming_slots:
-                issues.append({
-                    "code": "duplicate_target_slot_source",
-                    "target_id": target_id,
-                    "position": position,
-                })
-            incoming_slots.add(slot_key)
-            graph[source_id].add(target_id)
-
-    visiting: set[str] = set()
-    visited: set[str] = set()
-
-    def visit(match_id: str) -> bool:
-        if match_id in visiting:
-            return True
-        if match_id in visited:
-            return False
-        visiting.add(match_id)
-        has_cycle = any(visit(target_id) for target_id in graph.get(match_id, set()))
-        visiting.remove(match_id)
-        visited.add(match_id)
-        return has_cycle
-
-    if any(visit(match_id) for match_id in graph if match_id not in visited):
-        issues.append({"code": "advancement_cycle"})
-    return issues
+    return validate_competition_graph(snapshot)["issues"]
 
 
 def structure_snapshot_metrics(snapshot: dict) -> dict:

--- a/backend/tests/test_competition_graph_validation_unit.py
+++ b/backend/tests/test_competition_graph_validation_unit.py
@@ -1,0 +1,261 @@
+from services.competition_graph_validation import (
+    GRAPH_VALIDATION_VERSION,
+    validate_competition_graph,
+)
+from services.competition_snapshot import adapt_stage_matches
+from services.custom_bracket import build_matches_v2_from_schema
+
+
+def _direct_match(match_id: str, registrations: tuple[str, str]) -> dict:
+    return {
+        "id": match_id,
+        "slots": [
+            {
+                "position": position,
+                "registration_id": registration_id,
+                "source": {"type": "direct"},
+            }
+            for position, registration_id in enumerate(registrations, start=1)
+        ],
+        "results": [],
+        "advancement": [],
+    }
+
+
+def _result_slot(position: int, source_id: str, outcome: str = "winner", rank=1) -> dict:
+    return {
+        "position": position,
+        "registration_id": None,
+        "source": {
+            "type": "match_result",
+            "match_id": source_id,
+            "outcome": outcome,
+            "rank": rank,
+        },
+    }
+
+
+def _edge(target_id: str, position: int, outcome: str = "winner", rank=1) -> dict:
+    return {
+        "outcome": outcome,
+        "rank": rank,
+        "to_match_id": target_id,
+        "to_position": position,
+    }
+
+
+def _codes(report: dict) -> set[str]:
+    return {issue["code"] for issue in report["issues"]}
+
+
+def test_validator_accepts_multiple_roots_and_independent_matches():
+    first = _direct_match("a", ("r1", "r2"))
+    second = _direct_match("b", ("r3", "r4"))
+    final = {
+        "id": "final",
+        "slots": [_result_slot(1, "a"), _result_slot(2, "b")],
+        "results": [],
+        "advancement": [],
+    }
+    first["advancement"] = [_edge("final", 1)]
+    second["advancement"] = [_edge("final", 2)]
+    independent = _direct_match("round-robin-game", ("r1", "r3"))
+
+    report = validate_competition_graph({"matches": [first, second, final, independent]})
+
+    assert report == {
+        "validation_version": GRAPH_VALIDATION_VERSION,
+        "valid": True,
+        "match_count": 4,
+        "validated_match_count": 4,
+        "issue_count": 0,
+        "error_count": 0,
+        "warning_count": 0,
+        "issue_counts": {},
+        "issues": [],
+    }
+
+
+def test_validator_reports_missing_source_and_unreachable_match():
+    target = {
+        "id": "target",
+        "slots": [_result_slot(1, "missing"), {"position": 2, "source": {"type": "bye"}}],
+        "results": [],
+        "advancement": [],
+    }
+
+    report = validate_competition_graph({"matches": [target]})
+
+    assert report["valid"] is False
+    assert {"missing_slot_source_match", "unreachable_match"} <= _codes(report)
+
+
+def test_validator_checks_both_sides_of_slot_advancement_contract():
+    source = _direct_match("source", ("r1", "r2"))
+    target = {
+        "id": "target",
+        "slots": [_result_slot(1, "source", outcome="winner", rank=2)],
+        "results": [],
+        "advancement": [],
+    }
+    source["advancement"] = [_edge("target", 1, outcome="winner", rank=1)]
+
+    report = validate_competition_graph({"matches": [source, target]})
+
+    assert "target_slot_contract_mismatch" in _codes(report)
+
+    source["advancement"] = []
+    report_without_edge = validate_competition_graph({"matches": [source, target]})
+    assert "missing_source_advancement" in _codes(report_without_edge)
+
+
+def test_validator_reports_cycles_and_unreachable_cycle_members():
+    first = {
+        "id": "a",
+        "slots": [_result_slot(1, "b")],
+        "results": [],
+        "advancement": [_edge("b", 1)],
+    }
+    second = {
+        "id": "b",
+        "slots": [_result_slot(1, "a")],
+        "results": [],
+        "advancement": [_edge("a", 1)],
+    }
+
+    report = validate_competition_graph({"matches": [first, second]})
+
+    assert "advancement_cycle" in _codes(report)
+    unreachable = {
+        issue["match_id"]
+        for issue in report["issues"]
+        if issue["code"] == "unreachable_match"
+    }
+    assert unreachable == {"a", "b"}
+
+
+def test_validator_reports_duplicate_slots_participants_results_and_incoming_edges():
+    first = _direct_match("a", ("same", "same"))
+    first["results"] = [
+        {"registration_id": "same", "rank": 1},
+        {"registration_id": "same", "rank": 2},
+    ]
+    second = _direct_match("b", ("r3", "r4"))
+    target = {
+        "id": "target",
+        "slots": [
+            _result_slot(1, "a"),
+            {"position": 1, "source": {"type": "bye"}},
+        ],
+        "results": [],
+        "advancement": [],
+    }
+    first["advancement"] = [_edge("target", 1)]
+    second["advancement"] = [_edge("target", 1)]
+
+    report = validate_competition_graph({"matches": [first, second, target]})
+
+    assert {
+        "duplicate_slot_position",
+        "duplicate_match_participant",
+        "duplicate_result_participant",
+        "duplicate_target_slot_source",
+    } <= _codes(report)
+
+
+def test_validator_reports_invalid_result_advancement_and_source_ranks():
+    source = _direct_match("source", ("r1", "r2"))
+    source["results"] = [{"registration_id": "r1", "rank": 3}]
+    source["advancement"] = [_edge("target", 1, rank=3)]
+    target = {
+        "id": "target",
+        "slots": [_result_slot(1, "source", rank=3)],
+        "results": [],
+        "advancement": [],
+    }
+
+    report = validate_competition_graph({"matches": [source, target]})
+
+    assert {
+        "invalid_result_rank",
+        "invalid_advancement_rank",
+        "invalid_slot_source_rank",
+    } <= _codes(report)
+
+
+def test_validator_reports_edge_without_matching_target_slot_source():
+    source = _direct_match("source", ("r1", "r2"))
+    source["advancement"] = [_edge("target", 1)]
+    target = {
+        "id": "target",
+        "slots": [{"position": 1, "source": {"type": "unassigned"}}],
+        "results": [],
+        "advancement": [],
+    }
+
+    report = validate_competition_graph({"matches": [source, target]})
+
+    assert "missing_target_slot_source" in _codes(report)
+
+
+def test_validator_handles_large_graph_without_recursive_traversal():
+    match_count = 1500
+    matches = []
+    for index in range(match_count):
+        match_id = f"m-{index}"
+        match = {
+            "id": match_id,
+            "slots": (
+                [{"position": 1, "source": {"type": "direct"}}]
+                if index == 0
+                else [_result_slot(1, f"m-{index - 1}")]
+            ),
+            "results": [],
+            "advancement": [],
+        }
+        if index:
+            matches[index - 1]["advancement"] = [_edge(match_id, 1)]
+        matches.append(match)
+
+    report = validate_competition_graph({"matches": matches})
+
+    assert report["valid"] is True
+    assert report["validated_match_count"] == match_count
+
+
+def test_validator_accepts_current_single_double_and_ffa_generators():
+    registrations = [
+        {"id": f"r{index}", "user_id": f"u{index}", "status": "approved", "seed": index}
+        for index in range(1, 9)
+    ]
+    cases = [
+        (
+            {"id": "single", "format": "single_elim", "seeding_mode": "manual", "max_participants": 8},
+            {"id": "single-stage", "number": 1, "stage_type": "single_elimination", "match_type": "duel", "settings": {}},
+        ),
+        (
+            {"id": "double", "format": "double_elim", "seeding_mode": "manual", "max_participants": 8},
+            {"id": "double-stage", "number": 1, "stage_type": "double_elimination", "match_type": "duel", "settings": {}},
+        ),
+        (
+            {"id": "ffa", "format": "ffa_custom_bracket", "seeding_mode": "manual", "max_participants": 8},
+            {
+                "id": "ffa-stage",
+                "number": 1,
+                "stage_type": "ffa_custom_bracket",
+                "match_type": "ffa",
+                "settings": {"match_size": 4, "qualifiers_per_match": 2},
+            },
+        ),
+    ]
+
+    for tournament, stage in cases:
+        generated = build_matches_v2_from_schema(
+            tournament,
+            stage,
+            registrations,
+            preview=True,
+        )
+        report = validate_competition_graph({"matches": adapt_stage_matches(generated)})
+
+        assert report["valid"] is True, (stage["stage_type"], report)

--- a/backend/tests/test_competition_snapshot_unit.py
+++ b/backend/tests/test_competition_snapshot_unit.py
@@ -171,6 +171,21 @@ def test_stage_adapter_resolves_match_key_sources_to_stable_match_ids():
     assert final["slots"][0]["source"]["outcome"] == "winner"
 
 
+def test_stage_adapter_preserves_invalid_explicit_ranks_for_validation():
+    source = _stage_fixture()
+    source[0]["advancement"][0]["rank"] = 0
+    source[0]["advancement"][0]["flow"] = "invalid-flow"
+    source[2]["slots"][0]["source"]["rank"] = 0
+    source[2]["slots"][0]["source"]["flow"] = "invalid-flow"
+
+    adapted = adapt_stage_matches(source)
+
+    assert adapted[0]["advancement"][0]["rank"] == 0
+    assert adapted[0]["advancement"][0]["outcome"] == "invalid-flow"
+    assert adapted[2]["slots"][0]["source"]["rank"] == 0
+    assert adapted[2]["slots"][0]["source"]["outcome"] == "invalid-flow"
+
+
 def test_adapter_tolerates_unset_scores_and_non_numeric_sort_fields():
     legacy = adapt_legacy_matches([{
         "id": "m-void",


### PR DESCRIPTION
## Was sich ändert

- ergänzt den reinen, versionierten Validator `competition.graph-validation.v1` für `competition.structure.v1`
- prüft fehlende Match-/Slot-Quellen und Ziele sowie beide Seiten der Slot↔Advancement-Beziehung
- erkennt Zyklen, unerreichbare Matches, doppelte Slot-/Teilnehmer-/Resultatbelegung und ungültige Ränge/Outcomes
- lässt legitime Mehrfach-Wurzeln und unabhängige Round-Robin-/Liga-Matches zu
- verwendet iterative O(V+E)-Traversierung statt Rekursion, geprüft mit einer 1.500-Match-Kette
- bindet die bestehenden Read-Integritätsmetriken kompatibel an den neuen Validator an
- bewahrt explizit ungültige Stage-Ränge/Flows im Adapter, damit Korruption nicht still auf gültige Defaults normalisiert wird

## Sicherheit und Bestand

- read-only: keine Reparatur, Migration oder Datenbank-Schreiboperation
- keine Änderung von Match-IDs, Resultaten oder Generatoren
- kein Cutover und kein neues paralleles Bracket-System
- vorbereitet für den nächsten Schritt Preview → Validate → Apply

## Prüfung

- vollständige Backend-Suite: 317 bestanden, 282 übersprungen
- Single-, Double- und FFA-Generatoren durch den kanonischen Validator geprüft
- 1.500-Match-Lastfall ohne rekursive Traversierung
- Compile- und Whitespace-Check grün

Refs #120