### PR TITLE
feat(servers): configurable game icons and optional mod downloads

### DIFF
--- a/ADMIN_GUIDE.md
+++ b/ADMIN_GUIDE.md
@@ -333,6 +333,36 @@ Sichtbarkeit:
 
 Oeffentliche Profile zeigen nur Felder, die wirklich oeffentlich freigegeben sind.
 
+## Gameserver: Spielelogos und Modded-Einrichtung
+
+Unter **Admin → Game-Server → Bearbeiten**:
+
+1. Bei **Spiel-Verknüpfung** das passende Spiel auswählen. Dessen Logo erscheint
+   automatisch in der Vorschau und auf der Serverkarte. Fehlt es, zuerst unter
+   **Admin → Spiele** ein Logo hochladen. Bestehende Server werden nicht anhand
+   ähnlich klingender Namen automatisch zugeordnet.
+2. **Spiel-/Server-Icon anzeigen** schaltet das Bild ein/aus. Ein optionales eigenes
+   Server-Icon überschreibt das Spielelogo. Bei einem defekten Bild wird auf das
+   Spielelogo bzw. das allgemeine Server-Symbol zurückgefallen.
+3. Für modifizierte Server **Modded / Mods & Einrichtung anzeigen** aktivieren.
+   Optional kurze Installationshinweise hinterlegen.
+4. Über **Link hinzufügen** bis zu acht Einträge anlegen: Modloader, Modpaket,
+   Konfiguration oder Anleitung. Jeweils HTTPS-Adresse, optional Bezeichnung und
+   Version eintragen und **Link anzeigen** aktivieren.
+5. Speichern. Auf `/servers` erscheint der kompakte Bereich **Mods & Einrichtung**
+   zum Aufklappen. Bei Vanilla-Servern bleibt er ausgeschaltet.
+
+Einzelne Links und der gesamte Modding-Bereich lassen sich ohne Datenverlust
+ausschalten. Deaktivierte Links werden nur in der geschützten Adminantwort, nicht
+in der öffentlichen Serverlisten-API geliefert. Sichtbare Links folgen den
+bestehenden Serverrechten (öffentlich, Community, Mitglieder, intern).
+
+Nur vertrauenswürdige Downloadquellen eintragen. Die Webseite lädt oder installiert
+keine Mods selbst und prüft nicht, ob die Dateien zueinander passen. Keine Secrets,
+RCON-Passwörter oder privaten Server-Konfigurationsdateien verlinken. Die
+Mitgliedersichtbarkeit schützt die Anzeige des Links, nicht die externe Datei:
+Das Download-Ziel braucht für private Dateien einen eigenen Zugriffsschutz.
+
 ## Was sparsam genutzt werden sollte
 
 - zu viele Animationen

--- a/RESTPLAN.md
+++ b/RESTPLAN.md
@@ -1,20 +1,31 @@
 # Verbindlicher Restplan
 
 Stand: 8. September 2026. Sicherheitsbasis: PR #152, Wartung PR #153 (`e06e509`),
-Login-Wiederherstellung PR #154 (`216eb6c`). Dokumentationsübersicht: [DOCS.md](DOCS.md).
+Login-Wiederherstellung PR #154 (`216eb6c`), Website-Stabilisierung PR #155 (`df4711e`).
+Dokumentationsübersicht: [DOCS.md](DOCS.md).
+
+## Beauftragte Erweiterung: Gameserver
+
+Spielauswahl mit Icon-Vorschau und abschaltbarem Bild; optionaler Modded-Bereich
+mit einzeln schaltbaren HTTPS-Links für Loader, Modpakete, Konfigurationen und
+Anleitungen. Umsetzung und Regressionstests im Quellstand; echte Inhalte pflegt
+der Betreiber gemäß [ADMIN_GUIDE.md](ADMIN_GUIDE.md#gameserver-spielelogos-und-modded-einrichtung).
+Kein automatischer Download/Mod-Installationsdienst und kein Eingriff in laufende Gameserver.
 
 ## Aktuelle Priorität: gemeldete Produktivprobleme
 
 | Paket | Quellstand | Abnahme |
 | --- | --- | --- |
-| U1 – MongoDB-Update | Authentifizierte Prüfung vor einer möglichen Ersteinrichtung implementiert; Fehlerfälle lassen `.env` unverändert | Wiederholtes Update auf dem Server muss durchlaufen |
+| U1 – MongoDB-Update | Authentifizierte Prüfung implementiert; Fehlerfälle lassen `.env` unverändert | Betreiber meldet erfolgreichen Build/Containerstart und lokale Healthchecks |
 | U2 – Browser-Updates | Kein Cache für HTML/Update-Dateien, versionierter Worker, sichtbare Aktualisierung, öffentlicher Versionsvergleich implementiert | Proxy-Cache einmal korrigieren und Bestätigungslink ohne Strg+F5 testen |
 | U3 – Dashboard | Drei Hinweise als Vorschau; vollständige Liste aufklappbar und in der Höhe begrenzt | Desktop-/Handy-Ansicht bestätigen |
 | U4 – Passkeys | Einrichtung, Anmeldung, Entfernen, Signatur-/Origin-/Replay-Prüfung und Admin-MFA-Verknüpfung implementiert | Eigenen Passkey auf HTTPS einrichten, ausloggen und wieder anmelden |
 | U5 – Dokumentation | README gekürzt, Unterseitenindex und automatische Linkprüfung; obsolete Auth-Anleitung entfernt | Aktuelle CI und reale Betreiberabnahmen im Release festhalten |
 
-U1–U5 sind das aktuelle Arbeitspaket und noch keine Produktivfreigabe. Automatische
-Prüfungen und Integration müssen für diesen gemeinsamen Stand erfolgreich sein.
+U1–U5 wurden mit PR #155 integriert; Main-CI und CodeQL erfolgreich. Der Betreiber
+hat das Update ausgeführt. Lokale und öffentliche Release-Prüfung waren anschließend
+für Version `56d3241fb190ac592630` erfolgreich; beide Update-Dateien lieferten
+`no-store` und Cloudflare `BYPASS`. Das ersetzt nicht die persönliche Funktionsabnahme.
 Ein Bestätigungslink wurde laut Betreiber zugestellt; das Öffnen und der anschließende
 Login sind wegen des gemeldeten Seiten-/Cachefehlers noch nicht abgenommen.
 Die native App ist ausdrücklich pausiert. Die dort begonnenen SDK-Änderungen bleiben
@@ -29,7 +40,8 @@ Lokale Nachweise für U1–U5 am 8. September 2026:
   Browser-Authenticator; sie ersetzen nicht den Test mit deinem eigenen Gerät.
 - Python-Abhängigkeitsaudit ohne bekannte Schwachstellen, Secret-Scan erfolgreich;
   30 Markdown-Dateien ohne fehlende lokale Linkziele.
-- Linux-/Container-CI und CodeQL müssen zusätzlich am integrierten Stand erfolgreich sein.
+- Linux-/Container-CI und CodeQL für PR #155 und Main erfolgreich; der finale
+  Browserlauf enthält 68 bestandene Tests einschließlich der MFA-Speicherhärtung.
 
 Dieser Plan bestimmt die Reihenfolge. Ältere Roadmaps bleiben als Historie erhalten;
 ihre Checkboxen sind weder ein aktueller Release-Nachweis noch automatisch neue Aufträge.

--- a/backend/routes/game_server_routes.py
+++ b/backend/routes/game_server_routes.py
@@ -3,9 +3,10 @@ import logging
 import os
 from datetime import datetime, timezone
 from typing import Literal, Optional
+from urllib.parse import urlsplit
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from auth import get_optional_user, require_club_admin
 from database import get_db
@@ -87,6 +88,11 @@ def _public_doc(server: dict, game: dict | None = None, include_admin_fields: bo
         doc["access_secret_masked"] = "••••••"
     if game:
         doc["game"] = game
+    if not include_admin_fields:
+        enabled = server.get("modding_enabled") is True
+        doc["mod_resources"] = [item for item in (server.get("mod_resources") or []) if enabled and item.get("enabled") is True]
+        if not enabled:
+            doc.pop("modding_notes", None)
     return doc
 
 
@@ -105,6 +111,41 @@ def _maintenance_active(server: dict) -> bool:
         return True
 
 
+class ServerModResource(BaseModel):
+    kind: Literal["modloader", "modpack", "config", "guide"] = "modloader"
+    enabled: bool = False
+    label: str = Field(default="", max_length=80)
+    version: str = Field(default="", max_length=80)
+    url: str = Field(default="", max_length=2000)
+
+    @field_validator("url")
+    @classmethod
+    def safe_download_url(cls, value):
+        value = value.strip()
+        if not value:
+            return value
+        try:
+            parsed = urlsplit(value)
+            valid = parsed.scheme == "https" and parsed.hostname and not parsed.username and not parsed.password
+            valid = valid and parsed.port != 0 and not any(char.isspace() or ord(char) < 32 for char in value) and "\\" not in value
+        except ValueError:
+            valid = False
+        if not valid:
+            raise ValueError("Bitte eine vollständige HTTPS-Adresse ohne Zugangsdaten verwenden.")
+        return value
+
+    @model_validator(mode="after")
+    def require_enabled_url(self):
+        if self.enabled and not self.url:
+            raise ValueError("Aktivierte Mod-Links benötigen eine HTTPS-Adresse.")
+        return self
+
+
+async def _validate_game(db, game_id):
+    if game_id and not await db.games.find_one({"id": game_id}, {"id": 1}):
+        raise HTTPException(400, "Das ausgewählte Spiel existiert nicht mehr. Bitte erneut auswählen.")
+
+
 class GameServerPayload(BaseModel):
     name: str = Field(min_length=2, max_length=160)
     slug: Optional[str] = Field(default=None, max_length=90)
@@ -119,6 +160,10 @@ class GameServerPayload(BaseModel):
     access_secret: Optional[str] = Field(default=None, max_length=300)
     access_label: Optional[str] = Field(default=None, max_length=80)
     server_icon_url: Optional[str] = Field(default=None, max_length=300)
+    show_game_icon: bool = True
+    modding_enabled: bool = False
+    modding_notes: str = Field(default="", max_length=1500)
+    mod_resources: list[ServerModResource] = Field(default_factory=list, max_length=8)
     map_url: Optional[str] = Field(default=None, max_length=300)
     external_status_url: Optional[str] = Field(default=None, max_length=300)
     password_hint: Optional[str] = Field(default=None, max_length=180)
@@ -154,6 +199,10 @@ class GameServerPatch(BaseModel):
     access_secret: Optional[str] = Field(default=None, max_length=300)
     access_label: Optional[str] = Field(default=None, max_length=80)
     server_icon_url: Optional[str] = Field(default=None, max_length=300)
+    show_game_icon: Optional[bool] = None
+    modding_enabled: Optional[bool] = None
+    modding_notes: Optional[str] = Field(default=None, max_length=1500)
+    mod_resources: Optional[list[ServerModResource]] = Field(default=None, max_length=8)
     map_url: Optional[str] = Field(default=None, max_length=300)
     external_status_url: Optional[str] = Field(default=None, max_length=300)
     password_hint: Optional[str] = Field(default=None, max_length=180)
@@ -265,6 +314,7 @@ async def diagnose_game_server_route(server_id: str, me: dict = Depends(require_
 async def create_game_server(body: GameServerPayload, me: dict = Depends(require_club_admin())):
     db = get_db()
     data = body.model_dump()
+    await _validate_game(db, data.get("game_id"))
     if data.get("access_secret"):
         data["access_secret"] = encrypt_secret(data["access_secret"])
     data["slug"] = await unique_slug(db.game_servers, data.get("slug") or data["name"], fallback="server", max_length=80)
@@ -296,6 +346,8 @@ async def update_game_server(server_id: str, body: GameServerPatch, me: dict = D
         "max_players", "query_host", "query_port", "rcon_port", "last_sync_error",
     }
     raw = body.model_dump(exclude_unset=True)
+    if "game_id" in raw:
+        await _validate_game(db, raw["game_id"])
     updates = {k: v for k, v in raw.items() if v is not None or k in nullable_fields}
     if updates.get("access_secret"):
         updates["access_secret"] = encrypt_secret(updates["access_secret"])

--- a/backend/tests/test_game_server_resources_unit.py
+++ b/backend/tests/test_game_server_resources_unit.py
@@ -1,0 +1,128 @@
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from auth import get_current_user, get_optional_user
+from routes import game_server_routes as routes
+
+
+class Documents:
+    def __init__(self, rows=()):
+        self.rows = deepcopy(list(rows))
+
+    def matches(self, row, query):
+        return all(row.get(key) in value["$in"] if isinstance(value, dict) else row.get(key) == value for key, value in query.items())
+
+    async def find_one(self, query, *_args):
+        return next((deepcopy(row) for row in self.rows if self.matches(row, query)), None)
+
+    async def insert_one(self, row):
+        self.rows.append(deepcopy(row))
+
+    async def update_one(self, query, update):
+        for row in self.rows:
+            if self.matches(row, query):
+                row.update(deepcopy(update["$set"]))
+
+    def find(self, query, *_args):
+        cursor = SimpleNamespace(to_list=AsyncMock(return_value=[deepcopy(row) for row in self.rows if self.matches(row, query)]))
+        cursor.sort = lambda *_args: cursor
+        return cursor
+
+
+@pytest.fixture
+def setup(monkeypatch):
+    game = {"id": "minecraft", "name": "Minecraft", "logo_url": "/api/static/uploads/game.png"}
+    db = SimpleNamespace(games=Documents([game]), game_servers=Documents())
+    monkeypatch.setattr(routes, "get_db", lambda: db)
+    monkeypatch.setattr(routes, "unique_slug", AsyncMock(return_value="modded-server"))
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[get_current_user] = lambda: {"id": "admin", "role": "superadmin", "mfa_enabled": True, "auth_mfa_verified": True}
+    app.dependency_overrides[get_optional_user] = lambda: None
+    with TestClient(app) as client:
+        yield client, db, app
+
+
+def resource(**overrides):
+    return {"kind": "modloader", "enabled": True, "label": "Loader", "version": "1.2", "url": "https://downloads.example/loader", **overrides}
+
+
+@pytest.mark.parametrize("url", ["javascript:alert(1)", "data:text/html,test", "file:///etc/passwd", "http://example.test/mod", "//example.test/mod", "https://user:password@example.test/mod", "https://example.test\\@evil.test", "https://example.test/\nmod", "https://example.test:99999/mod", "https://example.test:0/mod", "https://"])
+def test_unsafe_download_links_are_rejected_even_when_disabled(url):
+    with pytest.raises(ValidationError):
+        routes.ServerModResource(**resource(url=url, enabled=False))
+
+
+def test_enabled_link_requires_url_and_resource_count_is_bounded():
+    with pytest.raises(ValidationError):
+        routes.ServerModResource(**resource(url=""))
+    with pytest.raises(ValidationError):
+        routes.GameServerPayload(name="Test", mod_resources=[resource()] * 9)
+    assert routes.ServerModResource(enabled=False).url == ""
+    assert routes.ServerModResource(**resource(url=" https://downloads.example/mod.zip?version=1#install ")).url.startswith("https://")
+
+
+def test_legacy_server_defaults_and_disabled_public_data():
+    payload = routes.GameServerPayload(name="Legacy").model_dump()
+    assert payload["show_game_icon"] is True
+    assert payload["modding_enabled"] is False
+    original = {**payload, "modding_notes": "Draft instructions", "mod_resources": [resource()]}
+    public = routes._public_doc(original)
+    assert public["mod_resources"] == []
+    assert "modding_notes" not in public
+    assert routes._public_doc(original, include_admin_fields=True)["mod_resources"] == [resource()]
+    assert original["modding_notes"] == "Draft instructions"
+
+
+def test_create_edit_disable_and_reenable_roundtrip(setup):
+    client, db, _app = setup
+    payload = {"name": "Minecraft Modded", "game_id": "minecraft", "visibility": "public", "modding_enabled": True,
+               "modding_notes": "Install loader first.", "mod_resources": [resource(), resource(kind="config", enabled=False, url="https://downloads.example/draft")]}
+    created = client.post("/api/game-servers", json=payload)
+    assert created.status_code == 200
+    identifier = created.json()["id"]
+    public = client.get("/api/game-servers").json()["items"][0]
+    assert public["game"]["logo_url"].endswith("game.png")
+    assert len(public["mod_resources"]) == 1
+    assert "draft" not in str(public)
+    assert client.patch(f"/api/game-servers/{identifier}", json={"modding_enabled": False, "show_game_icon": False}).status_code == 200
+    assert client.get("/api/game-servers").json()["items"][0]["mod_resources"] == []
+    saved = client.get("/api/game-servers/admin").json()[0]
+    assert len(saved["mod_resources"]) == 2
+    assert saved["modding_notes"] == "Install loader first."
+    assert client.patch(f"/api/game-servers/{identifier}", json={"modding_enabled": True}).status_code == 200
+    assert len(client.get("/api/game-servers").json()["items"][0]["mod_resources"]) == 1
+    assert client.patch(f"/api/game-servers/{identifier}", json={"mod_resources": [], "modding_notes": "", "game_id": None}).status_code == 200
+    assert db.game_servers.rows[0]["mod_resources"] == []
+    assert db.game_servers.rows[0]["game_id"] is None
+
+
+def test_missing_game_rejected_without_writing(setup):
+    client, db, _app = setup
+    assert client.post("/api/game-servers", json={"name": "Test", "game_id": "missing"}).status_code == 400
+    assert db.game_servers.rows == []
+
+
+@pytest.mark.parametrize("role", ["player", "moderator", "tournament_admin"])
+def test_non_club_admin_cannot_publish_downloads(setup, role):
+    client, _db, app = setup
+    app.dependency_overrides[get_current_user] = lambda: {"id": "user", "role": role, "mfa_enabled": True, "auth_mfa_verified": True}
+    assert client.post("/api/game-servers", json={"name": "Test", "mod_resources": [resource()]}).status_code == 403
+    assert client.get("/api/game-servers/admin").status_code == 403
+
+
+@pytest.mark.parametrize("visibility,user,visible", [("public", None, True), ("community", None, False), ("community", {"id": "user"}, True), ("members", {"id": "user"}, False), ("members", {"id": "user", "is_club_member": True}, True), ("internal", {"id": "admin", "role": "superadmin"}, False)])
+def test_resource_visibility_follows_server_permissions(setup, visibility, user, visible):
+    client, db, app = setup
+    db.game_servers.rows = [{"id": "s1", "name": "Test", "visibility": visibility, "modding_enabled": True, "mod_resources": [resource()]}]
+    app.dependency_overrides[get_optional_user] = lambda: user
+    items = client.get("/api/game-servers").json()["items"]
+    assert len(items) == int(visible)
+    if visible:
+        assert items[0]["mod_resources"] == [resource()]

--- a/frontend/e2e/server-resources.spec.js
+++ b/frontend/e2e/server-resources.spec.js
@@ -1,0 +1,87 @@
+const { test, expect } = require("@playwright/test");
+
+const game = { id: "minecraft", name: "Minecraft", logo_url: "/assets/brand/tls-favicon.png" };
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/**", (route) => route.fulfill({ contentType: "application/json", body: "{}" }));
+  await page.route("**/api/sponsors**", (route) => route.fulfill({ contentType: "application/json", body: "[]" }));
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: "null" }));
+});
+
+async function dismissCookies(page) {
+  const button = page.getByRole("button", { name: /alle akzeptieren/i });
+  if (await button.count()) await button.click();
+}
+
+test("server cards show game icons and compact enabled mod links only", async ({ page }, testInfo) => {
+  const resources = [
+    { kind: "modloader", enabled: true, label: "Fabric", version: "1.2", url: "https://downloads.example/loader" },
+    { kind: "config", enabled: false, label: "Draft config", url: "https://downloads.example/draft" },
+    { kind: "guide", enabled: true, label: "Unsafe", url: "javascript:alert(1)" },
+  ];
+  await page.route("**/api/game-servers", (route) => route.fulfill({ contentType: "application/json", body: JSON.stringify({
+    items: [
+      { id: "modded", name: "Modded Server", game, status: "online", modding_enabled: true, modding_notes: "Install loader first.", mod_resources: resources },
+      { id: "vanilla", name: "Vanilla Server", game, status: "online", show_game_icon: false, modding_enabled: false, mod_resources: resources },
+      { id: "fallback", name: "Broken Icon Server", game, server_icon_url: "/broken-server-icon.png", status: "offline" },
+    ], summary: { total: 3, online: 2 },
+  }) }));
+  await page.route("**/broken-server-icon.png", (route) => route.fulfill({ status: 404, body: "" }));
+  await page.goto("/servers");
+  await dismissCookies(page);
+  const modded = page.locator("article").filter({ has: page.getByRole("heading", { name: "Modded Server", exact: true }) });
+  await expect(modded.getByRole("img", { name: "Minecraft-Logo" })).toHaveAttribute("src", new URL(game.logo_url, page.url()).href);
+  await expect(modded.getByText("Install loader first.")).not.toBeVisible();
+  await modded.locator("summary").click();
+  await expect(modded.getByText("Install loader first.")).toBeVisible();
+  await expect(modded.getByRole("link", { name: /Fabric/ })).toHaveAttribute("href", "https://downloads.example/loader");
+  await expect(modded.getByRole("link", { name: /Draft config|Unsafe/ })).toHaveCount(0);
+  const vanilla = page.locator("article").filter({ has: page.getByRole("heading", { name: "Vanilla Server", exact: true }) });
+  await expect(vanilla.getByTestId("server-mod-resources")).toHaveCount(0);
+  await expect(vanilla.locator("img")).toHaveCount(0);
+  const fallback = page.locator("article").filter({ has: page.getByRole("heading", { name: "Broken Icon Server", exact: true }) });
+  await fallback.scrollIntoViewIfNeeded();
+  await expect(fallback.locator("img")).toHaveAttribute("src", new URL(game.logo_url, page.url()).href);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath("server-resources.png"), fullPage: true });
+});
+
+test("admin selects a game, saves optional resources and disables them without losing configuration", async ({ page }) => {
+  let saved = null;
+  await page.route("**/api/auth/me", (route) => route.fulfill({ contentType: "application/json", body: JSON.stringify({ id: "admin", role: "superadmin", mfa_enabled: true, auth_mfa_verified: true }) }));
+  await page.route("**/api/games", (route) => route.fulfill({ contentType: "application/json", body: JSON.stringify([game]) }));
+  await page.route("**/api/game-servers**", (route) => {
+    if (["POST", "PATCH"].includes(route.request().method())) saved = { ...saved, ...route.request().postDataJSON(), id: "server-1" };
+    return route.fulfill({ contentType: "application/json", body: JSON.stringify(route.request().method() === "GET" ? (saved ? [saved] : []) : saved) });
+  });
+  await page.goto("/admin/game-servers");
+  await dismissCookies(page);
+  await page.getByRole("button", { name: "Server anlegen", exact: true }).click();
+  const form = page.locator("form");
+  await form.getByLabel("Name", { exact: true }).fill("Modded Testserver");
+  await form.getByLabel("Spiel-Verknüpfung").selectOption("minecraft");
+  await expect(form.getByTestId("server-game-icon").locator("img")).toHaveAttribute("src", new URL(game.logo_url, page.url()).href);
+  await form.getByLabel("Modded / Mods & Einrichtung anzeigen").check();
+  await form.getByLabel("Installationshinweise").fill("Install loader first.");
+  await form.getByRole("button", { name: "Link hinzufügen" }).click();
+  const row = form.getByTestId("mod-resource-row");
+  await row.getByLabel("Bezeichnung (optional)").fill("Fabric");
+  await row.getByLabel("HTTPS-Adresse").fill("https://downloads.example/loader");
+  await row.getByLabel("Link 1 anzeigen").check();
+  await form.getByRole("button", { name: "Speichern", exact: true }).click();
+  await expect(form).toHaveCount(0);
+  expect(saved.game_id).toBe("minecraft");
+  expect(saved.mod_resources[0]).toMatchObject({ enabled: true, kind: "modloader", label: "Fabric" });
+  await page.getByTitle("Bearbeiten", { exact: true }).click();
+  await expect(page.getByLabel("HTTPS-Adresse")).toHaveValue("https://downloads.example/loader");
+  await page.getByLabel("Modded / Mods & Einrichtung anzeigen").uncheck();
+  await expect(page.getByLabel("HTTPS-Adresse")).toBeDisabled();
+  await page.getByLabel("Spiel-/Server-Icon anzeigen").uncheck();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+  await page.getByRole("button", { name: "Speichern", exact: true }).click();
+  await expect(page.locator("form")).toHaveCount(0);
+  expect(saved.modding_enabled).toBe(false);
+  expect(saved.show_game_icon).toBe(false);
+  expect(saved.mod_resources[0].url).toBe("https://downloads.example/loader");
+  expect(saved.modding_notes).toBe("Install loader first.");
+});

--- a/frontend/src/components/tls/GameServerIcon.jsx
+++ b/frontend/src/components/tls/GameServerIcon.jsx
@@ -1,0 +1,16 @@
+import { useState } from "react";
+import { Server } from "lucide-react";
+import { resolveMediaUrl } from "@/lib/api";
+
+export function GameServerIcon({ server }) {
+  const [failed, setFailed] = useState([]);
+  const candidates = server.show_game_icon === false ? [] : [server.server_icon_url, server.game?.logo_url];
+  const icon = candidates.filter(Boolean).map(resolveMediaUrl).find((url) => !failed.includes(url));
+  return (
+    <div className="w-14 h-14 rounded-sm border border-white/10 bg-black/30 flex items-center justify-center overflow-hidden shrink-0" data-testid="server-game-icon">
+      {icon ? <img src={icon} alt={`${server.game?.name || server.game_name || "Server"}-Logo`} loading="lazy" referrerPolicy="no-referrer"
+        onError={() => setFailed((current) => [...current, icon])} className="w-full h-full object-contain p-2" />
+        : <Server aria-label="Server-Symbol" className="w-6 h-6 text-[#29B6E8]" />}
+    </div>
+  );
+}

--- a/frontend/src/lib/serverResources.js
+++ b/frontend/src/lib/serverResources.js
@@ -1,0 +1,9 @@
+export const serverResourceLabels = { modloader: "Modloader", modpack: "Modpaket", config: "Konfiguration", guide: "Anleitung" };
+
+export function safeResourceUrl(value) {
+  if (typeof value !== "string" || /[\s\\\u0000-\u001f]/.test(value)) return "";
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && !url.username && !url.password ? url.href : "";
+  } catch { return ""; }
+}

--- a/frontend/src/lib/serverResources.test.js
+++ b/frontend/src/lib/serverResources.test.js
@@ -1,0 +1,9 @@
+import { safeResourceUrl } from "./serverResources";
+
+test.each(["javascript:alert(1)", "data:text/html,test", "http://example.test/mod", "//example.test/mod", "https://user:secret@example.test/mod", "https://example.test/\nmod", "https://example.test\\@evil.test", "", null])("unsafe mod link is not rendered: %s", (url) => {
+  expect(safeResourceUrl(url)).toBe("");
+});
+
+test("HTTPS download URLs retain their version and fragment", () => {
+  expect(safeResourceUrl("https://example.test/mod.zip?v=2#install")).toBe("https://example.test/mod.zip?v=2#install");
+});

--- a/frontend/src/pages/admin/AdminGameServersPage.jsx
+++ b/frontend/src/pages/admin/AdminGameServersPage.jsx
@@ -5,6 +5,9 @@ import { AdminLayout } from "@/components/tls/AdminLayout";
 import { api, formatApiError } from "@/lib/api";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useConfirm } from "@/components/tls/ConfirmDialog";
+import { Link } from "react-router-dom";
+import { GameServerIcon } from "@/components/tls/GameServerIcon";
+import { serverResourceLabels } from "@/lib/serverResources";
 
 const emptyForm = {
   name: "",
@@ -20,6 +23,10 @@ const emptyForm = {
   access_secret: "",
   access_label: "",
   server_icon_url: "",
+  show_game_icon: true,
+  modding_enabled: false,
+  modding_notes: "",
+  mod_resources: [],
   map_url: "",
   external_status_url: "",
   password_hint: "",
@@ -72,6 +79,7 @@ function toForm(server) {
     ...emptyForm,
     ...server,
     game_id: server.game_id || "",
+    mod_resources: server.mod_resources || [],
     max_players: server.max_players ?? "",
     query_host: server.query_host || "",
     query_port: server.query_port ?? "",
@@ -98,6 +106,13 @@ function toPayload(form) {
     access_secret: form.access_secret || undefined,
     access_label: form.access_label || null,
     server_icon_url: form.server_icon_url || null,
+    show_game_icon: form.show_game_icon !== false,
+    modding_enabled: !!form.modding_enabled,
+    modding_notes: form.modding_notes || "",
+    mod_resources: form.mod_resources.map((item) => ({
+      kind: item.kind, enabled: !!item.enabled, label: (item.label || "").trim(),
+      version: (item.version || "").trim(), url: (item.url || "").trim(),
+    })),
     map_url: form.map_url || null,
     external_status_url: form.external_status_url || null,
     password_hint: form.password_hint || null,
@@ -170,6 +185,9 @@ export default function AdminGameServersPage() {
   };
 
   const set = (key, value) => setForm((prev) => ({ ...prev, [key]: value }));
+  const setResource = (index, key, value) => setForm((prev) => ({ ...prev,
+    mod_resources: prev.mod_resources.map((item, position) => position === index ? { ...item, [key]: value } : item),
+  }));
 
   const save = async (event) => {
     event.preventDefault();
@@ -322,7 +340,8 @@ export default function AdminGameServersPage() {
               <span className="text-[11px] uppercase tracking-widest text-white/45 font-bold">Spiel-Verknüpfung</span>
               <select value={form.game_id} onChange={(e) => set("game_id", e.target.value)} className="mt-1 w-full bg-[#0A0A0A] border border-white/10 rounded-sm px-3 py-2 text-sm">
                 <option value="">Keine Verknüpfung</option>
-                {games.map((game) => <option key={game.id} value={game.id}>{game.short_name || game.name}</option>)}
+                {form.game_id && !games.some((game) => game.id === form.game_id) && <option value={form.game_id}>Spiel nicht verfügbar – bitte neu auswählen</option>}
+                {games.map((game) => <option key={game.id} value={game.id}>{game.display_name || game.name}</option>)}
               </select>
             </label>
             <Field label="Spielname fallback" value={form.game_name} onChange={(v) => set("game_name", v)} placeholder="z.B. Rust" />
@@ -361,7 +380,18 @@ export default function AdminGameServersPage() {
             {form.access_secret_kind !== "none" && (
               <Field label="Zugangs-Hinweis" value={form.access_label} onChange={(v) => set("access_label", v)} placeholder="z.B. Code im Discord, Passwort kopieren" />
             )}
-            <Field label="Server-Icon / Logo" value={form.server_icon_url} onChange={(v) => set("server_icon_url", v)} placeholder="/api/static/uploads/... oder https://..." />
+            <div className="md:col-span-2 xl:col-span-4 flex flex-wrap items-center gap-4 border border-white/10 rounded-sm p-4">
+              <GameServerIcon server={{ ...form, game: games.find((game) => game.id === form.game_id) }} />
+              <div className="flex-1 min-w-0 space-y-2">
+                <label className="flex items-center gap-2 text-sm text-white/80">
+                  <input type="checkbox" checked={form.show_game_icon !== false} onChange={(event) => set("show_game_icon", event.target.checked)} className="accent-[#29B6E8]" />
+                  Spiel-/Server-Icon anzeigen
+                </label>
+                <p className="text-xs text-white/55">Das Logo des ausgewählten Spiels wird automatisch übernommen. Ein eigenes Server-Icon hat Vorrang. Ohne Bild erscheint das Server-Symbol.</p>
+                <Link to="/admin/games" className="text-xs text-[#29B6E8] underline">Spiele und Logos verwalten</Link>
+              </div>
+              <Field label="Eigenes Server-Icon (optional)" value={form.server_icon_url} onChange={(v) => set("server_icon_url", v)} placeholder="leer = Spielelogo" />
+            </div>
             <Field label="Karten-Link" value={form.map_url} onChange={(v) => set("map_url", v)} placeholder="Dynmap, BattleMetrics, Karte..." />
             <Field label="Externe Statusseite" value={form.external_status_url} onChange={(v) => set("external_status_url", v)} placeholder="z.B. BattleMetrics/Serverliste" />
             <label className="block">
@@ -424,6 +454,36 @@ export default function AdminGameServersPage() {
               Server aktiv anzeigen
             </label>
           </div>
+
+          <section className="mt-5 border border-[#29B6E8]/25 rounded-sm p-4 space-y-4" aria-label="Modding-Einstellungen">
+            <label className="flex items-center gap-2 text-sm font-bold">
+              <input type="checkbox" checked={!!form.modding_enabled} onChange={(event) => set("modding_enabled", event.target.checked)} className="accent-[#29B6E8]" />
+              Modded / Mods & Einrichtung anzeigen
+            </label>
+            <p className="text-xs text-white/55">Optional für jedes Spiel. Ausgeschaltete Angaben bleiben gespeichert, werden aber nicht an die öffentliche Serverliste ausgegeben. Aktive Links folgen der Sichtbarkeit des Servers; das Download-Ziel benötigt bei privaten Dateien einen eigenen Zugriffsschutz.</p>
+            <fieldset disabled={!form.modding_enabled || saving} className="space-y-3 disabled:opacity-50">
+              <label className="block text-sm">Installationshinweise
+                <textarea value={form.modding_notes || ""} maxLength={1500} rows={3} onChange={(event) => set("modding_notes", event.target.value)} placeholder="Welche Version installieren? In welcher Reihenfolge? Keine Passwörter oder geheimen Konfigurationen eintragen."
+                  className="mt-1 block w-full bg-[#0A0A0A] border border-white/15 rounded-sm p-3 text-sm" />
+              </label>
+              {form.mod_resources.map((item, index) => (
+                <div key={index} className="border border-white/15 rounded-sm p-3 space-y-3" data-testid="mod-resource-row">
+                  <div className="flex items-center justify-between gap-3">
+                    <label className="flex items-center gap-2 text-sm font-bold"><input type="checkbox" checked={!!item.enabled} onChange={(event) => setResource(index, "enabled", event.target.checked)} className="accent-[#29B6E8]" />Link {index + 1} anzeigen</label>
+                    <button type="button" onClick={() => set("mod_resources", form.mod_resources.filter((_item, position) => index !== position))} className="min-h-11 px-3 text-xs text-[#FF6B62]" aria-label={`Link ${index + 1} entfernen`}>Entfernen</button>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <label className="block text-sm">Typ<select value={item.kind} onChange={(event) => setResource(index, "kind", event.target.value)} className="mt-1 block w-full bg-[#0A0A0A] border border-white/15 rounded-sm p-2">{Object.entries(serverResourceLabels).map(([kind, label]) => <option key={kind} value={kind}>{label}</option>)}</select></label>
+                    <Field label="Bezeichnung (optional)" value={item.label} maxLength={80} onChange={(value) => setResource(index, "label", value)} placeholder="z.B. Fabric Loader" />
+                    <Field label="Version (optional)" value={item.version} maxLength={80} onChange={(value) => setResource(index, "version", value)} placeholder="z.B. passende Loader-/Pack-Version" />
+                    <Field label="HTTPS-Adresse" type="url" value={item.url} maxLength={2000} required={!!item.enabled} onChange={(value) => setResource(index, "url", value)} placeholder="https://..." />
+                  </div>
+                </div>
+              ))}
+              <button type="button" disabled={form.mod_resources.length >= 8} onClick={() => set("mod_resources", [...form.mod_resources, { kind: "modloader", enabled: false, label: "", version: "", url: "" }])} className="min-h-11 px-4 py-2 border border-[#29B6E8]/45 rounded-sm text-sm text-[#29B6E8] disabled:opacity-40">Link hinzufügen</button>
+              <p className="text-xs text-white/45">Bis zu acht Links: Modloader, Modpaket, Konfiguration oder Anleitung. Nur HTTPS; keine Zugangsdaten im Link. Dateien werden nicht automatisch heruntergeladen oder installiert.</p>
+            </fieldset>
+          </section>
 
           <div className="mt-5 flex flex-col sm:flex-row gap-2">
             <button disabled={saving} className="w-full sm:w-auto px-5 py-2.5 bg-[#29B6E8] text-black rounded-sm font-bold uppercase tracking-wider disabled:opacity-50">
@@ -521,11 +581,11 @@ function Stat({ label, value, tone }) {
   );
 }
 
-function Field({ label, value, onChange, type = "text", placeholder = "", required = false }) {
+function Field({ label, value, onChange, type = "text", placeholder = "", required = false, maxLength }) {
   return (
     <label className="block">
       <span className="text-[11px] uppercase tracking-widest text-white/45 font-bold">{label}</span>
-      <input required={required} type={type} value={value ?? ""} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="mt-1 w-full bg-[#0A0A0A] border border-white/10 rounded-sm px-3 py-2 text-sm" />
+      <input required={required} maxLength={maxLength} type={type} value={value ?? ""} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="mt-1 w-full bg-[#0A0A0A] border border-white/10 rounded-sm px-3 py-2 text-sm" />
     </label>
   );
 }

--- a/frontend/src/pages/public/ServersPage.jsx
+++ b/frontend/src/pages/public/ServersPage.jsx
@@ -4,7 +4,9 @@ import { toast } from "sonner";
 import { Clipboard, ExternalLink, Eye, Gamepad2, KeyRound, Lock, Map, Server, Shield, Signal, Users } from "lucide-react";
 import { PublicLayout } from "@/components/tls/PublicLayout";
 import { useAuth } from "@/context/AuthContext";
-import { api, resolveMediaUrl } from "@/lib/api";
+import { api } from "@/lib/api";
+import { GameServerIcon } from "@/components/tls/GameServerIcon";
+import { safeResourceUrl, serverResourceLabels } from "@/lib/serverResources";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
@@ -86,7 +88,7 @@ export default function ServersPage() {
   }, []);
 
   useEffect(() => { load(); }, [load, user?.id, isClubMember]);
-  useApiInvalidation(load, ["game-servers"]);
+  useApiInvalidation(load, ["game-servers", "games"]);
 
   const grouped = useMemo(() => ({
     online: items.filter((item) => item.status === "online"),
@@ -176,7 +178,7 @@ function ServerCard({ server }) {
   const max = Number(server.max_players || 0);
   const current = Number(server.player_count || 0);
   const pct = max > 0 ? Math.min(100, Math.round((current / max) * 100)) : 0;
-  const iconUrl = server.server_icon_url || server.game?.logo_url;
+  const modResources = server.modding_enabled ? (server.mod_resources || []).filter((item) => item.enabled && safeResourceUrl(item.url)) : [];
   const maintenanceBandText = maintenanceLabel(server, nowTick);
   const copyAddress = async () => {
     if (!server.address || !navigator.clipboard) return;
@@ -246,9 +248,7 @@ function ServerCard({ server }) {
       <div className="p-5 flex flex-col grow">
         <div className="flex items-start justify-between gap-4">
           <div className="flex items-start gap-3 min-w-0">
-            <div className="w-14 h-14 rounded-sm border border-white/10 bg-black/30 flex items-center justify-center overflow-hidden shrink-0">
-              {iconUrl ? <img src={resolveMediaUrl(iconUrl)} alt="" className="w-full h-full object-contain p-2" /> : <Server className="w-6 h-6 text-[#29B6E8]" />}
-            </div>
+            <GameServerIcon server={server} />
             <div className="min-w-0 max-w-full pt-0.5">
               <div className="flex items-center gap-2 text-[10px] uppercase tracking-widest text-[#29B6E8] font-bold min-w-0">
                 <Gamepad2 className="w-3 h-3 shrink-0" />
@@ -263,6 +263,28 @@ function ServerCard({ server }) {
         </div>
 
         {server.description && <p className="mt-4 text-sm leading-relaxed text-white/60 line-clamp-3">{server.description}</p>}
+        {server.modding_enabled && (
+          <div className="mt-4 border border-[#29B6E8]/25 bg-[#29B6E8]/5 rounded-sm p-3" data-testid="server-mod-resources">
+            <span className="text-[10px] uppercase font-black tracking-widest text-[#29B6E8]">Modded</span>
+            {(modResources.length > 0 || server.modding_notes) && (
+              <details className="mt-2">
+                <summary className="cursor-pointer py-2 text-sm font-bold text-white/80">Mods & Einrichtung{modResources.length ? ` (${modResources.length})` : ""}</summary>
+                {server.modding_notes && <p className="mt-2 whitespace-pre-wrap break-words text-sm text-white/65">{server.modding_notes}</p>}
+                <ul className="mt-3 space-y-2">
+                  {modResources.map((item, index) => (
+                    <li key={index}>
+                      <a href={safeResourceUrl(item.url)} target="_blank" rel="noopener noreferrer" className="flex min-h-11 items-center justify-between gap-3 border border-white/15 rounded-sm px-3 py-2 text-sm hover:border-[#29B6E8]/60">
+                        <span className="min-w-0 break-words"><span className="block text-[10px] uppercase text-[#29B6E8]">{serverResourceLabels[item.kind] || "Download"}</span>{item.label || serverResourceLabels[item.kind] || "Download"}{item.version && <span className="block text-xs text-white/55">Version: {item.version}</span>}</span>
+                        <ExternalLink aria-label="Öffnet in neuem Tab" className="w-4 h-4 shrink-0 text-[#29B6E8]" />
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-3 text-xs text-white/45">Links öffnen im neuen Tab. Installiere nur Dateien aus vertrauenswürdigen Quellen.</p>
+              </details>
+            )}
+          </div>
+        )}
 
         <div className="mt-5 grid grid-cols-2 gap-x-5 gap-y-3 text-xs">
           {quickFacts.map((fact) => <Info key={fact.label} label={fact.label} value={fact.value} />)}


### PR DESCRIPTION
## Scope

Requested gameserver-directory extension; no production or game-server configuration is changed automatically.

- Make existing game selection/logo inheritance visible with a live icon preview, optional custom override, on/off switch and broken-image fallback.
- Add a per-server Modded switch, installation notes and up to eight individually enabled resources (modloader, modpack, configuration, guide), with optional label/version.
- Keep disabled configuration in admin storage while excluding disabled resources from the public directory API. Existing public/community/member/internal server permissions are unchanged.
- Validate HTTPS links, reject embedded credentials and unsafe schemes. Downloads are links only: no server-side fetch or automatic installation. External private files still require their own access controls.
- Verify selected game IDs, refresh the public list on game metadata changes and document the operator setup in ADMIN_GUIDE.md.
- Update RESTPLAN.md with the prior operator-confirmed update/cache results and this separately requested extension.

## Checks

- 24 new backend regressions pass: URL validation, resource bounds, create/edit/disable/re-enable, permissions and legacy defaults.
- Frontend: 34 unit tests and production build pass.
- Four new desktop/mobile browser cases pass: icons, fallback, compact details, resource filtering, admin save and preservation while disabled.
- Documentation-link, secret and fatal Python lint checks pass.
- Full local backend run: 457 passed, one existing Windows Bash test timed out (not a new feature test); repeat and required Linux CI will verify it before merge.
- Full desktop/mobile browser suite and Linux/Docker/CodeQL CI must pass before integration.

## Operator steps after deployment

Admin -> Spiele: maintain each game's logo. Admin -> Game-Server -> Bearbeiten: select the game, optionally enable Modded, add trusted HTTPS links and enable them, save. Existing entries are not guessed or bulk reassigned by name. Vanilla defaults stay unchanged. No migrations, new secrets, external provider keys or native-app changes.
