### PR TITLE
Package 3: Add deterministic structure planning

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -223,6 +223,26 @@ Read-Metriken und Kompatibilitaet. Der Validator ist noch keine Schreibfreigabe:
 die folgende Preview/Validate/Apply-Transaktion muss einen fehlerfreien Report
 verlangen und ihre Schreibwirkung separat absichern.
 
+## Nicht-destruktiver Strukturplan v1
+
+`POST /api/tournaments/{id}/bracket/plan` erzeugt fuer berechtigte
+Turniermitarbeiter eine Classic- oder Graph-Struktur, ohne Matches, Stages,
+Versionen oder Auditdaten zu schreiben. Die Antwort enthaelt die geplante
+kanonische Struktur, den vollstaendigen Graphvalidierungsbericht, den sichtbaren
+Ersetzungsumfang und die Apply-Anforderungen.
+
+`competition.structure-plan.v1` bindet den Plan mit SHA-256 an den aktuellen
+kanonischen Strukturzustand, die relevanten Turnierregeln, die Request-Settings
+und den Teilnehmer-Snapshot. Zufallsseeding verwendet einen lokalen,
+plan-gebundenen Zufallsgenerator; Stage- und Match-IDs werden per UUIDv5 aus dem
+Plan abgeleitet. Derselbe Input auf demselben Basiszustand erzeugt deshalb
+denselben `plan_hash`, dieselben Teilnehmerpositionen und dieselben IDs.
+
+Der Plan ist noch kein Apply: Der folgende Schreibschritt muss
+`expected_plan_hash` und `expected_base_structure_hash` zwingend pruefen,
+zwischenzeitliche Aenderungen mit `409` ablehnen und erst danach den bereits
+validierten Dokumentensatz kontrolliert aktivieren.
+
 ## Abnahmematrix
 
 - Teilnehmerzahlen 0/1 sowie 3/5/63/64/65 und grosse Strukturen;

--- a/backend/bracket_engine.py
+++ b/backend/bracket_engine.py
@@ -5,12 +5,13 @@ from typing import List, Dict, Any, Optional
 from models import new_id, now_utc
 
 
-def _participant_list(registrations: List[dict], seeding_mode: str = "random") -> List[dict]:
+def _participant_list(registrations: List[dict], seeding_mode: str = "random",
+                      rng: random.Random | None = None) -> List[dict]:
     regs = [r for r in registrations if r.get("status") in ("approved", "checked_in")]
     if seeding_mode == "manual":
         regs.sort(key=lambda r: r.get("seed") or 99999)
     elif seeding_mode == "random":
-        random.shuffle(regs)
+        (rng or random).shuffle(regs)
     # ranking mode uses pre-set seed from admin (already handled)
     return regs
 
@@ -73,8 +74,9 @@ def _make_match(tournament_id: str, round_num: int, round_name: str, bracket: st
 def generate_single_elimination(tournament_id: str, registrations: List[dict],
                                  best_of: int = 1, bronze_match: bool = False,
                                  seeding_mode: str = "random",
-                                 duration_minutes: Optional[int] = None) -> List[dict]:
-    regs = _participant_list(registrations, seeding_mode)
+                                 duration_minutes: Optional[int] = None,
+                                 rng: random.Random | None = None) -> List[dict]:
+    regs = _participant_list(registrations, seeding_mode, rng)
     n = len(regs)
     if n < 2:
         return []
@@ -189,16 +191,17 @@ def _propagate_winner(match: dict, round_matches: List[List[dict]]):
 
 def generate_double_elimination(tournament_id: str, registrations: List[dict],
                                  best_of: int = 1, seeding_mode: str = "random",
-                                 duration_minutes: Optional[int] = None) -> List[dict]:
+                                 duration_minutes: Optional[int] = None,
+                                 rng: random.Random | None = None) -> List[dict]:
     """Simplified double elim: generate WB as single elim, LB and Grand Final as 'pending'."""
-    regs = _participant_list(registrations, seeding_mode)
+    regs = _participant_list(registrations, seeding_mode, rng)
     n = len(regs)
     if n < 2:
         return []
     # Winner Bracket
     wb = generate_single_elimination(tournament_id, registrations, best_of=best_of,
                                       bronze_match=False, seeding_mode=seeding_mode,
-                                      duration_minutes=duration_minutes)
+                                      duration_minutes=duration_minutes, rng=rng)
     for m in wb:
         m["bracket"] = "winner"
     bracket_size = _next_power_of_two(n)
@@ -282,7 +285,8 @@ def generate_round_robin(tournament_id: str, registrations: List[dict],
     return matches
 
 
-def generate_bracket(tournament: dict, registrations: List[dict], preview: bool = False) -> List[dict]:
+def generate_bracket(tournament: dict, registrations: List[dict], preview: bool = False,
+                     rng: random.Random | None = None) -> List[dict]:
     fmt = tournament.get("format", "single_elim")
     best_of = tournament.get("best_of", 1)
     bronze = tournament.get("bronze_match", False)
@@ -290,9 +294,13 @@ def generate_bracket(tournament: dict, registrations: List[dict], preview: bool 
     duration_minutes = tournament.get("match_duration_minutes") or 30
     tid = tournament["id"]
     if fmt == "single_elim":
-        matches = generate_single_elimination(tid, registrations, best_of, bronze, seeding, duration_minutes)
+        matches = generate_single_elimination(
+            tid, registrations, best_of, bronze, seeding, duration_minutes, rng,
+        )
     elif fmt == "double_elim":
-        matches = generate_double_elimination(tid, registrations, best_of, seeding, duration_minutes)
+        matches = generate_double_elimination(
+            tid, registrations, best_of, seeding, duration_minutes, rng,
+        )
     elif fmt == "round_robin":
         matches = generate_round_robin(tid, registrations, best_of, False, duration_minutes)
     elif fmt == "league":

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -3,6 +3,7 @@ import csv
 import hashlib
 import io
 import json
+import random
 import re
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import RedirectResponse, StreamingResponse
@@ -31,8 +32,19 @@ from services.tournament_permissions import (
 )
 from services.custom_bracket import BracketSchemaError, build_matches_v2_from_schema
 from services.competition_formats import find_format_capability
+from services.competition_graph_validation import validate_competition_graph
 from services.competition_read import load_competition_read_model, observe_structure_read
+from services.competition_snapshot import build_structure_snapshot
 from services.competition_standings import placement_rows_for_structure, standings_for_structure
+from services.competition_structure_plan import (
+    STRUCTURE_PLAN_VERSION,
+    deterministic_structure_id,
+    ordered_plan_registrations,
+    stabilize_legacy_plan_matches,
+    stabilize_stage_plan_matches,
+    structure_plan_hash,
+    structure_plan_seed,
+)
 from services.competition_versions import (
     apply_competition_version_read_defaults,
     new_competition_version_fields,
@@ -63,6 +75,7 @@ STAFF_ROLES = {"moderator", "tournament_admin", "club_admin", "superadmin"}
 REGISTRATION_CHECKIN_STATUSES = {"approved", "checked_in", "no_show"}
 MENTION_RE = re.compile(r"@([A-Za-z0-9_.-]{2,32})")
 MAX_INITIAL_PREVIEW_MATCHES = 512
+MAX_STRUCTURE_PLAN_MATCHES = 5000
 BRACKET_REFRESH_LOCKED_STATUSES = {"check_in", "live", "paused", "completed", "results_published", "archived", "cancelled"}
 TOURNAMENT_MUTATION_LOCKED_DETAIL = "Turnier ist gesperrt und kann nur noch angesehen oder geloescht werden."
 LOCKABLE_TOURNAMENT_STATUSES = {"completed", "results_published", "archived", "cancelled"}
@@ -127,6 +140,10 @@ class TournamentBracketStructurePayload(BaseModel):
     match_type: Optional[str] = None
     name: Optional[str] = None
     settings: dict = Field(default_factory=dict)
+
+
+class TournamentStructurePlanPayload(TournamentBracketStructurePayload):
+    preview: bool = True
 
 
 def _next_power_of_two(n: int) -> int:
@@ -2777,6 +2794,155 @@ async def checkin_self(tid: str, me: dict = Depends(get_current_user)):
 
 
 # --- Bracket generation ---
+@router.post("/{tid}/bracket/plan")
+async def plan_bracket_from_tournament_format(
+    tid: str,
+    body: TournamentStructurePlanPayload,
+    me: dict = Depends(get_current_user),
+):
+    """Generate and validate a deterministic structure without writing it."""
+
+    db = get_db()
+    tid = await _resolve_tid(tid)
+    tournament = await _ensure_tournament_unlocked(db, tid)
+    await require_tournament_staff_permission(me, tid, STRUCTURE_STAFF_ROLES)
+    if not _can_rebuild_bracket_from_format(tournament):
+        raise HTTPException(
+            status_code=400,
+            detail="Für dieses Format gibt es keinen automatischen Format-Bracket-Generator.",
+        )
+
+    read_model = await load_competition_read_model(db, tid)
+    current_structure = read_model.structure_snapshot()
+    registrations = await db.tournament_registrations.find(
+        {"tournament_id": tid, "status": {"$in": ["approved", "checked_in"]}},
+        {"_id": 0},
+    ).to_list(5000)
+    registrations = ordered_plan_registrations(registrations)
+
+    stage_defaults = _stage_defaults_for_tournament_format(tournament, body)
+    if stage_defaults:
+        generator_registrations = registrations
+        engine = "graph"
+    else:
+        generator_registrations = (
+            _preview_registrations_for_tournament(tournament)
+            if body.preview
+            else registrations
+        )
+        engine = "classic"
+    if not body.preview and len(generator_registrations) < 2:
+        raise HTTPException(status_code=400, detail="Mindestens 2 Teilnehmer benötigt")
+
+    request_payload = body.model_dump()
+    seed_data = structure_plan_seed(
+        tournament,
+        request_payload,
+        generator_registrations,
+        current_structure,
+    )
+    plan_seed = seed_data["seed"]
+    rng = random.Random(plan_seed)
+    match_plan = _collect_match_plan(
+        read_model.legacy_matches,
+        read_model.stage_matches,
+    )
+    stage = None
+
+    if stage_defaults:
+        stage_id = deterministic_structure_id(plan_seed, "stage", "1")
+        generated_at = now_utc().isoformat()
+        stage = {
+            **stage_defaults,
+            "id": stage_id,
+            "tournament_id": tid,
+            "created_at": generated_at,
+            "updated_at": generated_at,
+        }
+        try:
+            matches = build_matches_v2_from_schema(
+                tournament,
+                stage,
+                generator_registrations,
+                preview=body.preview,
+                rng=rng,
+            )
+        except BracketSchemaError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if not matches:
+            raise HTTPException(status_code=400, detail="Die Struktur erzeugt keine Spiele.")
+        if len(matches) > MAX_STRUCTURE_PLAN_MATCHES:
+            raise HTTPException(status_code=400, detail="Die Struktur erzeugt zu viele Spiele.")
+        matches = stabilize_stage_plan_matches(
+            matches,
+            seed=plan_seed,
+            stage_id=stage_id,
+        )
+        _apply_match_plan(matches, match_plan, _v2_plan_key)
+        planned_structure = build_structure_snapshot(
+            tid,
+            stage_matches=matches,
+            stages=[stage],
+        )
+    else:
+        matches = generate_bracket(
+            tournament,
+            generator_registrations,
+            preview=body.preview,
+            rng=rng,
+        )
+        if not matches:
+            raise HTTPException(
+                status_code=400,
+                detail="Für dieses Format ist kein automatischer Bracket-Generator aktiv.",
+            )
+        if len(matches) > MAX_STRUCTURE_PLAN_MATCHES:
+            raise HTTPException(status_code=400, detail="Die Struktur erzeugt zu viele Spiele.")
+        matches = stabilize_legacy_plan_matches(matches, seed=plan_seed)
+        _apply_match_plan(matches, match_plan, _legacy_plan_key)
+        planned_structure = build_structure_snapshot(tid, legacy_matches=matches)
+
+    validation = validate_competition_graph(planned_structure)
+    plan_hash = structure_plan_hash(
+        engine=engine,
+        base_structure_hash=seed_data["base_structure_hash"],
+        input_hash=seed_data["input_hash"],
+        planned_structure=planned_structure,
+        stage=stage,
+    )
+    existing_matches = [*read_model.legacy_matches, *read_model.stage_matches]
+    force_required = (
+        any(not match.get("is_preview") for match in existing_matches)
+        or tournament.get("status") in {
+            "live", "paused", "completed", "results_published", "archived",
+        }
+    )
+    return {
+        "ok": validation["valid"],
+        "plan_version": STRUCTURE_PLAN_VERSION,
+        "plan_hash": plan_hash,
+        "base_structure_hash": seed_data["base_structure_hash"],
+        "input_hash": seed_data["input_hash"],
+        "engine": engine,
+        "preview": body.preview,
+        "match_count": len(matches),
+        "participant_count": len(registrations),
+        "stage": stage,
+        "structure": planned_structure,
+        "validation": validation,
+        "apply_requirements": {
+            "expected_plan_hash": plan_hash,
+            "expected_base_structure_hash": seed_data["base_structure_hash"],
+            "force_required": force_required,
+        },
+        "replacement_impact": {
+            "legacy_match_count": len(read_model.legacy_matches),
+            "stage_match_count": len(read_model.stage_matches),
+            "stage_count": len(read_model.stages),
+        },
+    }
+
+
 @router.post("/{tid}/generate-bracket")
 async def generate(tid: str, preview: bool = False, force: bool = False,
                    me: dict = Depends(get_current_user),

--- a/backend/services/competition_structure_plan.py
+++ b/backend/services/competition_structure_plan.py
@@ -1,0 +1,206 @@
+"""Deterministic, non-destructive planning helpers for competition structures."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from copy import deepcopy
+from datetime import date, datetime
+from typing import Any, Iterable
+
+
+STRUCTURE_PLAN_VERSION = "competition.structure-plan.v1"
+_VOLATILE_KEYS = {"_id", "created_at", "updated_at"}
+_TOURNAMENT_PLAN_FIELDS = (
+    "id",
+    "format",
+    "max_participants",
+    "best_of",
+    "bronze_match",
+    "seeding_mode",
+    "match_duration_minutes",
+    "randomize_advancement_rounds",
+    "engine_version",
+    "ruleset_version",
+)
+
+
+def _normalized(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _normalized(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            if key not in _VOLATILE_KEYS
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalized(item) for item in value]
+    if isinstance(value, set):
+        return sorted(_normalized(item) for item in value)
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
+def stable_structure_digest(value: Any) -> str:
+    """Hash JSON-like structure data while ignoring generated timestamps."""
+
+    payload = json.dumps(
+        _normalized(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def ordered_plan_registrations(registrations: Iterable[dict]) -> list[dict]:
+    """Return a stable generator input before optional seeded randomization."""
+
+    def seed_value(registration: dict) -> int:
+        try:
+            parsed = int(registration.get("seed"))
+        except (TypeError, ValueError):
+            return 2_147_483_647
+        return parsed if parsed > 0 else 2_147_483_647
+
+    return sorted(
+        (deepcopy(registration) for registration in registrations),
+        key=lambda registration: (
+            seed_value(registration),
+            str(registration.get("id") or ""),
+        ),
+    )
+
+
+def structure_plan_seed(
+    tournament: dict,
+    request_payload: dict,
+    registrations: Iterable[dict],
+    base_structure: dict,
+) -> dict:
+    """Build hashes binding a plan to inputs and the current structure state."""
+
+    base_structure_hash = stable_structure_digest(base_structure)
+    input_payload = {
+        "tournament": {
+            field: tournament.get(field)
+            for field in _TOURNAMENT_PLAN_FIELDS
+        },
+        "request": request_payload,
+        "registrations": [
+            {
+                "id": registration.get("id"),
+                "status": registration.get("status"),
+                "seed": registration.get("seed"),
+                "user_id": registration.get("user_id"),
+                "team_id": registration.get("team_id"),
+            }
+            for registration in ordered_plan_registrations(registrations)
+        ],
+    }
+    input_hash = stable_structure_digest(input_payload)
+    seed = stable_structure_digest({
+        "version": STRUCTURE_PLAN_VERSION,
+        "base_structure_hash": base_structure_hash,
+        "input_hash": input_hash,
+    })
+    return {
+        "seed": seed,
+        "base_structure_hash": base_structure_hash,
+        "input_hash": input_hash,
+    }
+
+
+def deterministic_structure_id(seed: str, kind: str, identity: str) -> str:
+    return str(uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"thelionsquad:{STRUCTURE_PLAN_VERSION}:{seed}:{kind}:{identity}",
+    ))
+
+
+def stabilize_stage_plan_matches(
+    matches: Iterable[dict],
+    *,
+    seed: str,
+    stage_id: str,
+) -> list[dict]:
+    """Replace generator UUIDs and their references with deterministic IDs."""
+
+    planned = [deepcopy(match) for match in matches]
+    old_to_new: dict[str, str] = {}
+    identities: set[str] = set()
+    for index, match in enumerate(planned):
+        identity = str(match.get("match_key") or (
+            f"{match.get('stage_number')}:{match.get('round')}:{match.get('order')}:{index}"
+        ))
+        if identity in identities:
+            identity = f"{identity}:{index}"
+        identities.add(identity)
+        new_id = deterministic_structure_id(seed, "match", identity)
+        if match.get("id"):
+            old_to_new[str(match["id"])] = new_id
+        match["id"] = new_id
+        match["stage_id"] = stage_id
+
+    for match in planned:
+        for edge in match.get("advancement") or []:
+            target_id = edge.get("to_match_id")
+            if target_id in old_to_new:
+                edge["to_match_id"] = old_to_new[target_id]
+        for slot in match.get("slots") or []:
+            source = slot.get("source") or {}
+            source_id = source.get("match_id")
+            if source_id in old_to_new:
+                source["match_id"] = old_to_new[source_id]
+            source_result = slot.get("source_result") or {}
+            result_source_id = source_result.get("from_match_id")
+            if result_source_id in old_to_new:
+                source_result["from_match_id"] = old_to_new[result_source_id]
+    return planned
+
+
+def stabilize_legacy_plan_matches(matches: Iterable[dict], *, seed: str) -> list[dict]:
+    """Replace classic generator UUIDs without changing bracket topology."""
+
+    planned = [deepcopy(match) for match in matches]
+    old_to_new: dict[str, str] = {}
+    identities: set[str] = set()
+    for index, match in enumerate(planned):
+        identity = (
+            f"{match.get('bracket')}:{match.get('round')}:"
+            f"{match.get('match_index', match.get('order'))}"
+        )
+        if identity in identities:
+            identity = f"{identity}:{index}"
+        identities.add(identity)
+        new_id = deterministic_structure_id(seed, "match", identity)
+        if match.get("id"):
+            old_to_new[str(match["id"])] = new_id
+        match["id"] = new_id
+
+    for match in planned:
+        for field in ("next_match_id", "next_loser_match_id"):
+            target_id = match.get(field)
+            if target_id in old_to_new:
+                match[field] = old_to_new[target_id]
+    return planned
+
+
+def structure_plan_hash(
+    *,
+    engine: str,
+    base_structure_hash: str,
+    input_hash: str,
+    planned_structure: dict,
+    stage: dict | None = None,
+) -> str:
+    return stable_structure_digest({
+        "version": STRUCTURE_PLAN_VERSION,
+        "engine": engine,
+        "base_structure_hash": base_structure_hash,
+        "input_hash": input_hash,
+        "stage": stage,
+        "structure": planned_structure,
+    })

--- a/backend/services/custom_bracket.py
+++ b/backend/services/custom_bracket.py
@@ -184,13 +184,14 @@ def infer_rounds(matches: list[BracketMatchSpec]) -> dict[str, int]:
     return {match.key: depth(match.key) for match in matches}
 
 
-def _ordered_registrations(registrations: list[dict], seeding_mode: str) -> list[dict]:
+def _ordered_registrations(registrations: list[dict], seeding_mode: str,
+                           rng: random.Random | None = None) -> list[dict]:
     regs = [r for r in registrations if r.get("status") in ("approved", "checked_in")]
     if seeding_mode in {"manual", "ranking"}:
         regs.sort(key=lambda r: (r.get("seed") is None, r.get("seed") or 999999, r.get("created_at") or ""))
     elif seeding_mode == "random":
         regs = list(regs)
-        random.shuffle(regs)
+        (rng or random).shuffle(regs)
     else:
         regs.sort(key=lambda r: (r.get("seed") is None, r.get("seed") or 999999, r.get("created_at") or ""))
     return regs
@@ -614,13 +615,19 @@ def _apply_auto_byes(docs: list[dict]) -> None:
             target["updated_at"] = now
 
 
-def build_matches_v2_from_schema(tournament: dict, stage: dict, registrations: list[dict], preview: bool = False) -> list[dict]:
+def build_matches_v2_from_schema(tournament: dict, stage: dict, registrations: list[dict],
+                                 preview: bool = False,
+                                 rng: random.Random | None = None) -> list[dict]:
     settings = stage.get("settings") or {}
     schema = _resolve_schema(tournament, stage, registrations, preview)
     specs = parse_custom_bracket_schema(schema)
     _validate_stage_flow(tournament, stage, specs)
     rounds = infer_rounds(specs)
-    ordered_regs = _ordered_registrations(registrations, tournament.get("seeding_mode") or "random")
+    ordered_regs = _ordered_registrations(
+        registrations,
+        tournament.get("seeding_mode") or "random",
+        rng,
+    )
     seed_to_reg = {index + 1: reg for index, reg in enumerate(ordered_regs)}
     now = _now_utc().isoformat()
     match_type = stage.get("match_type") or settings.get("match_type") or "ffa"

--- a/backend/tests/test_competition_structure_plan_unit.py
+++ b/backend/tests/test_competition_structure_plan_unit.py
@@ -1,0 +1,126 @@
+from services.competition_structure_plan import (
+    STRUCTURE_PLAN_VERSION,
+    deterministic_structure_id,
+    ordered_plan_registrations,
+    stabilize_legacy_plan_matches,
+    stabilize_stage_plan_matches,
+    stable_structure_digest,
+    structure_plan_hash,
+    structure_plan_seed,
+)
+
+
+def test_stable_digest_ignores_generated_timestamps_but_not_structure_changes():
+    first = {
+        "updated_at": "2026-08-17T10:00:00Z",
+        "matches": [{"id": "m1", "status": "ready", "created_at": "old"}],
+    }
+    same = {
+        "matches": [{"status": "ready", "created_at": "new", "id": "m1"}],
+        "updated_at": "2026-08-17T11:00:00Z",
+    }
+    changed = {"matches": [{"id": "m1", "status": "completed"}]}
+
+    assert stable_structure_digest(first) == stable_structure_digest(same)
+    assert stable_structure_digest(first) != stable_structure_digest(changed)
+
+
+def test_plan_seed_is_order_independent_and_bound_to_base_state():
+    tournament = {"id": "t1", "format": "single_elim", "seeding_mode": "random"}
+    registrations = [
+        {"id": "r2", "status": "approved", "seed": 2},
+        {"id": "r1", "status": "approved", "seed": 1},
+        {"id": "bad-seed", "status": "approved", "seed": "unknown"},
+    ]
+    base = {"schema_version": "competition.structure.v1", "matches": []}
+
+    first = structure_plan_seed(tournament, {"preview": False}, registrations, base)
+    reordered = structure_plan_seed(
+        tournament,
+        {"preview": False},
+        list(reversed(registrations)),
+        base,
+    )
+    changed = structure_plan_seed(
+        tournament,
+        {"preview": False},
+        registrations,
+        {**base, "matches": [{"id": "existing"}]},
+    )
+
+    assert first == reordered
+    assert first["seed"] != changed["seed"]
+    assert [row["id"] for row in ordered_plan_registrations(registrations)] == [
+        "r1", "r2", "bad-seed",
+    ]
+
+
+def test_stage_plan_ids_and_edges_are_deterministic():
+    matches = [
+        {
+            "id": "random-a",
+            "match_key": "A",
+            "slots": [],
+            "advancement": [{"to_match_id": "random-b"}],
+        },
+        {
+            "id": "random-b",
+            "match_key": "B",
+            "slots": [{
+                "source": {"match_id": "random-a"},
+                "source_result": {"from_match_id": "random-a"},
+            }],
+            "advancement": [],
+        },
+    ]
+    stage_id = deterministic_structure_id("seed", "stage", "1")
+
+    stabilized = stabilize_stage_plan_matches(matches, seed="seed", stage_id=stage_id)
+
+    assert stabilized[0]["id"] == deterministic_structure_id("seed", "match", "A")
+    assert stabilized[0]["advancement"][0]["to_match_id"] == stabilized[1]["id"]
+    assert stabilized[1]["slots"][0]["source"]["match_id"] == stabilized[0]["id"]
+    assert stabilized[1]["slots"][0]["source_result"]["from_match_id"] == stabilized[0]["id"]
+    assert {match["stage_id"] for match in stabilized} == {stage_id}
+
+
+def test_legacy_plan_ids_preserve_next_match_references():
+    matches = [
+        {
+            "id": "random-a",
+            "bracket": "winner",
+            "round": 1,
+            "match_index": 0,
+            "next_match_id": "random-b",
+        },
+        {
+            "id": "random-b",
+            "bracket": "winner",
+            "round": 2,
+            "match_index": 0,
+        },
+    ]
+
+    stabilized = stabilize_legacy_plan_matches(matches, seed="seed")
+
+    assert stabilized[0]["next_match_id"] == stabilized[1]["id"]
+    assert stabilized[0]["id"] != "random-a"
+
+
+def test_plan_hash_is_bound_to_validation_input_and_version():
+    structure = {"matches": [{"id": "m1"}]}
+    first = structure_plan_hash(
+        engine="graph",
+        base_structure_hash="base",
+        input_hash="input",
+        planned_structure=structure,
+    )
+    changed = structure_plan_hash(
+        engine="graph",
+        base_structure_hash="other-base",
+        input_hash="input",
+        planned_structure=structure,
+    )
+
+    assert STRUCTURE_PLAN_VERSION == "competition.structure-plan.v1"
+    assert first != changed

--- a/backend/tests/test_tournament_operations_unit.py
+++ b/backend/tests/test_tournament_operations_unit.py
@@ -448,6 +448,7 @@ def _bracket_rebuild_db(*, tournament, legacy_matches=None, v2_matches=None,
     )
     stages = SimpleNamespace(
         find_one=AsyncMock(return_value=existing_stage),
+        find=Mock(return_value=_Cursor([existing_stage] if existing_stage else [])),
         insert_one=AsyncMock(),
         delete_one=AsyncMock(),
         delete_many=AsyncMock(),
@@ -626,3 +627,101 @@ def test_custom_bracket_write_failure_cleans_new_generation_only(monkeypatch):
     db.matches.delete_many.assert_not_awaited()
     db.tournament_stages.delete_many.assert_not_awaited()
     db.match_reports_v2.delete_many.assert_not_awaited()
+
+
+@pytest.mark.parametrize(("tournament_format", "stage_type", "engine"), [
+    ("round_robin", None, "classic"),
+    ("custom_bracket", "custom_bracket", "graph"),
+])
+def test_structure_plan_is_deterministic_valid_and_read_only(
+    monkeypatch,
+    tournament_format,
+    stage_type,
+    engine,
+):
+    tournament = {
+        "id": "t1",
+        "format": tournament_format,
+        "max_participants": 4,
+        "match_duration_minutes": 30,
+        "seeding_mode": "random",
+        "status": "draft",
+    }
+    registrations = [
+        {"id": "r4", "user_id": "u4", "status": "approved", "seed": 4},
+        {"id": "r2", "user_id": "u2", "status": "approved", "seed": 2},
+        {"id": "r1", "user_id": "u1", "status": "approved", "seed": 1},
+        {"id": "r3", "user_id": "u3", "status": "approved", "seed": 3},
+    ]
+    db = _bracket_rebuild_db(tournament=tournament, registrations=registrations)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+    payload = tournament_routes.TournamentStructurePlanPayload(
+        stage_type=stage_type,
+        match_type="duel" if stage_type else None,
+        preview=False,
+    )
+
+    first = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1", payload, {"id": "admin-1"},
+    ))
+    second = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1", payload, {"id": "admin-1"},
+    ))
+
+    assert first["ok"] is True
+    assert first["engine"] == engine
+    assert first["validation"]["valid"] is True
+    assert first["plan_hash"] == second["plan_hash"]
+    assert first["base_structure_hash"] == second["base_structure_hash"]
+    assert [match["id"] for match in first["structure"]["matches"]] == [
+        match["id"] for match in second["structure"]["matches"]
+    ]
+    assert first["apply_requirements"]["force_required"] is False
+    db.matches.insert_many.assert_not_awaited()
+    db.matches.delete_many.assert_not_awaited()
+    db.matches_v2.insert_many.assert_not_awaited()
+    db.matches_v2.delete_many.assert_not_awaited()
+    db.tournament_stages.insert_one.assert_not_awaited()
+    db.tournament_stages.delete_many.assert_not_awaited()
+    db.tournaments.update_one.assert_not_awaited()
+
+
+def test_structure_plan_reports_replacement_impact_and_force_requirement(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "single_elim",
+        "max_participants": 4,
+        "seeding_mode": "manual",
+        "status": "live",
+    }
+    old_match = {
+        "id": "old-match",
+        "tournament_id": "t1",
+        "round": 1,
+        "match_index": 0,
+        "participant_a_id": "r1",
+        "participant_b_id": "r2",
+        "status": "completed",
+    }
+    db = _bracket_rebuild_db(
+        tournament=tournament,
+        legacy_matches=[old_match],
+        registrations=[
+            {"id": "r1", "status": "approved", "seed": 1},
+            {"id": "r2", "status": "approved", "seed": 2},
+        ],
+    )
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+
+    result = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1",
+        tournament_routes.TournamentStructurePlanPayload(preview=False),
+        {"id": "admin-1"},
+    ))
+
+    assert result["apply_requirements"]["force_required"] is True
+    assert result["replacement_impact"] == {
+        "legacy_match_count": 1,
+        "stage_match_count": 0,
+        "stage_count": 0,
+    }


### PR DESCRIPTION
## Was sich ändert

- ergänzt `POST /api/tournaments/{id}/bracket/plan` als staff-geschützte, vollständig read-only Strukturvorschau
- erzeugt Classic- und Graph-Pläne über dieselben bestehenden Generatoren
- validiert jeden Plan mit `competition.graph-validation.v1` und liefert den vollständigen maschinenlesbaren Bericht
- bindet `plan_hash` und `base_structure_hash` an Turnierregeln, Request, Teilnehmer-Snapshot und aktuellen Strukturzustand
- macht Zufallsseeding mit einem lokalen plan-gebundenen RNG reproduzierbar
- erzeugt Stage- und Match-IDs deterministisch per UUIDv5 und aktualisiert alle internen Referenzen
- liefert Force-Anforderung und exakten Ersetzungsumfang, ohne Matches, Stages, Versionen oder Auditdaten zu schreiben
- begrenzt einen Plan auf 5.000 Matches

## Sicherheit und Bestand

- kein Datenbank-Write und kein Audit-Write im Planpfad
- kein Cutover, keine Migration und keine Änderung bestehender IDs
- bestehende Generatoraufrufe behalten ihr bisheriges Verhalten; der RNG ist optional
- der Apply-Endpunkt bleibt absichtlich noch gesperrt, bis er beide erwarteten Hashes zwingend prüft und veraltetete Pläne mit 409 ablehnt

## Prüfung

- vollständige Backend-Suite: 325 bestanden, 282 übersprungen
- Classic- und Graph-Plan wiederholt auf identischen Hash, Teilnehmerpositionen und IDs geprüft
- DB-Insert/Update/Delete im Planpfad explizit als nicht aufgerufen geprüft
- Compile- und Whitespace-Check grün

Refs #120