### PR TITLE
fix(auth): Bestätigungsweg für bestehende Konten und MFA-Rückkehr

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -11,6 +11,48 @@ Das Script zieht den neuesten Code, baut Frontend/Backend neu, startet die Conta
 
 ## Danach pruefen
 
+### Bestehendes Konto: „E-Mail-Adresse noch nicht bestätigt“
+
+Vor der verpflichtenden E-Mail-Bestätigung wurden auch Passwort-Konten mit
+`email_verified=false` angelegt und konnten sich anmelden. Seit der Härtung
+werden diese Konten beim **Passwort-Login vor der MFA-Abfrage** gesperrt, bis
+die Adresse bestätigt ist. Ein erneuter Login verschickt keine Mail.
+Das Konto muss nicht neu angelegt und das Passwort nicht geändert werden.
+
+1. `https://lionsquad.at/verify-email` öffnen, bisherige E-Mail eintragen und
+   den Bestätigungslink einmal anfordern. Einige Minuten warten und Spam prüfen.
+2. Link öffnen; danach mit bisherigem Passwort und MFA-/Wiederherstellungscode
+   anmelden. MFA stammt aus der Authenticator-App, nicht aus einer Login-E-Mail.
+3. Kommt keine Mail: Der Betreiber führt im Server-Checkout folgenden
+   **rein lesenden** Bericht aus (Adresse durch die betroffene Adresse ersetzen):
+
+   ```bash
+   docker compose exec -T backend python - person@example.test < backend/login_diagnostics.py
+   ```
+
+   Der Bericht lässt E-Mail-Adresse, Benutzer-ID, Passwörter, Tokens, Mailtexte
+   und rohe Providerfehler weg. Er verändert keine Daten und versendet nichts.
+   Nach Aktualisierung des Checkouts ist dafür kein Backend-Neubau nötig.
+
+   - `recent_auth_mail` leer: kein neuer Bestätigungsversand erfasst.
+   - `pending`/`sending`: Warteschlange; `scheduler_disabled=true` verhindert
+     den automatischen Versand. Status allein beweist keinen laufenden Worker.
+   - `skipped`: Versand deaktiviert.
+   - `failed` oder `attempts > 0` mit Fehlerkategorie: SMTP/Resend-Konfiguration
+     unter **Admin → E-Mail** prüfen. Bei `configuration_readable=false` auch
+     den unverändert erforderlichen `SETTINGS_ENCRYPTION_KEY` lokal prüfen;
+     Schlüssel niemals hier veröffentlichen oder durch einen neuen ersetzen.
+   - `sent`: Mailserver hat angenommen, keine Garantie für Postfachzustellung.
+     Spam, Mailserver-Zustellung und Absender-Domain prüfen.
+
+Wenn kein Admin mehr ins Menü kommt, zunächst diesen Bericht auswerten.
+Keine pauschale Datenbankänderung aller Konten auf `email_verified=true`, keine
+MFA-Deaktivierung und kein Löschen/Neuanlegen des bestehenden Kontos.
+Der öffentliche Resend-Endpunkt bestätigt aus Datenschutzgründen weder die
+Existenz eines Kontos noch eine erfolgreiche Zustellung.
+
+Referenz: [OWASP – sichere Wiederherstellungsantworten](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html).
+
 ```bash
 docker compose ps
 docker compose logs --tail=100 backend

--- a/backend/login_diagnostics.py
+++ b/backend/login_diagnostics.py
@@ -1,0 +1,96 @@
+"""Read-only, shareable login/mail status. Never sends mail or changes accounts.
+
+Run from checkout on the Docker host (no rebuild required):
+docker compose exec -T backend python - person@example.test < backend/login_diagnostics.py
+"""
+import argparse
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+
+from database import get_db
+from services.mail_queue import get_mail_settings
+
+
+def error_category(value):
+    """Classify locally; never output raw provider errors (may contain secrets)."""
+    text = str(value or "").lower()
+    if not text:
+        return None
+    for category, needles in (
+        ("disabled", ("deaktiviert", "disabled")),
+        ("missing_configuration", ("not configured", "no api key", "credentials")),
+        ("authentication", ("authentication", "authenticate", "535", "api key", "unauthorized")),
+        ("relay_denied", ("relay",)),
+        ("tls_certificate", ("certificate", "zertifikat")),
+        ("network", ("timeout", "timed out", "connection", "connect", "name resolution")),
+        ("sender_or_recipient", ("sender", "recipient", "550", "domain")),
+    ):
+        if any(needle in text for needle in needles):
+            return category
+    return "other_delivery_error"
+
+
+async def report(email):
+    db = get_db()
+    user = await db.users.find_one({"email": email.strip().lower()}, {
+        "_id": 0, "id": 1, "email_verified": 1, "is_active": 1,
+        "is_banned": 1, "mfa_enabled": 1, "password_setup_required": 1,
+    })
+    result = {
+        "schema": "tls.login-diagnostics.v1", "read_only": True,
+        "account_found": bool(user),
+        "scheduler_disabled": os.environ.get("DISABLE_SCHEDULER", "").lower() == "true",
+        "frontend_url_configured": bool(os.environ.get("FRONTEND_URL", "").strip()),
+    }
+    if user:
+        result["account"] = {key: user.get(key) for key in (
+            "email_verified", "is_active", "is_banned", "mfa_enabled", "password_setup_required",
+        )}
+        result["active_verification_links"] = await db.email_verification_tokens.count_documents({
+            "user_id": user["id"], "used": False,
+            "expires_at": {"$gt": datetime.now(timezone.utc)},
+        })
+    try:
+        cfg = await get_mail_settings()
+        result["mail"] = {
+            "enabled": bool(cfg["enabled"]),
+            "provider": cfg["provider"] if cfg["provider"] in {"smtp", "resend"} else "unknown",
+            "smtp_host_configured": bool(cfg.get("smtp_host")),
+            "smtp_user_configured": bool(cfg.get("smtp_user")),
+            "smtp_password_configured": bool(cfg.get("smtp_pass")),
+            "resend_key_configured": bool(cfg.get("resend_api_key")),
+        }
+    except Exception:
+        result["mail"] = {"configuration_readable": False,
+                          "hint": "Check settings encryption key and mail configuration locally; do not share secrets."}
+    jobs = await db.mail_jobs.find({
+        "to": email.strip().lower(), "template_key": {"$in": ["email_verification", "password_reset"]},
+    }, {"_id": 0, "status": 1, "template_key": 1, "attempts": 1,
+        "created_at": 1, "next_attempt_at": 1, "last_error": 1}).sort("created_at", -1).limit(5).to_list(5)
+    result["recent_auth_mail"] = [{
+        "status": job.get("status"), "template": job.get("template_key"),
+        "attempts": job.get("attempts"), "created_at": job.get("created_at"),
+        "next_attempt_at": job.get("next_attempt_at"),
+        "error_category": error_category(job.get("last_error")),
+    } for job in jobs]
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("email", help="Account email; output omits the address and all secrets")
+    args = parser.parse_args()
+    try:
+        result = asyncio.run(asyncio.wait_for(report(args.email), timeout=20))
+    except Exception:
+        print(json.dumps({"read_only": True, "error": "diagnostic_unavailable",
+                          "hint": "Run inside the backend container with database access."}))
+        return 1
+    print(json.dumps(result, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -13,7 +13,7 @@ from auth import (
     set_auth_cookies, clear_auth_cookies, get_current_user, get_optional_user, _decode,
     hash_token, refresh_expires_at, as_utc_datetime,
 )
-from email_service import send_template
+from email_service import send_template, _site_base_url
 from models import (
     UserRegister, UserLogin, ForgotPasswordBody, ResetPasswordBody, ChangePasswordBody,
     now_utc, new_id,
@@ -137,10 +137,9 @@ async def _record_registration_consents(
 async def _send_email_verification(db, user: dict) -> None:
     token = secrets.token_urlsafe(32)
     now = now_utc()
-    await db.email_verification_tokens.update_many(
-        {"user_id": user["id"], "used": False},
-        {"$set": {"used": True, "invalidated_at": now}},
-    )
+    # Keep earlier, unexpired links usable until one is redeemed. A public
+    # resend request (or a delayed/failed mail) must not invalidate the link
+    # already in the account owner's inbox. verify_email consumes all links.
     await db.email_verification_tokens.insert_one({
         "id": new_id(),
         "token_hash": hash_token(token),
@@ -149,8 +148,8 @@ async def _send_email_verification(db, user: dict) -> None:
         "created_at": now,
         "expires_at": now + timedelta(hours=24),
     })
-    frontend = os.environ.get("FRONTEND_URL", "").rstrip("/")
-    verification_url = f"{frontend}/verify-email?token={token}" if frontend else f"/verify-email?token={token}"
+    frontend = await _site_base_url()
+    verification_url = f"{frontend}/verify-email?token={token}"
     await send_template(
         "email_verification",
         user["email"],
@@ -631,7 +630,11 @@ async def login(body: UserLogin, request: Request, response: Response):
     if user.get("is_banned"):
         raise HTTPException(status_code=403, detail="Account gesperrt")
     if user.get("email_verified") is False:
-        raise HTTPException(status_code=403, detail="E-Mail-Adresse noch nicht bestätigt. Bitte prüfe dein Postfach.")
+        raise HTTPException(
+            status_code=403,
+            detail="E-Mail-Adresse noch nicht bestätigt. Bitte fordere einen Bestätigungslink an. Das ist auch für bestehende Konten erforderlich.",
+            headers={"X-Auth-Error": "email_verification_required"},
+        )
 
     await _clear_failed(db, identifier)
     if _requires_admin_mfa(user):
@@ -908,7 +911,11 @@ async def mobile_login(body: UserLogin, request: Request):
     if user.get("is_banned"):
         raise HTTPException(status_code=403, detail="Account gesperrt")
     if user.get("email_verified") is False:
-        raise HTTPException(status_code=403, detail="E-Mail-Adresse noch nicht bestätigt. Bitte prüfe dein Postfach.")
+        raise HTTPException(
+            status_code=403,
+            detail="E-Mail-Adresse noch nicht bestätigt. Bitte fordere einen Bestätigungslink an. Das ist auch für bestehende Konten erforderlich.",
+            headers={"X-Auth-Error": "email_verification_required"},
+        )
 
     await _clear_failed(db, identifier)
     if _requires_admin_mfa(user):
@@ -1089,9 +1096,9 @@ async def resend_verification(body: ForgotPasswordBody, request: Request):
     await enforce_rate_limit(request, "auth:verify-resend:ip", limit=6, window_seconds=3600)
     await enforce_rate_limit(request, "auth:verify-resend:email", limit=3, window_seconds=3600, subject=email)
     user = await db.users.find_one({"email": email})
-    if user and user.get("email_verified") is False and user.get("is_active") is not False:
+    if user and user.get("email_verified") is False and user.get("is_active") is not False and not user.get("is_banned"):
         await _send_email_verification(db, user)
-    return {"ok": True, "message": "Falls eine Bestätigung aussteht, wurde ein neuer Link gesendet."}
+    return {"ok": True, "message": "Falls eine Bestätigung aussteht, wurde der Versand angefordert. Bitte prüfe in einigen Minuten dein Postfach und den Spam-Ordner."}
 
 
 @router.post("/verify-email")

--- a/backend/tests/test_login_verification_recovery_unit.py
+++ b/backend/tests/test_login_verification_recovery_unit.py
@@ -1,0 +1,125 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import HTTPException, Response
+
+from routes import auth_routes as routes
+from login_diagnostics import error_category
+import login_diagnostics
+
+
+@pytest.mark.parametrize("endpoint", [routes.login, routes.mobile_login])
+@pytest.mark.parametrize("mfa", [False, True])
+def test_unverified_existing_account_cannot_skip_verification(monkeypatch, endpoint, mfa):
+    db = SimpleNamespace(users=SimpleNamespace(find_one=AsyncMock(return_value={
+        "id": "existing", "email_verified": False, "password_hash": "hash",
+        "role": "superadmin", "mfa_enabled": mfa,
+    })))
+    monkeypatch.setattr(routes, "get_db", lambda: db)
+    monkeypatch.setattr(routes, "load_auth_settings", AsyncMock(return_value={"password_login_enabled": True}))
+    monkeypatch.setattr(routes, "_check_brute_force", AsyncMock())
+    monkeypatch.setattr(routes, "_client_identifier", lambda *_: "test")
+    monkeypatch.setattr(routes, "verify_password", lambda *_: True)
+    challenge = AsyncMock()
+    monkeypatch.setattr(routes, "_create_mfa_login_challenge", challenge)
+    body = SimpleNamespace(email="existing@example.test", password="test")
+    args = (body, Mock(), Response()) if endpoint is routes.login else (body, Mock())
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(endpoint(*args))
+    assert exc.value.status_code == 403
+    assert exc.value.headers["X-Auth-Error"] == "email_verification_required"
+    challenge.assert_not_awaited()
+
+
+def test_resend_keeps_previous_links_and_uses_absolute_site_url(monkeypatch):
+    tokens = SimpleNamespace(insert_one=AsyncMock(), update_many=AsyncMock())
+    send = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(routes, "send_template", send)
+    monkeypatch.setattr(routes, "_site_base_url", AsyncMock(return_value="https://club.example"))
+    asyncio.run(routes._send_email_verification(
+        SimpleNamespace(email_verification_tokens=tokens),
+        {"id": "existing", "email": "existing@example.test"},
+    ))
+    tokens.update_many.assert_not_awaited()
+    doc = tokens.insert_one.call_args.args[0]
+    assert "token" not in doc and doc["token_hash"]
+    assert send.call_args.kwargs["verification_url"].startswith("https://club.example/verify-email?token=")
+
+
+@pytest.mark.parametrize("endpoint", [routes.login, routes.mobile_login])
+def test_verified_admin_still_requires_mfa(monkeypatch, endpoint):
+    user = {"id": "existing", "email_verified": True, "password_hash": "hash",
+            "role": "superadmin", "mfa_enabled": True}
+    db = SimpleNamespace(users=SimpleNamespace(find_one=AsyncMock(return_value=user)))
+    monkeypatch.setattr(routes, "get_db", lambda: db)
+    monkeypatch.setattr(routes, "load_auth_settings", AsyncMock(return_value={"password_login_enabled": True}))
+    monkeypatch.setattr(routes, "_check_brute_force", AsyncMock())
+    monkeypatch.setattr(routes, "_clear_failed", AsyncMock())
+    monkeypatch.setattr(routes, "_client_identifier", lambda *_: "test")
+    monkeypatch.setattr(routes, "verify_password", lambda *_: True)
+    challenge = AsyncMock(return_value={"mfa_required": True, "mfa_ticket": "test-ticket"})
+    monkeypatch.setattr(routes, "_create_mfa_login_challenge", challenge)
+    issue = AsyncMock()
+    monkeypatch.setattr(routes, "_issue_session", issue)
+    monkeypatch.setattr(routes, "_issue_mobile_session", issue)
+    body = SimpleNamespace(email="existing@example.test", password="test")
+    args = (body, Mock(), Response()) if endpoint is routes.login else (body, Mock())
+    result = asyncio.run(endpoint(*args))
+    assert result["mfa_required"] is True
+    assert challenge.await_args.args[-1] == ("web" if endpoint is routes.login else "mobile")
+    issue.assert_not_awaited()
+
+
+@pytest.mark.parametrize("user,send_count", [
+    (None, 0), ({"email_verified": True}, 0),
+    ({"email_verified": False, "is_banned": True}, 0),
+    ({"email_verified": False, "is_active": False}, 0),
+    ({"email_verified": False, "is_active": True}, 1),
+])
+def test_resend_returns_same_truthful_response(monkeypatch, user, send_count):
+    monkeypatch.setattr(routes, "get_db", lambda: SimpleNamespace(users=SimpleNamespace(find_one=AsyncMock(return_value=user))))
+    monkeypatch.setattr(routes, "enforce_rate_limit", AsyncMock())
+    send = AsyncMock()
+    monkeypatch.setattr(routes, "_send_email_verification", send)
+    response = asyncio.run(routes.resend_verification(SimpleNamespace(email="existing@example.test"), Mock()))
+    assert response == {"ok": True, "message": "Falls eine Bestätigung aussteht, wurde der Versand angefordert. Bitte prüfe in einigen Minuten dein Postfach und den Spam-Ordner."}
+    assert send.await_count == send_count
+
+
+@pytest.mark.parametrize("raw,category", [
+    ("535 Authentication failed password=private", "authentication"),
+    ("Relay access denied for private@example.test", "relay_denied"),
+    ("CERTIFICATE_VERIFY_FAILED", "tls_certificate"),
+    ("Unexpected provider output token=private", "other_delivery_error"),
+    (None, None),
+])
+def test_diagnostics_never_return_raw_delivery_errors(raw, category):
+    assert error_category(raw) == category
+
+
+def test_diagnostic_report_omits_identifiers_credentials_and_mail_content(monkeypatch):
+    import json
+    cursor = Mock()
+    cursor.sort.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=[{
+        "status": "failed", "template_key": "email_verification", "attempts": 2,
+        "last_error": "535 Authentication failed: private-password",
+        "html": "private-token", "to": "private@example.test",
+    }])
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={"id": "private-id", "email_verified": False})),
+        email_verification_tokens=SimpleNamespace(count_documents=AsyncMock(return_value=1)),
+        mail_jobs=SimpleNamespace(find=Mock(return_value=cursor)),
+    )
+    monkeypatch.setattr(login_diagnostics, "get_db", lambda: db)
+    monkeypatch.setattr(login_diagnostics, "get_mail_settings", AsyncMock(return_value={
+        "provider": "smtp", "enabled": True, "smtp_pass": "private-password",
+        "resend_api_key": "private-key", "smtp_user": "private-user",
+    }))
+    result = asyncio.run(login_diagnostics.report("private@example.test"))
+    assert "private" not in json.dumps(result)
+    assert result["read_only"] is True
+    assert result["recent_auth_mail"][0]["error_category"] == "authentication"

--- a/frontend/e2e/login-recovery.spec.js
+++ b/frontend/e2e/login-recovery.spec.js
@@ -1,0 +1,80 @@
+const { test, expect } = require("@playwright/test");
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/**", (route) => route.fulfill({
+    contentType: "application/json", body: JSON.stringify({}),
+  }));
+  await page.route("**/api/auth/me", (route) => route.fulfill({
+    contentType: "application/json", body: "null",
+  }));
+  await page.addInitScript(() => localStorage.setItem("tls_cookie_consent", "all"));
+});
+
+async function dismissCookies(page) {
+  const button = page.getByRole("button", { name: /alle akzeptieren/i });
+  if (await button.count()) await button.click();
+}
+
+test("existing unverified account has a recovery path without re-registration", async ({ page }) => {
+  // The old API message remains supported during rolling updates.
+  await page.route("**/api/auth/login", (route) => route.fulfill({
+    status: 403, contentType: "application/json",
+    body: JSON.stringify({ detail: "E-Mail-Adresse noch nicht bestätigt. Bitte prüfe dein Postfach." }),
+  }));
+  await page.goto("/login");
+  await dismissCookies(page);
+  await page.getByTestId("login-email").fill("existing@example.test");
+  await page.getByTestId("login-password").fill("existing-password");
+  await page.getByTestId("login-submit").click();
+  await expect(page.getByTestId("login-verification-recovery")).toBeVisible();
+  await page.getByRole("link", { name: "Bestätigungslink anfordern", exact: true }).click();
+  await expect(page.locator("#verify-email")).toHaveValue("existing@example.test");
+  expect(new URL(page.url()).search).toBe("");
+  await expect(page.locator("#verify-sent")).toHaveCount(0);
+
+  let sends = 0;
+  await page.route("**/api/auth/resend-verification", async (route) => {
+    sends += 1;
+    expect(route.request().postDataJSON()).toEqual({ email: "existing@example.test" });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await route.fulfill({ contentType: "application/json", body: '{"ok":true}' });
+  });
+  await page.getByTestId("verify-resend-submit").evaluate((button) => {
+    button.form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    button.form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  });
+  await expect(page.locator("#verify-sent")).toContainText("Versand angefordert");
+  expect(sends).toBe(1);
+  await expect(page.getByText(/muss der Betreiber die Mail-Warteschlange/)).toBeVisible();
+});
+
+test("verification request errors remain visible and allow retry", async ({ page }) => {
+  await page.route("**/api/auth/resend-verification", (route) => route.fulfill({
+    status: 429, contentType: "application/json", body: JSON.stringify({ detail: "Bitte später erneut versuchen." }),
+  }));
+  await page.goto("/verify-email");
+  await dismissCookies(page);
+  await page.locator("#verify-email").fill("existing@example.test");
+  await page.getByTestId("verify-resend-submit").click();
+  await expect(page.locator("#verify-error")).toContainText("Bitte später erneut versuchen.");
+  await expect(page.getByTestId("verify-resend-submit")).toBeEnabled();
+  await expect(page.locator("#verify-sent")).toHaveCount(0);
+});
+
+test("MFA supports recovery-code letters and clean restart after expired challenge", async ({ page }) => {
+  await page.addInitScript(() => sessionStorage.setItem("tls.mfa.ticket", "expired-test-ticket"));
+  await page.route("**/api/auth/mfa/complete", (route) => route.fulfill({
+    status: 401, contentType: "application/json", body: JSON.stringify({ detail: "MFA-Anmeldung ist ungültig oder abgelaufen." }),
+  }));
+  await page.goto("/login");
+  await dismissCookies(page);
+  const code = page.getByTestId("login-mfa-code");
+  await expect(code).toHaveAttribute("inputmode", "text");
+  await code.fill("ABCD-EFGH");
+  await page.getByTestId("login-mfa-submit").click();
+  await expect(page.locator("#login-error")).toContainText("abgelaufen");
+  await page.getByRole("button", { name: "Zurück zum Login" }).click();
+  await expect(page.getByTestId("login-email")).toBeVisible();
+  await expect(page.locator("#login-error")).toHaveCount(0);
+  expect(await page.evaluate(() => sessionStorage.getItem("tls.mfa.ticket"))).toBeNull();
+});

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -93,7 +93,14 @@ export function AuthProvider({ children }) {
     } catch (e) {
       const msg = formatApiError(e.response?.data?.detail) || e.message;
       setError(msg);
-      return { ok: false, error: msg };
+      return {
+        ok: false,
+        error: msg,
+        verificationRequired: e.response?.status === 403 && (
+          e.response?.headers?.["x-auth-error"] === "email_verification_required"
+          || /^E-Mail-Adresse noch nicht bestätigt\./.test(msg)
+        ),
+      };
     }
   };
 

--- a/frontend/src/pages/public/EmailVerificationPage.jsx
+++ b/frontend/src/pages/public/EmailVerificationPage.jsx
@@ -1,16 +1,19 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { api, formatApiError } from "@/lib/api";
 import { Logo } from "@/components/tls/Logo";
 import { AuthFormAlert, AuthTextField } from "@/components/tls/AuthFormFields";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useSubmissionGuard } from "@/hooks/useSubmissionGuard";
 
 export default function EmailVerificationPage() {
   useDocumentTitle("E-Mail bestätigen", "E-Mail-Adresse für den Community-Account bestätigen.", { robots: "noindex, nofollow" });
   const [params] = useSearchParams();
+  const location = useLocation();
+  const { submitting, submitOnce } = useSubmissionGuard();
   const token = params.get("token") || "";
-  const [email, setEmail] = useState(params.get("email") || "");
-  const [status, setStatus] = useState(token ? "checking" : "sent");
+  const [email, setEmail] = useState(location.state?.email || params.get("email") || "");
+  const [status, setStatus] = useState(token ? "checking" : params.get("sent") === "1" ? "sent" : "idle");
   const [message, setMessage] = useState("");
   const handled = useRef(false);
 
@@ -31,14 +34,14 @@ export default function EmailVerificationPage() {
   const resend = async (event) => {
     event.preventDefault();
     if (!email.trim()) return;
-    setStatus("checking");
-    try {
-      await api.post("/auth/resend-verification", { email: email.trim() });
+    const attempt = await submitOnce(() => api.post("/auth/resend-verification", { email: email.trim() }));
+    if (!attempt.started) return;
+    if (!attempt.error) {
       setStatus("sent");
-      setMessage("Falls eine Bestätigung aussteht, wurde ein neuer Link gesendet.");
-    } catch (error) {
+      setMessage("Falls eine Bestätigung aussteht, wurde der Versand angefordert. Bitte prüfe in einigen Minuten dein Postfach und den Spam-Ordner.");
+    } else {
       setStatus("error");
-      setMessage(formatApiError(error.response?.data?.detail) || "Der Link konnte nicht gesendet werden.");
+      setMessage(attempt.error.response?.data?.detail ? formatApiError(attempt.error.response.data.detail) : "Der Versand konnte nicht angefordert werden. Bitte versuche es erneut.");
     }
   };
 
@@ -47,18 +50,19 @@ export default function EmailVerificationPage() {
       <div className="w-full max-w-md border border-white/10 rounded-sm bg-[#121212] p-8 md:p-10">
         <div className="flex justify-center mb-8"><Logo size="xl" /></div>
         <h1 className="font-heading text-2xl font-black uppercase text-center">E-Mail bestätigen</h1>
-        <p className="text-sm text-white/60 text-center mt-2">Öffne den Link aus deiner E-Mail, bevor du dich anmeldest.</p>
+        <p className="text-sm text-white/60 text-center mt-2">Auch ein bestehendes Konto kann nach einem Sicherheitsupdate eine E-Mail-Bestätigung benötigen. Dein Konto und dein Passwort bleiben erhalten.</p>
         <div className="mt-6">
           {status === "checking" && <AuthFormAlert id="verify-status" tone="info">Bestätigung wird geprüft …</AuthFormAlert>}
           {status === "success" && <AuthFormAlert id="verify-success" tone="success">{message}</AuthFormAlert>}
           {status === "error" && <AuthFormAlert id="verify-error">{message}</AuthFormAlert>}
-          {status === "sent" && <AuthFormAlert id="verify-sent" tone="success">{message || "Bitte prüfe dein Postfach und auch den Spam-Ordner."}</AuthFormAlert>}
+          {status === "sent" && <AuthFormAlert id="verify-sent" tone="info">{message || "Der Versand wurde angefordert. Bitte prüfe in einigen Minuten dein Postfach und den Spam-Ordner."}</AuthFormAlert>}
+          {status === "sent" && <p className="mt-3 text-sm text-white/70">Noch keine Mail? Wiederholtes Einloggen versendet keine Bestätigung. Prüfe die Adresse unten und fordere den Link einmal erneut an. Bleibt die Mail aus, muss der Betreiber die Mail-Warteschlange und den Versand prüfen.</p>}
         </div>
         {status !== "success" && (
           <form onSubmit={resend} className="mt-6 space-y-3">
             <AuthTextField id="verify-email" label="E-Mail" type="email" value={email} onChange={setEmail} autoComplete="email" required />
-            <button type="submit" disabled={status === "checking"} className="w-full py-3 border border-[#29B6E8]/50 text-[#29B6E8] font-bold uppercase rounded-sm disabled:opacity-50">
-              Bestätigungslink erneut senden
+            <button type="submit" disabled={submitting || status === "checking"} className="w-full py-3 border border-[#29B6E8]/50 text-[#29B6E8] font-bold uppercase rounded-sm disabled:opacity-50" data-testid="verify-resend-submit">
+              {submitting ? "Versand wird angefordert …" : "Bestätigungslink anfordern"}
             </button>
           </form>
         )}

--- a/frontend/src/pages/public/LoginPage.jsx
+++ b/frontend/src/pages/public/LoginPage.jsx
@@ -27,10 +27,12 @@ export default function LoginPage() {
   const { submitting: loading, submitOnce } = useSubmissionGuard();
   const [err, setErr] = useState(null);
   const [fieldErrors, setFieldErrors] = useState({});
+  const [verificationRequired, setVerificationRequired] = useState(false);
 
   const setField = (field, setter) => (value) => {
     setter(value);
     setErr(null);
+    setVerificationRequired(false);
     setFieldErrors((current) => ({ ...current, [field]: null }));
   };
 
@@ -87,6 +89,7 @@ export default function LoginPage() {
       nav(next);
     } else {
       setErr(res.error);
+      setVerificationRequired(!!res.verificationRequired);
     }
   };
 
@@ -105,7 +108,7 @@ export default function LoginPage() {
               value={mfaCode}
               onChange={(value) => { setMfaCode(value); setErr(null); }}
               autoComplete="one-time-code"
-              inputMode="numeric"
+              inputMode="text"
               required
               testId="login-mfa-code"
             />
@@ -113,7 +116,7 @@ export default function LoginPage() {
             <button disabled={loading} type="submit" className="w-full py-3 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm disabled:opacity-50" data-testid="login-mfa-submit">
               {loading ? "Prüfe …" : "Anmeldung bestätigen"}
             </button>
-            <button type="button" onClick={() => { setMfaTicket(""); sessionStorage.removeItem("tls.mfa.ticket"); }} className="w-full text-xs text-white/45 hover:text-white">Zurück</button>
+            <button type="button" disabled={loading} onClick={() => { setMfaTicket(""); setMfaCode(""); setErr(null); sessionStorage.removeItem("tls.mfa.ticket"); }} className="w-full text-xs text-white/45 hover:text-white">Zurück zum Login</button>
           </form>
         ) : settings.password_login_enabled !== false ? <form onSubmit={submit} className="mt-8 space-y-4" noValidate aria-describedby={err ? "login-error" : undefined}>
           <AuthTextField
@@ -140,6 +143,12 @@ export default function LoginPage() {
             testId="login-password"
           />
           {err && <AuthFormAlert id="login-error">{err}</AuthFormAlert>}
+          {verificationRequired && (
+            <div className="space-y-2 text-sm" data-testid="login-verification-recovery">
+              <p className="text-white/70">Dein Konto bleibt bestehen. Bestätige zuerst deine E-Mail-Adresse; danach meldest du dich mit deinem bisherigen Passwort und gegebenenfalls MFA an.</p>
+              <Link to="/verify-email" state={{ email: email.trim() }} className="inline-block py-2 text-[#29B6E8] underline">Bestätigungslink anfordern</Link>
+            </div>
+          )}
           <button
             data-testid="login-submit"
             disabled={loading}
@@ -159,6 +168,7 @@ export default function LoginPage() {
             <div>Kein Account? <Link to="/register" className="text-[#29B6E8] hover:text-white font-bold">Registrieren</Link></div>
           )}
           <div><Link to="/forgot-password" className="text-white/45 hover:text-[#29B6E8]">Passwort vergessen?</Link></div>
+          <div><Link to="/verify-email" state={{ email: email.trim() }} className="text-white/60 hover:text-[#29B6E8]">Keine Bestätigungs-E-Mail erhalten?</Link></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Bestehende Passwort-Konten mit email_verified=false erhalten im Login einen klaren Bestätigungsweg. Resend-Mehrfachschutz, korrekte Versandmeldung, Erhalt gültiger Links, MFA-Recovery-Code-Tastatur und sauberer Neustart ergänzt. Read-only Login-/Maildiagnose ohne Geheimnisse und UPDATE-Anleitung. Keine automatische Freischaltung, keine MFA-Abschaltung, keine App-Änderungen. Lokal: 399 Backend-Tests erfolgreich (19 skipped, 277 live deselected), 17 Frontend-Tests, 6 Browser-Tests Desktop/Handy, Produktionsbuild und Secret-Scan erfolgreich. Nutzer bestätigt inzwischen Mail-Eingang nach Anforderung über /verify-email; abschließender Konto-Login noch vom Nutzer zu testen.