### PR TITLE
chore: Phase 0 - Haertung und Aufraeumen aus dem Plattform-Audit

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -30,6 +30,7 @@ jobs:
   android-apk:
     name: Build Android APK
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import logging
 import json
+import re
 from datetime import datetime, timezone, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -203,7 +204,7 @@ async def mobile_client_logs(
         query["platform"] = platform.strip().lower()
     if user_id:
         query["user_id"] = user_id.strip()
-    search = q.strip()
+    search = re.escape(q.strip()[:80])
     if search:
         query["$or"] = [
             {"message": {"$regex": search, "$options": "i"}},

--- a/backend/tests/test_prepare_security_env.py
+++ b/backend/tests/test_prepare_security_env.py
@@ -47,9 +47,12 @@ exit 99
         python_shim = tmp_path / "bin/python3"
         python_shim.write_text(f'#!/usr/bin/env bash\nexec {shlex.quote(Path(sys.executable).as_posix())} "$@"\n', encoding="utf8", newline="\n")
         python_shim.chmod(0o755)
-    result = subprocess.run([BASH, "-c", 'export PATH="$PWD/bin:$PATH"; bash scripts/prepare-security-env.sh'],
+    # stdin must be detached: a lingering grandchild otherwise keeps the captured
+    # pipes open on Windows, so communicate() waits past the timeout even though
+    # the script itself already exited.
+    result = subprocess.run([BASH, "-c", 'export PATH="$PWD/bin:$PATH"; bash scripts/prepare-security-env.sh </dev/null'],
                             cwd=tmp_path, env={**os.environ, "SCENARIO": scenario},
-                            text=True, capture_output=True, timeout=30)
+                            text=True, capture_output=True, stdin=subprocess.DEVNULL, timeout=30)
     assert (result.returncode == 0) is success, result.stderr
     assert (tmp_path / "created").exists() is created
     assert "test-password" not in result.stdout + result.stderr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,14 @@ services:
       - /var/cache/nginx:size=64m
       - /var/run:size=8m
       - /tmp:size=32m
+    cap_drop:
+      - ALL
+    # nginx startet als root, bindet Port 80 und setzt die Worker auf den nginx-User.
+    cap_add:
+      - NET_BIND_SERVICE
+      - CHOWN
+      - SETGID
+      - SETUID
     security_opt:
       - no-new-privileges:true
     mem_limit: 512m

--- a/scripts/test_crown_events.sh
+++ b/scripts/test_crown_events.sh
@@ -3,9 +3,12 @@
 set -u
 API=$(grep REACT_APP_BACKEND_URL /app/frontend/.env | cut -d '=' -f2)
 J=/tmp/tls_crown_admin.txt
+: "${TLS_ADMIN_EMAIL:?Set TLS_ADMIN_EMAIL before running this smoke script}"
+: "${TLS_ADMIN_PASSWORD:?Set TLS_ADMIN_PASSWORD before running this smoke script}"
 
 curl -s -c $J -X POST "$API/api/auth/login" -H "Content-Type: application/json" -H "Origin: $API" \
-  -d '{"email":"admin@lionsquad.at","password":"LionSquad2026!Admin"}' -o /dev/null -w "admin login: %{http_code}\n"
+  --data "$(TLS_ADMIN_EMAIL="$TLS_ADMIN_EMAIL" TLS_ADMIN_PASSWORD="$TLS_ADMIN_PASSWORD" python3 -c 'import json,os; print(json.dumps({"email": os.environ["TLS_ADMIN_EMAIL"], "password": os.environ["TLS_ADMIN_PASSWORD"]}))')" \
+  -o /dev/null -w "admin login: %{http_code}\n"
 CSRF=$(grep csrf_token $J | awk '{print $7}')
 
 echo "== leaderboard top4 =="


### PR DESCRIPTION
## Zusammenfassung

Erstes Paket aus dem Plattform-Audit: fünf kleine, verhaltensneutrale Korrekturen. Kein Feature, keine Migration, keine Abhängigkeitsänderung.

| Änderung | Warum |
| --- | --- |
| `admin_routes.py`: `re.escape()` + 80-Zeichen-Deckel auf dem Suchbegriff | War die einzige Suchroute ohne Escaping — alle anderen (`search_routes`, `team_routes`, `user_routes`, `news_routes`, `badge_routes`) machen das bereits. ReDoS-Hygiene und Konsistenz. |
| `test_crown_events.sh`: Zugangsdaten aus `TLS_ADMIN_EMAIL` / `TLS_ADMIN_PASSWORD` | Das Admin-Passwort stand hartkodiert im Repository. |
| `docker-compose.yml`: `cap_drop: ALL` + minimales `cap_add` für den Frontend-Container | Der Backend-Service ist bereits so gehärtet, der Frontend-Service war es nicht. nginx bekommt nur `NET_BIND_SERVICE`, `CHOWN`, `SETGID`, `SETUID` zurück — genug zum Binden von Port 80 und zum Wechsel auf den Worker-User. |
| `mobile-release.yml`: `timeout-minutes: 45` für den APK-Job | Vorher lief der Job ins GitHub-Standardlimit von 360 Minuten. |
| `test_prepare_security_env.py`: `stdin` abgekoppelt | Unter Windows hielt ein hängender Enkelprozess die abgefangenen Pipes offen, wodurch `communicate()` in den Timeout lief, obwohl das Skript längst korrekt beendet war. |

## Nachweise

- Backend lokal: **458 passed, 19 skipped, 0 failed** — und die Suite läuft durch den Pipe-Fix in 33s statt 92s.
- `bash -n` über alle Shell-Skripte, `check-secrets.py`, `check-doc-links.py` (30 Dateien, 0 kaputte Ziele): grün.
- YAML von `docker-compose.yml` und `mobile-release.yml` validiert.
- **Offen für die CI:** Die `cap_drop`-Änderung ließ sich lokal nicht prüfen (kein Docker auf dem Arbeitsplatz). Der Container-Smoke-Job baut den Stack und ruft `/health` auf — falls nginx mit den reduzierten Capabilities nicht startet, fällt es dort auf.

## Bewusst nicht enthalten

Die im Audit vorgeschlagene Archivierung von `TOURNAMENT_ROADMAP.md`, `APP_BETA_PHASE_PLAN.md` und `IMPROVEMENT_REPORT.md` entfällt: `DOCS.md` legt seit #155 ausdrücklich fest, dass diese Dokumente als gekennzeichnete Historie am Ort bleiben. Der pytest-`live`-Marker war ebenfalls bereits registriert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)