### PR TITLE
feat: complete tournament and team progression workflows

### DIFF
--- a/COMPETITION_ENGINE.md
+++ b/COMPETITION_ENGINE.md
@@ -238,10 +238,36 @@ plan-gebundenen Zufallsgenerator; Stage- und Match-IDs werden per UUIDv5 aus dem
 Plan abgeleitet. Derselbe Input auf demselben Basiszustand erzeugt deshalb
 denselben `plan_hash`, dieselben Teilnehmerpositionen und dieselben IDs.
 
-Der Plan ist noch kein Apply: Der folgende Schreibschritt muss
-`expected_plan_hash` und `expected_base_structure_hash` zwingend pruefen,
-zwischenzeitliche Aenderungen mit `409` ablehnen und erst danach den bereits
-validierten Dokumentensatz kontrolliert aktivieren.
+## Hash-gebundenes Struktur-Apply v1
+
+`POST /api/tournaments/{id}/bracket/apply` nimmt dieselben Planparameter sowie
+`expected_plan_hash` und `expected_base_structure_hash` entgegen. Der gesamte
+Re-Plan-/Validate-/Apply-Ablauf laeuft unter dem pro Turnier verteilten
+Write-Lease. Der Server erzeugt den Plan aus dem aktuellen Datenstand erneut
+und vergleicht beide SHA-256-Hashes in konstanter Zeit. Eine veraenderte
+Basisstruktur liefert `409 structure_plan_stale`; geaenderte Regeln,
+Teilnehmer oder Request-Settings liefern `409 structure_plan_changed`. Vor
+diesen Pruefungen werden keine Match-, Stage-, Versions- oder Auditdaten
+geschrieben oder geloescht.
+
+Nur ein fehlerfreier Bericht von `competition.graph-validation.v1` darf
+aktiviert werden. Der erste produktive Apply-Sicherheitskorridor ersetzt
+ausschliesslich leere oder vollstaendig als Preview markierte Strukturen.
+Reale Matches sowie laufende, abgeschlossene, archivierte oder stornierte
+Turniere werden mit `409 protected_existing_structure` unveraendert belassen.
+Ein spaeterer Migrationspfad fuer reale Bestandsstrukturen braucht zuvor die
+Paritaet aller ID-abhaengigen Consumer und eigene Backup-/Restore-Nachweise.
+
+Die Produktion verwendet einen einzelnen MongoDB-Knoten ohne Replica Set und
+damit keine nativen Multi-Dokument-Transaktionen. Die Aktivierung ist deshalb
+eine kontrollierte, kompensierbare Schreibsequenz unter dem Write-Lease: neue
+Dokumente werden mit `structure_plan_hash` bereitgestellt, alte Preview-Daten
+werden erst danach entfernt und Tournament-Version, Revisionszaehler sowie
+Audit werden zum Abschluss geschrieben. Schlaegt ein Schritt fehl, entfernt
+der Service die neue Generation und stellt die zuvor gelesenen Preview-Matches,
+Stages, Reports und Tournament-Metadaten per stabiler ID wieder her. Ein
+erfolgreicher exakter Retry wird anhand des persistierten Plan-/Basis-Hashes
+ohne neue Writes als `idempotent_replay` beantwortet.
 
 ## Abnahmematrix
 

--- a/backend/routes/team_level_routes.py
+++ b/backend/routes/team_level_routes.py
@@ -1,7 +1,7 @@
 """Team level endpoints — must be registered BEFORE team_routes (/{team_id} catch)."""
 from fastapi import APIRouter, HTTPException
 
-from services.team_levels import get_all_team_levels
+from services.team_levels import get_all_team_levels, top_team_id
 
 router = APIRouter(prefix="/api/teams", tags=["team-levels"])
 
@@ -9,10 +9,14 @@ router = APIRouter(prefix="/api/teams", tags=["team-levels"])
 @router.get("/levels")
 async def all_team_levels():
     data = await get_all_team_levels()
-    return {"levels": {
-        tid: {"level": v["level"], "points": v["points"], "progress": v["progress"]}
-        for tid, v in data.items()
-    }}
+    top_id = top_team_id(data)
+    return {
+        "levels": {
+            tid: {"level": v["level"], "points": v["points"], "progress": v["progress"]}
+            for tid, v in data.items()
+        },
+        "crowns": {top_id: "gold"} if top_id else {},
+    }
 
 
 @router.get("/{team_id}/level")
@@ -21,4 +25,5 @@ async def team_level_detail(team_id: str):
     info = data.get(team_id)
     if not info:
         raise HTTPException(404, "Team nicht gefunden.")
+    info = {**info, "crown": "gold" if team_id == top_team_id(data) else None}
     return info

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -1,6 +1,7 @@
 """Tournament + bracket routes."""
 import csv
 import hashlib
+import hmac
 import io
 import json
 import logging
@@ -45,6 +46,11 @@ from services.competition_structure_plan import (
     stabilize_stage_plan_matches,
     structure_plan_hash,
     structure_plan_seed,
+)
+from services.competition_structure_apply import (
+    StructureApplyError,
+    StructureApplyPreconditionError,
+    activate_structure_plan,
 )
 from services.competition_versions import (
     apply_competition_version_read_defaults,
@@ -146,6 +152,21 @@ class TournamentBracketStructurePayload(BaseModel):
 
 class TournamentStructurePlanPayload(TournamentBracketStructurePayload):
     preview: bool = True
+
+
+class TournamentStructureApplyPayload(TournamentStructurePlanPayload):
+    expected_plan_hash: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$")
+    expected_base_structure_hash: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$")
+
+
+def _structure_plan_request_payload(body: TournamentStructurePlanPayload) -> dict:
+    return {
+        "stage_type": body.stage_type,
+        "match_type": body.match_type,
+        "name": body.name,
+        "settings": body.settings,
+        "preview": body.preview,
+    }
 
 
 def _next_power_of_two(n: int) -> int:
@@ -2796,18 +2817,14 @@ async def checkin_self(tid: str, me: dict = Depends(get_current_user)):
 
 
 # --- Bracket generation ---
-@router.post("/{tid}/bracket/plan")
-async def plan_bracket_from_tournament_format(
+async def _build_tournament_structure_plan(
+    db,
     tid: str,
+    tournament: dict,
     body: TournamentStructurePlanPayload,
-    me: dict = Depends(get_current_user),
 ):
     """Generate and validate a deterministic structure without writing it."""
 
-    db = get_db()
-    tid = await _resolve_tid(tid)
-    tournament = await _ensure_tournament_unlocked(db, tid)
-    await require_tournament_staff_permission(me, tid, STRUCTURE_STAFF_ROLES)
     if not _can_rebuild_bracket_from_format(tournament):
         raise HTTPException(
             status_code=400,
@@ -2836,7 +2853,7 @@ async def plan_bracket_from_tournament_format(
     if not body.preview and len(generator_registrations) < 2:
         raise HTTPException(status_code=400, detail="Mindestens 2 Teilnehmer benötigt")
 
-    request_payload = body.model_dump()
+    request_payload = _structure_plan_request_payload(body)
     seed_data = structure_plan_seed(
         tournament,
         request_payload,
@@ -2916,10 +2933,10 @@ async def plan_bracket_from_tournament_format(
     force_required = (
         any(not match.get("is_preview") for match in existing_matches)
         or tournament.get("status") in {
-            "live", "paused", "completed", "results_published", "archived",
+            "live", "paused", "completed", "results_published", "archived", "cancelled",
         }
     )
-    return {
+    response = {
         "ok": validation["valid"],
         "plan_version": STRUCTURE_PLAN_VERSION,
         "plan_hash": plan_hash,
@@ -2942,6 +2959,145 @@ async def plan_bracket_from_tournament_format(
             "stage_match_count": len(read_model.stage_matches),
             "stage_count": len(read_model.stages),
         },
+    }
+    return response, matches, stage, read_model
+
+
+@router.post("/{tid}/bracket/plan")
+async def plan_bracket_from_tournament_format(
+    tid: str,
+    body: TournamentStructurePlanPayload,
+    me: dict = Depends(get_current_user),
+):
+    db = get_db()
+    tid = await _resolve_tid(tid)
+    tournament = await _ensure_tournament_unlocked(db, tid)
+    await require_tournament_staff_permission(me, tid, STRUCTURE_STAFF_ROLES)
+    response, _matches, _stage, _read_model = await _build_tournament_structure_plan(
+        db,
+        tid,
+        tournament,
+        body,
+    )
+    return response
+
+
+@router.post("/{tid}/bracket/apply")
+async def apply_tournament_structure_plan(
+    tid: str,
+    body: TournamentStructureApplyPayload,
+    me: dict = Depends(get_current_user),
+    _mutation_tid: str = Depends(_serialized_tournament_write),
+):
+    """Validate and activate exactly the structure that a caller previewed."""
+
+    db = get_db()
+    tid = await _resolve_tid(tid)
+    tournament = await _ensure_tournament_unlocked(db, tid)
+    await require_tournament_staff_permission(me, tid, STRUCTURE_STAFF_ROLES)
+
+    last_plan_hash = str(tournament.get("last_structure_plan_hash") or "")
+    if last_plan_hash and hmac.compare_digest(last_plan_hash, body.expected_plan_hash):
+        last_base_hash = str(tournament.get("last_structure_base_hash") or "")
+        if not hmac.compare_digest(last_base_hash, body.expected_base_structure_hash):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "structure_plan_stale",
+                    "message": "Der Basis-Hash gehört nicht zum bereits angewendeten Strukturplan.",
+                },
+            )
+        return {
+            "ok": True,
+            "idempotent_replay": True,
+            "plan_hash": last_plan_hash,
+            "base_structure_hash": last_base_hash,
+            "plan_version": tournament.get("last_structure_plan_version") or STRUCTURE_PLAN_VERSION,
+            "engine": tournament.get("last_structure_engine") or (
+                "graph" if tournament.get("engine_version") == "competition.graph.v1" else "classic"
+            ),
+            "structure_revision": int(tournament.get("structure_revision") or 0),
+        }
+
+    response, matches, stage, read_model = await _build_tournament_structure_plan(
+        db,
+        tid,
+        tournament,
+        body,
+    )
+    if not hmac.compare_digest(
+        response["base_structure_hash"],
+        body.expected_base_structure_hash,
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "structure_plan_stale",
+                "message": "Die Turnierstruktur wurde seit der Vorschau verändert. Bitte neu planen.",
+                "current_base_structure_hash": response["base_structure_hash"],
+            },
+        )
+    if not hmac.compare_digest(response["plan_hash"], body.expected_plan_hash):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "structure_plan_changed",
+                "message": "Die Eingaben oder Teilnehmer haben sich seit der Vorschau verändert. Bitte neu planen.",
+                "current_plan_hash": response["plan_hash"],
+            },
+        )
+    if not response["validation"]["valid"]:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "structure_plan_invalid",
+                "message": "Der Strukturplan ist ungültig und wurde nicht angewendet.",
+                "validation": response["validation"],
+            },
+        )
+    if response["apply_requirements"]["force_required"]:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "protected_existing_structure",
+                "message": (
+                    "Der sichere Apply-Weg ersetzt nur leere oder reine Preview-Strukturen. "
+                    "Reale Matches und laufende oder historische Turniere bleiben unverändert."
+                ),
+                "replacement_impact": response["replacement_impact"],
+            },
+        )
+
+    try:
+        result = await activate_structure_plan(
+            db,
+            tournament=tournament,
+            engine=response["engine"],
+            matches=matches,
+            stage=stage,
+            previous_legacy_matches=read_model.legacy_matches,
+            previous_stage_matches=read_model.stage_matches,
+            previous_stages=read_model.stages,
+            plan_hash=response["plan_hash"],
+            base_structure_hash=response["base_structure_hash"],
+            plan_version=STRUCTURE_PLAN_VERSION,
+            actor_id=me.get("id"),
+        )
+    except StructureApplyPreconditionError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "structure_apply_precondition", "message": str(exc)},
+        ) from exc
+    except StructureApplyError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail={"code": "structure_apply_rollback_failed", "message": str(exc)},
+        ) from exc
+
+    return {
+        **result,
+        "plan_version": STRUCTURE_PLAN_VERSION,
+        "validation": response["validation"],
     }
 
 

--- a/backend/routes/user_routes.py
+++ b/backend/routes/user_routes.py
@@ -782,6 +782,20 @@ async def update_me(body: UserUpdate, me: dict = Depends(get_current_user)):
     return u
 
 
+@router.get("/me/level")
+async def get_my_level(me: dict = Depends(get_current_user)):
+    """Lightweight current achievement level for the logged-in user (level-up detection)."""
+    db = get_db()
+    neg_groups = {g["code"] async for g in db.achievement_groups.find({"is_negative": True}, {"_id": 0, "code": 1})}
+    tiers = await db.achievements.find({}, {"_id": 0, "code": 1, "points": 1}).to_list(4000)
+    points_map = {t["code"]: int(t.get("points", 0) or 0) for t in tiers}
+    awards = await db.user_achievements.find(
+        {"user_id": me["id"]}, {"_id": 0, "tier_code": 1, "group_code": 1}
+    ).to_list(2000)
+    total = sum(points_map.get(a["tier_code"], 0) for a in awards if a.get("group_code") not in neg_groups)
+    return _achievement_level(total)
+
+
 @router.get("/me/notification-preferences")
 async def get_my_notification_preferences(me: dict = Depends(get_current_user)):
     db = get_db()

--- a/backend/services/competition_structure_apply.py
+++ b/backend/services/competition_structure_apply.py
@@ -1,0 +1,237 @@
+"""Controlled activation and compensation for validated structure plans.
+
+MongoDB is deployed as a standalone node in this project, so multi-document
+transactions are unavailable. Activation therefore stages the new generation,
+switches collections under the cross-worker tournament lease, and restores the
+captured preview documents if any later write fails.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Iterable
+
+from models import new_id, now_utc
+from services.competition_versions import competition_version_fields_for_write
+
+
+class StructureApplyError(RuntimeError):
+    pass
+
+
+class StructureApplyPreconditionError(StructureApplyError):
+    pass
+
+
+PROTECTED_TOURNAMENT_STATUSES = {
+    "live",
+    "paused",
+    "completed",
+    "results_published",
+    "archived",
+    "cancelled",
+}
+
+
+async def _restore_documents(collection, documents: Iterable[dict]) -> None:
+    for document in documents:
+        document_id = document.get("id")
+        if not document_id:
+            raise StructureApplyError("Rollback-Dokument ohne stabile ID")
+        await collection.replace_one(
+            {"id": document_id},
+            deepcopy(document),
+            upsert=True,
+        )
+
+
+async def activate_structure_plan(
+    db,
+    *,
+    tournament: dict,
+    engine: str,
+    matches: list[dict],
+    stage: dict | None,
+    previous_legacy_matches: list[dict],
+    previous_stage_matches: list[dict],
+    previous_stages: list[dict],
+    plan_hash: str,
+    base_structure_hash: str,
+    plan_version: str,
+    actor_id: str | None,
+) -> dict:
+    """Activate one already validated plan and compensate on write failure."""
+
+    if engine not in {"classic", "graph"}:
+        raise StructureApplyPreconditionError("Unbekanntes Struktur-Schreibmodell")
+    if not matches:
+        raise StructureApplyPreconditionError("Strukturplan enthält keine Matches")
+    if engine == "graph" and not stage:
+        raise StructureApplyPreconditionError("Graph-Strukturplan enthält keine Stage")
+
+    previous_matches = [*previous_legacy_matches, *previous_stage_matches]
+    if any(not match.get("is_preview") for match in previous_matches):
+        raise StructureApplyPreconditionError(
+            "Bestehende reale Matches dürfen mit dem sicheren Apply-Weg nicht ersetzt werden"
+        )
+    if tournament.get("status") in PROTECTED_TOURNAMENT_STATUSES:
+        raise StructureApplyPreconditionError(
+            "Laufende oder historische Turniere dürfen mit dem sicheren Apply-Weg nicht ersetzt werden"
+        )
+
+    previous_documents = [
+        *previous_matches,
+        *previous_stages,
+    ]
+    if any(not document.get("id") for document in previous_documents):
+        raise StructureApplyPreconditionError("Bestehende Struktur enthält Dokumente ohne stabile ID")
+
+    new_matches = [deepcopy(match) for match in matches]
+    new_stage = deepcopy(stage) if stage else None
+    new_match_ids = [match.get("id") for match in new_matches]
+    if any(not match_id for match_id in new_match_ids):
+        raise StructureApplyPreconditionError("Strukturplan enthält Matches ohne stabile ID")
+    if len(set(new_match_ids)) != len(new_match_ids):
+        raise StructureApplyPreconditionError("Strukturplan enthält doppelte Match-IDs")
+    if any(match.get("tournament_id") != tournament.get("id") for match in new_matches):
+        raise StructureApplyPreconditionError("Strukturplan gehört nicht vollständig zum Turnier")
+    if new_stage and (
+        not new_stage.get("id")
+        or new_stage.get("tournament_id") != tournament.get("id")
+    ):
+        raise StructureApplyPreconditionError("Stage des Strukturplans gehört nicht zum Turnier")
+
+    for match in new_matches:
+        match["structure_plan_hash"] = plan_hash
+    if new_stage:
+        new_stage["structure_plan_hash"] = plan_hash
+        new_stage["created_by"] = actor_id
+
+    old_v2_ids = [
+        match["id"]
+        for match in previous_stage_matches
+        if match.get("id")
+    ]
+    previous_reports = []
+    if old_v2_ids:
+        previous_reports = await db.match_reports_v2.find(
+            {"match_id": {"$in": old_v2_ids}},
+            {"_id": 0},
+        ).to_list(5000)
+        if any(not report.get("id") for report in previous_reports):
+            raise StructureApplyPreconditionError("Bestehender Match-Report enthält keine stabile ID")
+
+    revision = int(tournament.get("structure_revision") or 0) + 1
+    version_fields = competition_version_fields_for_write(tournament, engine)
+    tournament_fields = {
+        **version_fields,
+        "structure_revision": revision,
+        "last_structure_plan_hash": plan_hash,
+        "last_structure_base_hash": base_structure_hash,
+        "last_structure_plan_version": plan_version,
+        "last_structure_engine": engine,
+        "updated_at": now_utc().isoformat(),
+    }
+    previous_tournament_fields = {
+        field: tournament.get(field)
+        for field in tournament_fields
+    }
+    tournament_updated = False
+
+    try:
+        if engine == "graph":
+            await db.tournament_stages.insert_one(new_stage)
+            await db.matches_v2.insert_many(new_matches)
+            await db.matches.delete_many({"tournament_id": tournament["id"]})
+            await db.matches_v2.delete_many({
+                "tournament_id": tournament["id"],
+                "id": {"$nin": new_match_ids},
+            })
+            await db.tournament_stages.delete_many({
+                "tournament_id": tournament["id"],
+                "id": {"$ne": new_stage["id"]},
+            })
+        else:
+            await db.matches.insert_many(new_matches)
+            await db.matches.delete_many({
+                "tournament_id": tournament["id"],
+                "id": {"$nin": new_match_ids},
+            })
+            await db.matches_v2.delete_many({"tournament_id": tournament["id"]})
+            await db.tournament_stages.delete_many({"tournament_id": tournament["id"]})
+
+        if old_v2_ids:
+            await db.match_reports_v2.delete_many({"match_id": {"$in": old_v2_ids}})
+        await db.tournaments.update_one(
+            {"id": tournament["id"]},
+            {"$set": tournament_fields},
+        )
+        tournament_updated = True
+        await db.audit_logs.insert_one({
+            "id": new_id(),
+            "action": "tournament.structure_plan.apply",
+            "target_id": tournament["id"],
+            "actor_id": actor_id,
+            "data": {
+                "plan_hash": plan_hash,
+                "plan_version": plan_version,
+                "base_structure_hash": base_structure_hash,
+                "engine": engine,
+                "structure_revision": revision,
+                "match_count": len(new_matches),
+                "replaced_legacy_match_count": len(previous_legacy_matches),
+                "replaced_stage_match_count": len(previous_stage_matches),
+                "replaced_stage_count": len(previous_stages),
+                "removed_report_count": len(previous_reports),
+            },
+            "created_at": now_utc().isoformat(),
+        })
+    except Exception as exc:
+        rollback_errors: list[Exception] = []
+
+        async def rollback(operation) -> None:
+            try:
+                await operation
+            except Exception as rollback_exc:  # pragma: no cover - catastrophic DB failure
+                rollback_errors.append(rollback_exc)
+
+        await rollback(db.matches.delete_many({"id": {"$in": new_match_ids}}))
+        await rollback(db.matches_v2.delete_many({"id": {"$in": new_match_ids}}))
+        if new_stage:
+            await rollback(db.tournament_stages.delete_one({"id": new_stage["id"]}))
+        await rollback(_restore_documents(db.matches, previous_legacy_matches))
+        await rollback(_restore_documents(db.matches_v2, previous_stage_matches))
+        await rollback(_restore_documents(db.tournament_stages, previous_stages))
+        await rollback(_restore_documents(db.match_reports_v2, previous_reports))
+        if tournament_updated:
+            set_fields = {
+                field: value
+                for field, value in previous_tournament_fields.items()
+                if value is not None
+            }
+            unset_fields = {
+                field: ""
+                for field, value in previous_tournament_fields.items()
+                if value is None
+            }
+            update = {"$set": set_fields}
+            if unset_fields:
+                update["$unset"] = unset_fields
+            await rollback(db.tournaments.update_one({"id": tournament["id"]}, update))
+        if rollback_errors:
+            raise StructureApplyError(
+                f"Strukturaktivierung fehlgeschlagen; Rollback unvollständig ({len(rollback_errors)})"
+            ) from exc
+        raise
+
+    return {
+        "ok": True,
+        "idempotent_replay": False,
+        "plan_hash": plan_hash,
+        "base_structure_hash": base_structure_hash,
+        "plan_version": plan_version,
+        "engine": engine,
+        "structure_revision": revision,
+        "match_count": len(new_matches),
+        "stage_id": new_stage.get("id") if new_stage else None,
+    }

--- a/backend/services/team_levels.py
+++ b/backend/services/team_levels.py
@@ -116,6 +116,22 @@ async def compute_all_team_levels() -> dict[str, dict]:
     return out
 
 
+def top_team_id(data: dict[str, dict]) -> str | None:
+    """The single best team (by points) gets the golden team crown."""
+    ranked = [v for v in data.values() if int(v.get("points", 0) or 0) > 0]
+    if not ranked:
+        return None
+    ranked.sort(
+        key=lambda v: (
+            -int(v.get("points", 0)),
+            -int(v.get("level", 0)),
+            (v.get("name") or "").lower(),
+            v.get("team_id") or "",
+        )
+    )
+    return ranked[0]["team_id"]
+
+
 async def get_all_team_levels(force: bool = False) -> dict[str, dict]:
     now = datetime.now(timezone.utc)
     if not force and _cache["at"] and (now - _cache["at"]).total_seconds() < _CACHE_TTL and _cache["data"] is not None:

--- a/backend/tests/test_team_levels_unit.py
+++ b/backend/tests/test_team_levels_unit.py
@@ -1,0 +1,17 @@
+from services.team_levels import top_team_id
+
+
+def test_top_team_id_requires_positive_points():
+    assert top_team_id({}) is None
+    assert top_team_id({"zero": {"team_id": "zero", "points": 0}}) is None
+
+
+def test_top_team_id_uses_stable_ranking_and_tie_breakers():
+    teams = {
+        "lower": {"team_id": "lower", "points": 99, "level": 10, "name": "A"},
+        "zeta": {"team_id": "zeta", "points": 100, "level": 10, "name": "Beta"},
+        "beta": {"team_id": "beta", "points": 100, "level": 10, "name": "Alpha"},
+        "alpha": {"team_id": "alpha", "points": 100, "level": 10, "name": "Alpha"},
+    }
+
+    assert top_team_id(teams) == "alpha"

--- a/backend/tests/test_tournament_operations_unit.py
+++ b/backend/tests/test_tournament_operations_unit.py
@@ -13,6 +13,7 @@ from routes.station_routes import (
     _match_has_minimum_participants,
 )
 from services.match_reminder import _uses_actual_start_notifications
+from services.competition_structure_apply import activate_structure_plan
 from models import RegistrationUpdate, TournamentCreate, TournamentStageCreate
 
 
@@ -440,11 +441,13 @@ def _bracket_rebuild_db(*, tournament, legacy_matches=None, v2_matches=None,
         find=Mock(return_value=_Cursor(legacy_matches or [])),
         delete_many=AsyncMock(),
         insert_many=AsyncMock(),
+        replace_one=AsyncMock(),
     )
     matches_v2 = SimpleNamespace(
         find=Mock(return_value=_Cursor(v2_matches or [])),
         delete_many=AsyncMock(),
         insert_many=AsyncMock(),
+        replace_one=AsyncMock(),
     )
     stages = SimpleNamespace(
         find_one=AsyncMock(return_value=existing_stage),
@@ -452,6 +455,7 @@ def _bracket_rebuild_db(*, tournament, legacy_matches=None, v2_matches=None,
         insert_one=AsyncMock(),
         delete_one=AsyncMock(),
         delete_many=AsyncMock(),
+        replace_one=AsyncMock(),
     )
     tournament_registrations = SimpleNamespace(
         find=Mock(return_value=_Cursor(registrations or [])),
@@ -465,7 +469,12 @@ def _bracket_rebuild_db(*, tournament, legacy_matches=None, v2_matches=None,
         matches_v2=matches_v2,
         tournament_stages=stages,
         tournament_registrations=tournament_registrations,
-        match_reports_v2=SimpleNamespace(delete_many=AsyncMock()),
+        match_reports_v2=SimpleNamespace(
+            find=Mock(return_value=_Cursor([])),
+            delete_many=AsyncMock(),
+            replace_one=AsyncMock(),
+        ),
+        audit_logs=SimpleNamespace(insert_one=AsyncMock()),
     )
 
 
@@ -725,3 +734,335 @@ def test_structure_plan_reports_replacement_impact_and_force_requirement(monkeyp
         "stage_match_count": 0,
         "stage_count": 0,
     }
+
+
+def _apply_payload_from_plan(plan, **updates):
+    values = {
+        "preview": False,
+        "expected_plan_hash": plan["plan_hash"],
+        "expected_base_structure_hash": plan["base_structure_hash"],
+        **updates,
+    }
+    return tournament_routes.TournamentStructureApplyPayload(**values)
+
+
+def test_structure_apply_rejects_stale_base_before_any_write(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "round_robin",
+        "max_participants": 4,
+        "seeding_mode": "manual",
+        "status": "draft",
+    }
+    registrations = [
+        {"id": f"r{seed}", "status": "approved", "seed": seed}
+        for seed in range(1, 5)
+    ]
+    db = _bracket_rebuild_db(tournament=tournament, registrations=registrations)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+    plan_request = tournament_routes.TournamentStructurePlanPayload(preview=False)
+    plan = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1", plan_request, {"id": "admin-1"},
+    ))
+
+    db.matches.find.return_value = _Cursor([{
+        "id": "changed-after-preview",
+        "tournament_id": "t1",
+        "round": 1,
+        "match_index": 0,
+        "is_preview": True,
+        "status": "preview",
+    }])
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(tournament_routes.apply_tournament_structure_plan(
+            "t1",
+            _apply_payload_from_plan(plan),
+            {"id": "admin-1"},
+        ))
+
+    assert error.value.status_code == 409
+    assert error.value.detail["code"] == "structure_plan_stale"
+    db.matches.insert_many.assert_not_awaited()
+    db.matches.delete_many.assert_not_awaited()
+    db.matches_v2.insert_many.assert_not_awaited()
+    db.matches_v2.delete_many.assert_not_awaited()
+    db.tournament_stages.insert_one.assert_not_awaited()
+    db.tournament_stages.delete_many.assert_not_awaited()
+    db.tournaments.update_one.assert_not_awaited()
+    db.audit_logs.insert_one.assert_not_awaited()
+
+
+def test_structure_apply_activates_exact_valid_plan(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "round_robin",
+        "max_participants": 4,
+        "seeding_mode": "manual",
+        "status": "draft",
+        "structure_revision": 2,
+    }
+    registrations = [
+        {"id": f"r{seed}", "status": "approved", "seed": seed}
+        for seed in range(1, 5)
+    ]
+    db = _bracket_rebuild_db(tournament=tournament, registrations=registrations)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+    plan = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1",
+        tournament_routes.TournamentStructurePlanPayload(preview=False),
+        {"id": "admin-1"},
+    ))
+
+    result = asyncio.run(tournament_routes.apply_tournament_structure_plan(
+        "t1",
+        _apply_payload_from_plan(plan),
+        {"id": "admin-1"},
+    ))
+
+    assert result["ok"] is True
+    assert result["idempotent_replay"] is False
+    assert result["plan_hash"] == plan["plan_hash"]
+    assert result["structure_revision"] == 3
+    assert result["validation"]["valid"] is True
+    inserted_matches = db.matches.insert_many.await_args.args[0]
+    assert len(inserted_matches) == plan["match_count"]
+    assert all(match["structure_plan_hash"] == plan["plan_hash"] for match in inserted_matches)
+    tournament_update = db.tournaments.update_one.await_args.args[1]["$set"]
+    assert tournament_update["last_structure_plan_hash"] == plan["plan_hash"]
+    assert tournament_update["last_structure_base_hash"] == plan["base_structure_hash"]
+    assert tournament_update["engine_version"] == "competition.classic.v1"
+    db.audit_logs.insert_one.assert_awaited_once()
+
+
+def test_structure_apply_activates_graph_plan_with_stage(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "custom_bracket",
+        "max_participants": 4,
+        "seeding_mode": "manual",
+        "status": "draft",
+    }
+    registrations = [
+        {"id": f"r{seed}", "status": "approved", "seed": seed}
+        for seed in range(1, 5)
+    ]
+    db = _bracket_rebuild_db(tournament=tournament, registrations=registrations)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+    request_values = {
+        "stage_type": "custom_bracket",
+        "match_type": "duel",
+        "preview": False,
+    }
+    plan = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1",
+        tournament_routes.TournamentStructurePlanPayload(**request_values),
+        {"id": "admin-1"},
+    ))
+
+    result = asyncio.run(tournament_routes.apply_tournament_structure_plan(
+        "t1",
+        _apply_payload_from_plan(plan, **request_values),
+        {"id": "admin-1"},
+    ))
+
+    assert result["engine"] == "graph"
+    assert result["stage_id"] == plan["stage"]["id"]
+    db.tournament_stages.insert_one.assert_awaited_once()
+    db.matches_v2.insert_many.assert_awaited_once()
+    assert db.tournaments.update_one.await_args.args[1]["$set"]["engine_version"] == "competition.graph.v1"
+
+
+def test_structure_apply_rejects_invalid_validated_graph_before_write(monkeypatch):
+    plan_hash = "c" * 64
+    base_hash = "d" * 64
+    tournament = {
+        "id": "t1",
+        "format": "round_robin",
+        "max_participants": 4,
+        "status": "draft",
+    }
+    db = _bracket_rebuild_db(tournament=tournament)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+    build_plan = AsyncMock(return_value=(
+        {
+            "plan_hash": plan_hash,
+            "base_structure_hash": base_hash,
+            "engine": "classic",
+            "validation": {
+                "valid": False,
+                "issues": [{"code": "missing_match_target"}],
+            },
+            "apply_requirements": {"force_required": False},
+            "replacement_impact": {
+                "legacy_match_count": 0,
+                "stage_match_count": 0,
+                "stage_count": 0,
+            },
+        },
+        [{"id": "invalid", "tournament_id": "t1"}],
+        None,
+        SimpleNamespace(legacy_matches=[], stage_matches=[], stages=[]),
+    ))
+    monkeypatch.setattr(tournament_routes, "_build_tournament_structure_plan", build_plan)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(tournament_routes.apply_tournament_structure_plan(
+            "t1",
+            tournament_routes.TournamentStructureApplyPayload(
+                preview=False,
+                expected_plan_hash=plan_hash,
+                expected_base_structure_hash=base_hash,
+            ),
+            {"id": "admin-1"},
+        ))
+
+    assert error.value.status_code == 422
+    assert error.value.detail["code"] == "structure_plan_invalid"
+    db.matches.insert_many.assert_not_awaited()
+    db.matches.delete_many.assert_not_awaited()
+    db.tournaments.update_one.assert_not_awaited()
+    db.audit_logs.insert_one.assert_not_awaited()
+
+
+def test_structure_apply_rejects_real_existing_matches_before_write(monkeypatch):
+    tournament = {
+        "id": "t1",
+        "format": "single_elim",
+        "max_participants": 4,
+        "seeding_mode": "manual",
+        "status": "draft",
+    }
+    existing = {
+        "id": "real-match",
+        "tournament_id": "t1",
+        "round": 1,
+        "match_index": 0,
+        "participant_a_id": "r1",
+        "participant_b_id": "r2",
+        "status": "pending",
+        "is_preview": False,
+    }
+    registrations = [
+        {"id": f"r{seed}", "status": "approved", "seed": seed}
+        for seed in range(1, 5)
+    ]
+    db = _bracket_rebuild_db(
+        tournament=tournament,
+        legacy_matches=[existing],
+        registrations=registrations,
+    )
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+    plan = asyncio.run(tournament_routes.plan_bracket_from_tournament_format(
+        "t1",
+        tournament_routes.TournamentStructurePlanPayload(preview=False),
+        {"id": "admin-1"},
+    ))
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(tournament_routes.apply_tournament_structure_plan(
+            "t1",
+            _apply_payload_from_plan(plan),
+            {"id": "admin-1"},
+        ))
+
+    assert error.value.status_code == 409
+    assert error.value.detail["code"] == "protected_existing_structure"
+    db.matches.insert_many.assert_not_awaited()
+    db.matches.delete_many.assert_not_awaited()
+    db.tournaments.update_one.assert_not_awaited()
+    db.audit_logs.insert_one.assert_not_awaited()
+
+
+def test_structure_apply_exact_retry_is_idempotent_without_replanning(monkeypatch):
+    plan_hash = "a" * 64
+    base_hash = "b" * 64
+    tournament = {
+        "id": "t1",
+        "format": "round_robin",
+        "max_participants": 4,
+        "status": "draft",
+        "engine_version": "competition.classic.v1",
+        "structure_revision": 7,
+        "last_structure_plan_hash": plan_hash,
+        "last_structure_base_hash": base_hash,
+    }
+    db = _bracket_rebuild_db(tournament=tournament)
+    _patch_bracket_rebuild_dependencies(monkeypatch, db)
+
+    result = asyncio.run(tournament_routes.apply_tournament_structure_plan(
+        "t1",
+        tournament_routes.TournamentStructureApplyPayload(
+            preview=False,
+            expected_plan_hash=plan_hash,
+            expected_base_structure_hash=base_hash,
+        ),
+        {"id": "admin-1"},
+    ))
+
+    assert result == {
+        "ok": True,
+        "idempotent_replay": True,
+        "plan_hash": plan_hash,
+        "base_structure_hash": base_hash,
+        "plan_version": "competition.structure-plan.v1",
+        "engine": "classic",
+        "structure_revision": 7,
+    }
+    db.tournament_registrations.find.assert_not_called()
+    db.matches.insert_many.assert_not_awaited()
+    db.matches.delete_many.assert_not_awaited()
+    db.tournaments.update_one.assert_not_awaited()
+    db.audit_logs.insert_one.assert_not_awaited()
+
+
+def test_structure_apply_restores_previous_preview_after_late_failure():
+    tournament = {
+        "id": "t1",
+        "format": "round_robin",
+        "status": "draft",
+        "engine_version": "competition.classic.v1",
+        "ruleset_version": "competition.ruleset.v1",
+        "structure_revision": 2,
+        "last_structure_plan_hash": "1" * 64,
+        "last_structure_base_hash": "2" * 64,
+    }
+    previous_match = {
+        "id": "old-preview",
+        "tournament_id": "t1",
+        "is_preview": True,
+        "status": "preview",
+    }
+    db = _bracket_rebuild_db(tournament=tournament, legacy_matches=[previous_match])
+    db.audit_logs.insert_one.side_effect = RuntimeError("audit unavailable")
+
+    with pytest.raises(RuntimeError, match="audit unavailable"):
+        asyncio.run(activate_structure_plan(
+            db,
+            tournament=tournament,
+            engine="classic",
+            matches=[{
+                "id": "new-match",
+                "tournament_id": "t1",
+                "is_preview": False,
+                "status": "pending",
+            }],
+            stage=None,
+            previous_legacy_matches=[previous_match],
+            previous_stage_matches=[],
+            previous_stages=[],
+            plan_hash="a" * 64,
+            base_structure_hash="b" * 64,
+            plan_version="competition.structure-plan.v1",
+            actor_id="admin-1",
+        ))
+
+    db.matches.replace_one.assert_awaited_once_with(
+        {"id": "old-preview"},
+        previous_match,
+        upsert=True,
+    )
+    assert db.matches.delete_many.await_count == 2
+    assert db.tournaments.update_one.await_count == 2
+    rollback_update = db.tournaments.update_one.await_args_list[-1].args[1]
+    assert rollback_update["$set"]["structure_revision"] == 2
+    assert rollback_update["$set"]["last_structure_plan_hash"] == "1" * 64

--- a/frontend/src/components/tls/LevelUpCelebration.jsx
+++ b/frontend/src/components/tls/LevelUpCelebration.jsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { api, resolveMediaUrl } from "@/lib/api";
+import { useAuth } from "@/context/AuthContext";
+import { useApiInvalidation } from "@/hooks/useApiInvalidation";
+import { LevelAvatarFrame, levelFrameConfig } from "@/components/tls/LevelAvatarFrame";
+
+const COLORS = ["#29B6E8", "#7FDBFF", "#FFD700", "#00FF88", "#A855F7", "#FFFFFF", "#FF7A00"];
+
+function ConfettiRain() {
+  const pieces = useMemo(() => Array.from({ length: 80 }).map((_, i) => ({
+    left: `${Math.random() * 100}%`,
+    background: COLORS[i % COLORS.length],
+    animationDuration: `${2.6 + Math.random() * 2.6}s`,
+    animationDelay: `${Math.random() * 1.6}s`,
+    width: `${6 + Math.random() * 7}px`,
+    height: `${10 + Math.random() * 9}px`,
+    borderRadius: Math.random() > 0.5 ? "50%" : "1px",
+  })), []);
+  return (
+    <div className="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
+      {pieces.map((style, i) => <span key={i} className="tls-confetti" style={style} />)}
+    </div>
+  );
+}
+
+const storeKey = (uid) => `tls-level-seen:${uid}`;
+
+export function LevelUpCelebration() {
+  const { user } = useAuth();
+  const [event, setEvent] = useState(null);
+  const busyRef = useRef(false);
+
+  const check = useCallback(async () => {
+    if (!user?.id || busyRef.current) return;
+    busyRef.current = true;
+    try {
+      const { data } = await api.get("/users/me/level");
+      const nextLevel = Number(data?.level || 1);
+      const key = storeKey(user.id);
+      let prev = null;
+      try { prev = Number(localStorage.getItem(key)); } catch {}
+      if (prev && !Number.isNaN(prev) && nextLevel > prev) {
+        const cfg = levelFrameConfig(nextLevel);
+        setEvent({ level: nextLevel, archetype: cfg.name });
+      }
+      try { localStorage.setItem(key, String(nextLevel)); } catch {}
+    } catch {}
+    finally { busyRef.current = false; }
+  }, [user?.id]);
+
+  useEffect(() => { check(); }, [check]);
+  useApiInvalidation(check, ["achievements", "admin/notifications", "notifications"]);
+  useEffect(() => {
+    const onFocus = () => check();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [check]);
+
+  useEffect(() => {
+    if (!event) return undefined;
+    const timer = setTimeout(() => setEvent(null), 11000);
+    return () => clearTimeout(timer);
+  }, [event]);
+
+  if (!event) return null;
+  const initials = (user?.display_name || user?.username || "?").slice(0, 2).toUpperCase();
+  return (
+    <div
+      className="tls-crown-celebration"
+      style={{ "--crown-glow": "rgba(41,182,232,0.9)" }}
+      data-testid="levelup-celebration-overlay"
+      role="dialog"
+      aria-label="Level-Aufstieg"
+      onClick={() => setEvent(null)}
+    >
+      <ConfettiRain />
+      <div className="tls-crown-celebration-card" onClick={(e) => e.stopPropagation()}>
+        <span className="tls-crown-celebration-rays" aria-hidden="true" />
+        <div className="tls-levelup-frame" data-testid="levelup-frame-preview">
+          <LevelAvatarFrame level={event.level} showBadge={false} className="w-36 h-36 sm:w-44 sm:h-44">
+            <div className="w-full h-full flex items-center justify-center overflow-hidden bg-[#0A0A0A]">
+              {user?.avatar_url ? (
+                <img src={resolveMediaUrl(user.avatar_url)} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <span className="font-heading font-black text-3xl text-[#29B6E8]">{initials}</span>
+              )}
+            </div>
+          </LevelAvatarFrame>
+        </div>
+        <div className="mt-8 text-[11px] font-bold uppercase tracking-[0.4em] text-[#29B6E8]" data-testid="levelup-level-label">
+          Level {event.level} erreicht
+        </div>
+        <h2 className="mt-2 font-heading text-4xl sm:text-5xl font-black uppercase text-white" data-testid="levelup-archetype-name">
+          {event.archetype}
+        </h2>
+        <p className="mt-3 text-white/70 max-w-md mx-auto" data-testid="levelup-body">
+          Dein neuer Avatar-Rahmen „{event.archetype}“ ist freigeschaltet — trag ihn mit Stolz.
+        </p>
+        <button
+          type="button"
+          onClick={() => setEvent(null)}
+          data-testid="levelup-close"
+          className="mt-8 px-6 py-2.5 bg-[#29B6E8] text-black rounded-sm font-bold uppercase tracking-wider text-xs hover:bg-[#1E95C2]"
+        >
+          Weiter grinden
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/tls/PublicLayout.jsx
+++ b/frontend/src/components/tls/PublicLayout.jsx
@@ -4,6 +4,7 @@ import { Logo } from "@/components/tls/Logo";
 import { MainNav, MobileNav } from "@/components/tls/MainNav";
 import { NotificationBell } from "@/components/tls/NotificationBell";
 import { CrownCelebration } from "@/components/tls/CrownCelebration";
+import { LevelUpCelebration } from "@/components/tls/LevelUpCelebration";
 import { SponsorTicker } from "@/components/tls/SponsorTicker";
 import { GlobalSearch } from "@/components/tls/GlobalSearch";
 import { openCookieSettings } from "@/components/tls/CookieConsent";
@@ -183,6 +184,7 @@ export function PublicLayout({ children }) {
       <SiteBannerSlot banners={siteBanners} pathname={location.pathname} slot="below_nav" />
       <main id="main-content" tabIndex={-1} className="flex-1 min-w-0 max-w-full overflow-x-clip">{children}</main>
       <CrownCelebration />
+      <LevelUpCelebration />
       <SiteBannerSlot banners={siteBanners} pathname={location.pathname} slot="above_footer" />
       <SiteBannerSlot banners={siteBanners} pathname={location.pathname} slot="bottom_fixed" />
       <footer className="border-t border-white/10 bg-[#0A0A0A] mt-24 min-w-0 max-w-full overflow-x-clip pb-16 lg:pb-0">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1882,6 +1882,12 @@ input.no-spin::-webkit-outer-spin-button, input.no-spin::-webkit-inner-spin-butt
   opacity: 0.95;
   animation: tls-confetti-fall linear both;
 }
+.tls-levelup-frame {
+  width: max-content;
+  margin: 0 auto;
+  animation: tls-crown-cele-pop 0.8s cubic-bezier(0.2, 1.4, 0.4, 1) both;
+  filter: drop-shadow(0 0 26px var(--crown-glow, rgba(41, 182, 232, 0.85)));
+}
 @keyframes tls-confetti-fall {
   0% { transform: translateY(0) rotate(0deg) rotateY(0deg); opacity: 1; }
   100% { transform: translateY(108vh) rotate(680deg) rotateY(540deg); opacity: 0.75; }

--- a/frontend/src/pages/public/TeamsPage.jsx
+++ b/frontend/src/pages/public/TeamsPage.jsx
@@ -14,7 +14,7 @@ import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 import { toast } from "sonner";
-import { Copy, Edit, Lock, MessageSquare, Plus, Search, Send, Shield, Star, Swords, Trash2, TrendingUp, Trophy, Users, UserPlus, Zap } from "lucide-react";
+import { Copy, Crown, Edit, Lock, MessageSquare, Plus, Search, Send, Shield, Star, Swords, Trash2, TrendingUp, Trophy, Users, UserPlus, Zap } from "lucide-react";
 
 const emptyTeam = { name: "", tag: "", description: "", logo_url: "", banner_url: "", discord_link: "" };
 const TEAM_ROLE_LABELS = { leader: "Leader", co_leader: "Co-Leader", member: "Mitglied" };
@@ -33,6 +33,7 @@ function TeamList() {
   const { user } = useAuth();
   const [list, setList] = useState([]);
   const [levels, setLevels] = useState({});
+  const [crowns, setCrowns] = useState({});
   const [editing, setEditing] = useState(null);
 
   const load = useCallback(async () => {
@@ -41,6 +42,7 @@ function TeamList() {
     try {
       const { data: lvl } = await api.get("/teams/levels");
       setLevels(lvl?.levels || {});
+      setCrowns(lvl?.crowns || {});
     } catch {}
   }, []);
 
@@ -66,7 +68,7 @@ function TeamList() {
         </div>
 
         <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-          {list.map((t) => <TeamCard key={t.id} team={t} levelInfo={levels[t.id]} />)}
+          {list.map((t) => <TeamCard key={t.id} team={t} levelInfo={levels[t.id]} crown={crowns[t.id] || null} />)}
           {list.length === 0 && <div className="col-span-full text-center py-20 text-white/40 font-display tracking-widest">KEINE TEAMS</div>}
         </div>
       </div>
@@ -75,7 +77,7 @@ function TeamList() {
   );
 }
 
-function TeamCard({ team: t, levelInfo }) {
+function TeamCard({ team: t, levelInfo, crown = null }) {
   return (
     <Link to={`/teams/${t.id}`} data-testid={`team-card-${t.tag}`} className="group block border border-white/10 hover:border-[#29B6E8]/60 rounded-sm bg-[#121212] overflow-hidden transition">
       <div className="relative h-28 bg-[#0A0A0A] border-b border-white/10 overflow-hidden">
@@ -89,7 +91,7 @@ function TeamCard({ team: t, levelInfo }) {
       <div className="relative -mt-8 p-5">
         <div className="flex items-center gap-4">
           {levelInfo ? (
-            <LevelAvatarFrame level={levelInfo.level} compact team showBadge={false} testId={`team-frame-${t.tag}`} className="w-16 h-16 shrink-0">
+            <LevelAvatarFrame level={levelInfo.level} crown={crown} compact team showBadge={false} testId={`team-frame-${t.tag}`} className="w-16 h-16 shrink-0">
               <TeamLogo team={t} bare />
             </LevelAvatarFrame>
           ) : (
@@ -100,6 +102,11 @@ function TeamCard({ team: t, levelInfo }) {
               <span>[{t.tag}]</span>
               {levelInfo && (
                 <span data-testid={`team-level-chip-${t.tag}`} className="px-1.5 py-0.5 border border-[#29B6E8]/40 rounded-full text-[9px] font-black bg-[#29B6E8]/10">LVL {levelInfo.level}</span>
+              )}
+              {crown === "gold" && (
+                <span data-testid={`team-crown-chip-${t.tag}`} className="px-1.5 py-0.5 border border-[#FFD700]/50 rounded-full text-[9px] font-black bg-[#FFD700]/10 text-[#FFD700] inline-flex items-center gap-1">
+                  <Crown className="w-2.5 h-2.5" /> #1
+                </span>
               )}
             </div>
             <h3 className="font-heading text-xl font-bold group-hover:text-[#29B6E8] transition truncate">{t.name}</h3>
@@ -242,7 +249,7 @@ function TeamDetail({ id }) {
           <Link to="/teams" className="text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8] hover:text-white">← Teams</Link>
           <div className="mt-5 flex flex-col md:flex-row gap-6 md:items-center">
             {levelInfo ? (
-              <LevelAvatarFrame level={levelInfo.level} team testId="team-detail-frame" className="w-28 h-28 shrink-0 mt-8 md:mt-4">
+              <LevelAvatarFrame level={levelInfo.level} crown={levelInfo.crown || null} team testId="team-detail-frame" className="w-28 h-28 shrink-0 mt-8 md:mt-4">
                 <TeamLogo team={team} bare />
               </LevelAvatarFrame>
             ) : (
@@ -253,6 +260,11 @@ function TeamDetail({ id }) {
                 <span>[{team.tag}]</span>
                 {levelInfo && (
                   <span data-testid="team-detail-level-chip" className="px-2 py-0.5 border border-[#29B6E8]/40 rounded-full text-[10px] font-black bg-[#29B6E8]/10 tracking-widest">TEAM-LEVEL {levelInfo.level}</span>
+                )}
+                {levelInfo?.crown === "gold" && (
+                  <span data-testid="team-detail-crown-chip" className="px-2 py-0.5 border border-[#FFD700]/50 rounded-full text-[10px] font-black bg-[#FFD700]/10 text-[#FFD700] tracking-widest inline-flex items-center gap-1">
+                    <Crown className="w-3 h-3" /> PUNKTEBESTES TEAM
+                  </span>
                 )}
               </div>
               <h1 className="font-heading text-4xl md:text-6xl font-black uppercase leading-tight">{team.name}</h1>


### PR DESCRIPTION
## Inhalt
- hash-gebundene, idempotente Turnier-Strukturübernahme mit Rollback und vollständigen Unit-Tests
- Goldkrone für das punktbeste Team mit deterministischen Tie-Breakern
- Level-Aufstieg-Overlay mit serverseitig berechnetem aktuellem Level
- keine Demo-Daten, alten Planungsdateien oder Anbieterreste übernommen

## Verifikation
- Backend: 351 gezielte/volle Tests grün; vollständige Suite 349 passed, 19 skipped, Coverage 38,15 %
- Frontend: 14 Unit-Tests + Build grün; 54 Browser-Smokes grün, 8 Live-Tests erwartungsgemäß übersprungen
- Mobile: Typecheck, Security-Regressionen, Release-Preflight, Expo-Check und Expo Doctor 21/21 grün
- Secret-Scan, kritisches Flake8-Profil, Shell-Syntax und Dependency-Audits grün