### PR TITLE
feat: Phase 2 - Tastaturbedienbare Overlays, Testinfrastruktur und erste Seitentests

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -7,28 +7,6 @@
       "count": 1
     }
   },
-  "src/components/tls/ConfirmDialog.jsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx-a11y/no-autofocus": {
-      "count": 2
-    },
-    "jsx-a11y/no-noninteractive-element-interactions": {
-      "count": 1
-    }
-  },
-  "src/components/tls/CrownCelebration.jsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 2
-    },
-    "jsx-a11y/no-noninteractive-element-interactions": {
-      "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "src/components/tls/GermanDateField.jsx": {
     "jsx-a11y/role-supports-aria-props": {
       "count": 1
@@ -40,17 +18,6 @@
     },
     "jsx-a11y/no-static-element-interactions": {
       "count": 4
-    }
-  },
-  "src/components/tls/LevelUpCelebration.jsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 2
-    },
-    "jsx-a11y/no-noninteractive-element-interactions": {
-      "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 1
     }
   },
   "src/components/tls/MarkdownEditor.jsx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -107,6 +107,10 @@
   "devDependencies": {
     "@eslint/js": "9.39.5",
     "@playwright/test": "^1.62.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-v8": "^4.1.11",
     "autoprefixer": "^10.5.4",

--- a/frontend/src/components/tls/AchievementUnlockOverlay.jsx
+++ b/frontend/src/components/tls/AchievementUnlockOverlay.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { motion, AnimatePresence } from "framer-motion";
 import { Trophy, X, Volume2, VolumeX } from "lucide-react";
 import { AchievementIcon } from "@/components/tls/AchievementIcon";
@@ -69,12 +70,17 @@ export function AchievementUnlockOverlay({ tiers = [], onClose, heading, sub }) 
     return () => clearTimeout(timer);
   }, [open, paused, onClose]);
 
+  const cardRef = useModalBehavior(!!open, () => onClose?.());
+
   return (
     <AnimatePresence>
       {open && (
         <motion.div
           data-testid="achievement-unlock-overlay"
           className="fixed inset-0 z-[120] flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={heading || "Erfolg freigeschaltet"}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -127,6 +133,8 @@ export function AchievementUnlockOverlay({ tiers = [], onClose, heading, sub }) 
               y: { type: "spring", stiffness: 220, damping: 20 },
               x: { delay: 0.5, duration: 0.55, ease: "easeOut" },
             }}
+            ref={cardRef}
+            tabIndex={-1}
             onClick={(e) => e.stopPropagation()}
             onMouseEnter={() => setPaused(true)}
             onMouseLeave={() => setPaused(false)}

--- a/frontend/src/components/tls/ConfirmDialog.jsx
+++ b/frontend/src/components/tls/ConfirmDialog.jsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
 import { AlertTriangle, X } from "lucide-react";
+import { useModalBehavior } from "@/hooks/useModalBehavior";
 
 const ConfirmContext = createContext(null);
 
@@ -46,13 +47,15 @@ export function ConfirmDialogProvider({ children }) {
 
   const value = useMemo(() => ({ confirm, prompt }), [confirm, prompt]);
   const promptInvalid = dialog?.kind === "prompt" && dialog.required && !draft.trim();
+  const dialogRef = useModalBehavior(!!dialog, () => close(false));
 
   return (
     <ConfirmContext.Provider value={value}>
       {children}
       {dialog && (
         <div className="fixed inset-0 z-[100] bg-black/75 backdrop-blur-sm p-4 flex items-center justify-center" role="presentation" onClick={() => close(false)}>
-          <div className="w-full max-w-md bg-[#121212] border border-white/10 rounded-sm shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="confirm-title" data-testid="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- fängt nur den Klick ab, damit er den Dialog nicht schließt; Escape und Abbrechen bleiben der Tastaturweg */}
+          <div ref={dialogRef} tabIndex={-1} className="w-full max-w-md bg-[#121212] border border-white/10 rounded-sm shadow-2xl focus:outline-none" role="dialog" aria-modal="true" aria-labelledby="confirm-title" data-testid="confirm-dialog" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-start gap-3 p-5 border-b border-white/10">
               <div className={`w-10 h-10 rounded-sm border flex items-center justify-center shrink-0 ${dialog.tone === "danger" ? "border-[#FF3B30]/45 text-[#FF3B30] bg-[#FF3B30]/10" : "border-[#29B6E8]/45 text-[#29B6E8] bg-[#29B6E8]/10"}`}>
                 <AlertTriangle className="w-5 h-5" />
@@ -67,7 +70,6 @@ export function ConfirmDialogProvider({ children }) {
                       onChange={(e) => setDraft(e.target.value)}
                       placeholder={dialog.placeholder}
                       className="mt-4 input min-h-28 resize-y"
-                      autoFocus
                     />
                   ) : (
                     <input
@@ -75,7 +77,6 @@ export function ConfirmDialogProvider({ children }) {
                       onChange={(e) => setDraft(e.target.value)}
                       placeholder={dialog.placeholder}
                       className="mt-4 input"
-                      autoFocus
                     />
                   )
                 )}

--- a/frontend/src/components/tls/ConfirmDialog.test.jsx
+++ b/frontend/src/components/tls/ConfirmDialog.test.jsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ConfirmDialogProvider, useConfirm, usePrompt } from "./ConfirmDialog";
+
+function ConfirmHarness(options) {
+  const confirm = useConfirm();
+  const [result, setResult] = useState("offen");
+  return (
+    <div>
+      <button type="button" onClick={async () => setResult(String(await confirm(options)))}>
+        Löschen
+      </button>
+      <output data-testid="result">{result}</output>
+    </div>
+  );
+}
+
+function PromptHarness(options) {
+  const prompt = usePrompt();
+  const [result, setResult] = useState("offen");
+  return (
+    <div>
+      <button type="button" onClick={async () => setResult(String(await prompt(options)))}>
+        Grund erfassen
+      </button>
+      <output data-testid="result">{result}</output>
+    </div>
+  );
+}
+
+function renderConfirm(options) {
+  return render(
+    <ConfirmDialogProvider>
+      <ConfirmHarness {...options} />
+    </ConfirmDialogProvider>
+  );
+}
+
+function renderPrompt(options) {
+  return render(
+    <ConfirmDialogProvider>
+      <PromptHarness {...options} />
+    </ConfirmDialogProvider>
+  );
+}
+
+test("Bestätigen löst die Aktion mit true auf", async () => {
+  const user = userEvent.setup();
+  renderConfirm();
+
+  await user.click(screen.getByRole("button", { name: "Löschen" }));
+  await user.click(screen.getByTestId("confirm-dialog-confirm"));
+
+  await waitFor(() => expect(screen.getByTestId("result")).toHaveTextContent("true"));
+  expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+});
+
+test("Abbrechen löst mit false auf", async () => {
+  const user = userEvent.setup();
+  renderConfirm();
+
+  await user.click(screen.getByRole("button", { name: "Löschen" }));
+  await user.click(screen.getByTestId("confirm-dialog-cancel"));
+
+  await waitFor(() => expect(screen.getByTestId("result")).toHaveTextContent("false"));
+});
+
+test("Escape bricht ab, statt die Aktion auszuführen", async () => {
+  const user = userEvent.setup();
+  renderConfirm();
+
+  await user.click(screen.getByRole("button", { name: "Löschen" }));
+  expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
+
+  await user.keyboard("{Escape}");
+
+  await waitFor(() => expect(screen.getByTestId("result")).toHaveTextContent("false"));
+  expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+});
+
+test("Klick auf den Hintergrund bricht ab", async () => {
+  const user = userEvent.setup();
+  renderConfirm();
+
+  await user.click(screen.getByRole("button", { name: "Löschen" }));
+  await user.click(screen.getByRole("presentation"));
+
+  await waitFor(() => expect(screen.getByTestId("result")).toHaveTextContent("false"));
+});
+
+test("Der Dialog übernimmt den Fokus und gibt ihn danach zurück", async () => {
+  const user = userEvent.setup();
+  renderConfirm();
+  const trigger = screen.getByRole("button", { name: "Löschen" });
+
+  await user.click(trigger);
+  await waitFor(() => expect(screen.getByTestId("confirm-dialog").contains(document.activeElement)).toBe(true));
+
+  await user.keyboard("{Escape}");
+
+  await waitFor(() => expect(trigger).toHaveFocus());
+});
+
+test("Eigene Beschriftungen werden angezeigt", async () => {
+  const user = userEvent.setup();
+  renderConfirm({ title: "Turnier verwerfen", confirmLabel: "Endgültig löschen", cancelLabel: "Behalten" });
+
+  await user.click(screen.getByRole("button", { name: "Löschen" }));
+
+  expect(screen.getByText("Turnier verwerfen")).toBeInTheDocument();
+  expect(screen.getByTestId("confirm-dialog-confirm")).toHaveTextContent("Endgültig löschen");
+  expect(screen.getByTestId("confirm-dialog-cancel")).toHaveTextContent("Behalten");
+});
+
+test("Die Eingabe des Prompts wird zurückgegeben", async () => {
+  const user = userEvent.setup();
+  renderPrompt({ multiline: false });
+
+  await user.click(screen.getByRole("button", { name: "Grund erfassen" }));
+  await user.keyboard("Regelverstoss");
+  await user.click(screen.getByTestId("confirm-dialog-confirm"));
+
+  await waitFor(() => expect(screen.getByTestId("result")).toHaveTextContent("Regelverstoss"));
+});
+
+test("Ein Pflicht-Prompt lässt sich nicht leer bestätigen", async () => {
+  const user = userEvent.setup();
+  renderPrompt({ required: true, multiline: false });
+
+  await user.click(screen.getByRole("button", { name: "Grund erfassen" }));
+  expect(screen.getByTestId("confirm-dialog-confirm")).toBeDisabled();
+
+  await user.keyboard("Grund");
+
+  expect(screen.getByTestId("confirm-dialog-confirm")).toBeEnabled();
+});
+
+test("Das Eingabefeld des Prompts bekommt den Fokus", async () => {
+  const user = userEvent.setup();
+  renderPrompt({ multiline: false, placeholder: "Grund" });
+
+  await user.click(screen.getByRole("button", { name: "Grund erfassen" }));
+
+  await waitFor(() => expect(screen.getByPlaceholderText("Grund")).toHaveFocus());
+});

--- a/frontend/src/components/tls/CrownCelebration.jsx
+++ b/frontend/src/components/tls/CrownCelebration.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { CrownIcon, CROWN_LABELS, refreshCrowns } from "./LevelAvatarFrame";
+import { useModalBehavior } from "@/hooks/useModalBehavior";
 
 const GLOWS = {
   gold: "rgba(255,215,0,0.9)",
@@ -44,19 +45,24 @@ export function CrownCelebration() {
     return () => clearTimeout(timer);
   }, [event]);
 
+  const cardRef = useModalBehavior(!!event, () => setEvent(null));
+
+  const variant = event?.variant || "gold";
   if (!event) return null;
-  const variant = event.variant || "gold";
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- Escape und die Schaltfläche schließen das Overlay; der Klick daneben ist nur eine Maus-Abkürzung.
     <div
       className="tls-crown-celebration"
       style={{ "--crown-glow": GLOWS[variant] || GLOWS.gold }}
       data-testid="crown-celebration-overlay"
       role="dialog"
+      aria-modal="true"
       aria-label="Kronen-Feier"
       onClick={() => setEvent(null)}
     >
       <ConfettiRain />
-      <div className="tls-crown-celebration-card" onClick={(e) => e.stopPropagation()}>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- fängt nur den Klick ab, damit er das Overlay nicht schließt */}
+      <div ref={cardRef} tabIndex={-1} className="tls-crown-celebration-card focus:outline-none" onClick={(e) => e.stopPropagation()}>
         <span className="tls-crown-celebration-rays" aria-hidden="true" />
         <div className="tls-crown-celebration-crown">
           <CrownIcon variant={variant} />

--- a/frontend/src/components/tls/LevelUpCelebration.jsx
+++ b/frontend/src/components/tls/LevelUpCelebration.jsx
@@ -3,6 +3,7 @@ import { api, resolveMediaUrl } from "@/lib/api";
 import { useAuth } from "@/context/AuthContext";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { LevelAvatarFrame, levelFrameConfig } from "@/components/tls/LevelAvatarFrame";
+import { useModalBehavior } from "@/hooks/useModalBehavior";
 
 const COLORS = ["#29B6E8", "#7FDBFF", "#FFD700", "#00FF88", "#A855F7", "#FFFFFF", "#FF7A00"];
 
@@ -62,19 +63,24 @@ export function LevelUpCelebration() {
     return () => clearTimeout(timer);
   }, [event]);
 
+  const cardRef = useModalBehavior(!!event, () => setEvent(null));
+
   if (!event) return null;
   const initials = (user?.display_name || user?.username || "?").slice(0, 2).toUpperCase();
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- Escape und die Schaltfläche schließen das Overlay; der Klick daneben ist nur eine Maus-Abkürzung.
     <div
       className="tls-crown-celebration"
       style={{ "--crown-glow": "rgba(41,182,232,0.9)" }}
       data-testid="levelup-celebration-overlay"
       role="dialog"
+      aria-modal="true"
       aria-label="Level-Aufstieg"
       onClick={() => setEvent(null)}
     >
       <ConfettiRain />
-      <div className="tls-crown-celebration-card" onClick={(e) => e.stopPropagation()}>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- fängt nur den Klick ab, damit er das Overlay nicht schließt */}
+      <div ref={cardRef} tabIndex={-1} className="tls-crown-celebration-card focus:outline-none" onClick={(e) => e.stopPropagation()}>
         <span className="tls-crown-celebration-rays" aria-hidden="true" />
         <div className="tls-levelup-frame" data-testid="levelup-frame-preview">
           <LevelAvatarFrame level={event.level} showBadge={false} className="w-36 h-36 sm:w-44 sm:h-44">

--- a/frontend/src/hooks/useModalBehavior.js
+++ b/frontend/src/hooks/useModalBehavior.js
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Keyboard behaviour every one of our own overlays needs: Escape closes it, Tab
+ * stays inside it, and focus returns where it came from afterwards.
+ *
+ * Radix handles this for the dialogs built on it; these are the hand-rolled
+ * overlays that do not go through Radix. Focus is moved into the overlay even
+ * for the celebration popups that appear on their own, because they cover the
+ * whole screen: without it a keyboard user cannot reach their close button.
+ *
+ * Returns the ref to put on the element that holds the focusable content.
+ */
+export function useModalBehavior(active, onDismiss) {
+  const containerRef = useRef(null);
+  const dismissRef = useRef(onDismiss);
+  dismissRef.current = onDismiss;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const container = containerRef.current;
+    const previouslyFocused = document.activeElement;
+
+    const focusableItems = () => Array.from(container?.querySelectorAll(FOCUSABLE) || []);
+
+    if (container && !container.contains(document.activeElement)) {
+      const [first] = focusableItems();
+      (first || container).focus?.();
+    }
+
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        dismissRef.current?.();
+        return;
+      }
+      if (event.key !== "Tab" || !container) return;
+      const items = focusableItems();
+      if (!items.length) {
+        event.preventDefault();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const current = document.activeElement;
+      if (event.shiftKey && (current === first || !container.contains(current))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (current === last || !container.contains(current))) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      previouslyFocused?.focus?.();
+    };
+  }, [active]);
+
+  return containerRef;
+}

--- a/frontend/src/hooks/useModalBehavior.test.jsx
+++ b/frontend/src/hooks/useModalBehavior.test.jsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { useModalBehavior } from "./useModalBehavior";
+
+function Overlay({ onDismiss, withInput = false }) {
+  const ref = useModalBehavior(true, onDismiss);
+  return (
+    <div ref={ref} tabIndex={-1} data-testid="overlay">
+      {withInput ? <input aria-label="Grund" /> : null}
+      <button type="button">Erste</button>
+      <button type="button">Letzte</button>
+    </div>
+  );
+}
+
+function Harness({ withInput = false }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>Öffnen</button>
+      {open ? <Overlay onDismiss={() => setOpen(false)} withInput={withInput} /> : null}
+    </div>
+  );
+}
+
+test("Escape schließt das Overlay", async () => {
+  const user = userEvent.setup();
+  const onDismiss = vi.fn();
+  render(<Overlay onDismiss={onDismiss} />);
+
+  await user.keyboard("{Escape}");
+
+  expect(onDismiss).toHaveBeenCalledTimes(1);
+});
+
+test("Fokus wandert beim Öffnen in das Overlay", async () => {
+  const user = userEvent.setup();
+  render(<Harness />);
+
+  await user.click(screen.getByRole("button", { name: "Öffnen" }));
+
+  expect(screen.getByRole("button", { name: "Erste" })).toHaveFocus();
+});
+
+test("Ein Eingabefeld bekommt den Fokus vor den Schaltflächen", async () => {
+  const user = userEvent.setup();
+  render(<Harness withInput />);
+
+  await user.click(screen.getByRole("button", { name: "Öffnen" }));
+
+  expect(screen.getByLabelText("Grund")).toHaveFocus();
+});
+
+test("Tab bleibt im Overlay und springt vom letzten zum ersten Element", async () => {
+  const user = userEvent.setup();
+  render(<Overlay onDismiss={() => {}} />);
+  const first = screen.getByRole("button", { name: "Erste" });
+  const last = screen.getByRole("button", { name: "Letzte" });
+
+  expect(first).toHaveFocus();
+  await user.tab();
+  expect(last).toHaveFocus();
+  await user.tab();
+  expect(first).toHaveFocus();
+});
+
+test("Shift+Tab springt vom ersten zum letzten Element", async () => {
+  const user = userEvent.setup();
+  render(<Overlay onDismiss={() => {}} />);
+
+  expect(screen.getByRole("button", { name: "Erste" })).toHaveFocus();
+  await user.tab({ shift: true });
+
+  expect(screen.getByRole("button", { name: "Letzte" })).toHaveFocus();
+});
+
+test("Nach dem Schließen kehrt der Fokus zum auslösenden Element zurück", async () => {
+  const user = userEvent.setup();
+  render(<Harness />);
+  const opener = screen.getByRole("button", { name: "Öffnen" });
+
+  await user.click(opener);
+  expect(screen.getByRole("button", { name: "Erste" })).toHaveFocus();
+
+  await user.keyboard("{Escape}");
+
+  expect(screen.queryByTestId("overlay")).not.toBeInTheDocument();
+  expect(opener).toHaveFocus();
+});
+
+test("Ein inaktives Overlay fängt keine Tastatureingaben ab", async () => {
+  const user = userEvent.setup();
+  const onDismiss = vi.fn();
+
+  function Inactive() {
+    const ref = useModalBehavior(false, onDismiss);
+    return <div ref={ref}><button type="button">Egal</button></div>;
+  }
+
+  render(<Inactive />);
+  await user.keyboard("{Escape}");
+
+  expect(onDismiss).not.toHaveBeenCalled();
+});

--- a/frontend/src/lib/datetime.test.js
+++ b/frontend/src/lib/datetime.test.js
@@ -1,0 +1,128 @@
+import {
+  formatDate,
+  formatDateTime,
+  fromDateTimeLocal,
+  getRegistrationState,
+  hasOnlineRegistration,
+  normalizeDateTimeFields,
+  toDateTimeLocalInput,
+} from "./datetime";
+
+// getRegistrationState entscheidet, ob sich jemand anmelden darf.
+// normalizeDateTimeFields wandelt Formulareingaben vor dem Speichern um.
+
+describe("Formatierung", () => {
+  test("leere Werte bekommen den Platzhalter", () => {
+    expect(formatDateTime(null)).toBe("TBD");
+    expect(formatDate(undefined)).toBe("TBD");
+    expect(formatDateTime("", { fallback: "offen" })).toBe("offen");
+  });
+
+  test("unlesbare Werte werden unveraendert durchgereicht statt zu crashen", () => {
+    expect(formatDateTime("kein datum")).toBe("kein datum");
+    expect(formatDate("kein datum")).toBe("kein datum");
+  });
+});
+
+describe("Formularfelder", () => {
+  test("Eingabe und Rueckwandlung ergeben denselben Zeitpunkt", () => {
+    const input = toDateTimeLocalInput("2026-09-08T20:30:00Z");
+    expect(input).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    expect(new Date(fromDateTimeLocal(input)).getTime()).toBe(new Date("2026-09-08T20:30:00Z").getTime());
+  });
+
+  test("ungueltige Eingaben ergeben null statt eines kaputten Datums", () => {
+    expect(fromDateTimeLocal("")).toBeNull();
+    expect(fromDateTimeLocal("morgen")).toBeNull();
+    expect(toDateTimeLocalInput("morgen")).toBe("");
+    expect(toDateTimeLocalInput(null)).toBe("");
+  });
+
+  test("gesetzte Felder werden nach ISO umgewandelt", () => {
+    const payload = normalizeDateTimeFields(
+      { start_date: "2026-09-08T20:30", name: "Cup" },
+      ["start_date"]
+    );
+
+    expect(payload.start_date).toBe(new Date("2026-09-08T20:30").toISOString());
+    expect(payload.name).toBe("Cup");
+  });
+
+  test("geleerte Felder werden zu null, fehlende bleiben abwesend", () => {
+    const payload = normalizeDateTimeFields(
+      { start_date: "", other: "x" },
+      ["start_date", "end_date"]
+    );
+
+    expect(payload.start_date).toBeNull();
+    expect("end_date" in payload).toBe(false);
+  });
+});
+
+describe("Anmeldestatus", () => {
+  const future = new Date(Date.now() + 86400000).toISOString();
+  const past = new Date(Date.now() - 86400000).toISOString();
+
+  test("ohne Turnier ist keine Anmeldung moeglich", () => {
+    expect(getRegistrationState(null).canRegister).toBe(false);
+  });
+
+  test("Entwuerfe sind nicht anmeldbar", () => {
+    const state = getRegistrationState({ status: "draft" });
+    expect(state.canRegister).toBe(false);
+    expect(state.state).toBe("draft");
+  });
+
+  test("deaktivierte und Nur-Einladung-Turniere sind gesperrt", () => {
+    expect(getRegistrationState({ status: "registration_open", registration_enabled: false }).canRegister).toBe(false);
+    expect(getRegistrationState({ status: "registration_open", is_invite_only: true }).canRegister).toBe(false);
+  });
+
+  test("offen im Zeitfenster", () => {
+    const state = getRegistrationState({
+      status: "registration_open",
+      registration_open_from: past,
+      registration_open_until: future,
+    });
+
+    expect(state.canRegister).toBe(true);
+    expect(state.state).toBe("open");
+  });
+
+  test("vor dem Start noch nicht offen", () => {
+    const state = getRegistrationState({ status: "registration_open", registration_open_from: future });
+
+    expect(state.canRegister).toBe(false);
+    expect(state.state).toBe("scheduled");
+  });
+
+  test("nach dem Ende geschlossen", () => {
+    const state = getRegistrationState({ status: "registration_open", registration_open_until: past });
+
+    expect(state.canRegister).toBe(false);
+    expect(state.state).toBe("closed");
+  });
+
+  test("ein anderer Status als registration_open bleibt geschlossen", () => {
+    expect(getRegistrationState({ status: "live" }).canRegister).toBe(false);
+    expect(getRegistrationState({ status: "completed" }).canRegister).toBe(false);
+  });
+
+  test("das Substantiv der Beschriftung ist anpassbar", () => {
+    expect(getRegistrationState({ status: "live" }, "Einreichung").label).toContain("Einreichung");
+  });
+});
+
+describe("Online-Anmeldung", () => {
+  test("braucht beide Schalter und mindestens einen Zeitpunkt", () => {
+    expect(hasOnlineRegistration({
+      online_registration_enabled: true,
+      registration_enabled: true,
+      registration_open_from: "2026-09-01T10:00:00Z",
+    })).toBe(true);
+
+    expect(hasOnlineRegistration({ online_registration_enabled: true, registration_enabled: true })).toBe(false);
+    expect(hasOnlineRegistration({ online_registration_enabled: false, registration_enabled: true, registration_open_from: "x" })).toBe(false);
+    expect(hasOnlineRegistration(null)).toBe(false);
+  });
+});

--- a/frontend/src/lib/dirtyPayload.test.js
+++ b/frontend/src/lib/dirtyPayload.test.js
@@ -1,0 +1,88 @@
+import { buildDirtyPayload, hasPayloadChanges, sameValue } from "./dirtyPayload";
+
+// Diese Funktionen entscheiden, was beim Speichern eines Turniers oder der
+// Systemeinstellungen tatsaechlich an die API geht. Ein Fehler hier heisst
+// entweder verlorene Aenderungen oder ungewolltes Ueberschreiben.
+
+test("nur geaenderte Felder landen im Payload", () => {
+  const payload = buildDirtyPayload(
+    { name: "Winter Cup", max_teams: 16, description: "gleich" },
+    { name: "Sommer Cup", max_teams: 16, description: "gleich" }
+  );
+
+  expect(payload).toEqual({ name: "Winter Cup" });
+});
+
+test("ohne Aenderung bleibt der Payload leer", () => {
+  const original = { name: "Cup", tags: ["a", "b"] };
+  const payload = buildDirtyPayload({ name: "Cup", tags: ["a", "b"] }, original);
+
+  expect(payload).toEqual({});
+  expect(hasPayloadChanges(payload)).toBe(false);
+});
+
+test("ein Feld auf null zu setzen gilt als Aenderung", () => {
+  const payload = buildDirtyPayload({ start_date: null }, { start_date: "2026-09-01T18:00:00Z" });
+
+  expect(payload).toEqual({ start_date: null });
+  expect(hasPayloadChanges(payload)).toBe(true);
+});
+
+test("undefined wird uebersprungen und loescht nichts versehentlich", () => {
+  const payload = buildDirtyPayload({ name: "Cup", start_date: undefined }, { name: "Alt", start_date: "2026-09-01" });
+
+  expect(payload).toEqual({ name: "Cup" });
+  expect("start_date" in payload).toBe(false);
+});
+
+test("neue Felder ohne Vorgaenger gelten als Aenderung", () => {
+  expect(buildDirtyPayload({ prize_pool: "500" }, {})).toEqual({ prize_pool: "500" });
+});
+
+test("Schluesselreihenfolge in Objekten macht keinen Unterschied", () => {
+  const payload = buildDirtyPayload(
+    { rules: { schedule_mode: "hybrid", event_mode: "local" } },
+    { rules: { event_mode: "local", schedule_mode: "hybrid" } }
+  );
+
+  expect(payload).toEqual({});
+});
+
+test("Reihenfolge in Listen ist dagegen eine echte Aenderung", () => {
+  const payload = buildDirtyPayload({ seeds: ["b", "a"] }, { seeds: ["a", "b"] });
+
+  expect(payload).toEqual({ seeds: ["b", "a"] });
+});
+
+test("verschachtelte Aenderungen werden erkannt", () => {
+  const payload = buildDirtyPayload(
+    { settings: { limits: { teams: 32 } } },
+    { settings: { limits: { teams: 16 } } }
+  );
+
+  expect(payload).toEqual({ settings: { limits: { teams: 32 } } });
+});
+
+test("null und undefined gelten als derselbe Wert", () => {
+  // Beide werden vor dem Vergleich zu null normalisiert. Wichtig zu wissen:
+  // ein Wechsel von "nicht gesetzt" auf null erzeugt bewusst keinen Schreibvorgang.
+  expect(sameValue(null, undefined)).toBe(true);
+  expect(buildDirtyPayload({ note: null }, { note: undefined })).toEqual({});
+});
+
+test("Zahl und Zahl als Text sind nicht dasselbe", () => {
+  expect(sameValue(16, "16")).toBe(false);
+  expect(buildDirtyPayload({ max_teams: "16" }, { max_teams: 16 })).toEqual({ max_teams: "16" });
+});
+
+test("leere oder fehlende Eingaben ergeben einen leeren Payload", () => {
+  expect(buildDirtyPayload(null, { a: 1 })).toEqual({});
+  expect(buildDirtyPayload(undefined)).toEqual({});
+  expect(buildDirtyPayload({}, undefined)).toEqual({});
+});
+
+test("hasPayloadChanges vertraegt fehlende Eingaben", () => {
+  expect(hasPayloadChanges(null)).toBe(false);
+  expect(hasPayloadChanges(undefined)).toBe(false);
+  expect(hasPayloadChanges({ name: "Cup" })).toBe(true);
+});

--- a/frontend/src/pages/admin/AdminTournamentEditPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.jsx
@@ -204,6 +204,7 @@ export default function AdminTournamentEditPage() {
   const { id } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const [t, setT] = useState(null);
+  const [loadError, setLoadError] = useState("");
   const [regs, setRegs] = useState([]);
   const [bracket, setBracket] = useState(null);
   const [tab, setTab] = useState(searchParams.get("tab") || "participants");
@@ -270,14 +271,20 @@ export default function AdminTournamentEditPage() {
       catch { setGroups([]); }
     }
     if (isAdmin) {
-      const [{ data: s }, { data: u }, { data: teamRows }] = await Promise.all([
-        api.get(`/tournaments/${id}/staff`),
-        api.get("/users"),
-        api.get("/teams"),
-      ]);
-      setStaff(s || []);
-      setUsers(u || []);
-      setTeams(teamRows || []);
+      try {
+        const [{ data: s }, { data: u }, { data: teamRows }] = await Promise.all([
+          api.get(`/tournaments/${id}/staff`),
+          api.get("/users"),
+          api.get("/teams"),
+        ]);
+        setStaff(s || []);
+        setUsers(u || []);
+        setTeams(teamRows || []);
+      } catch {
+        setStaff([]);
+        setUsers([]);
+        setTeams([]);
+      }
     } else if (isModerator) {
       try {
         const [{ data: u }, { data: teamRows }] = await Promise.all([
@@ -293,8 +300,14 @@ export default function AdminTournamentEditPage() {
     }
   }, [id, isAdmin, isModerator]);
 
-  useEffect(() => { load(); }, [load]);
-  useApiInvalidation(load, ["tournaments", "matches", "stations"]);
+  // Ohne diesen Fang bleibt die Seite bei unerreichbarem Backend stumm auf
+  // "Lade…" stehen und die Rejection landet unbehandelt in der Konsole.
+  const loadSafely = useCallback(() => load()
+    .then(() => setLoadError(""))
+    .catch((error) => setLoadError(formatRequestError(error, "Turnier konnte nicht geladen werden."))), [load]);
+
+  useEffect(() => { loadSafely(); }, [loadSafely]);
+  useApiInvalidation(loadSafely, ["tournaments", "matches", "stations"]);
 
   const autoAssignStations = async ({ silent = false, reload = true } = {}) => {
     if (!stations.length) return null;
@@ -602,7 +615,13 @@ export default function AdminTournamentEditPage() {
     }
   };
 
-  if (!t) return <AdminLayout><div className="p-10 text-white/40">Lade…</div></AdminLayout>;
+  if (!t) return (
+    <AdminLayout>
+      {loadError
+        ? <div className="p-10 text-[#FF3B30]" data-testid="admin-tr-load-error">{loadError}</div>
+        : <div className="p-10 text-white/40">Lade…</div>}
+    </AdminLayout>
+  );
   const hasFlexibleStructure = stages.length > 0 || matchesV2.length > 0;
   const canRecordResults = ["live", "paused"].includes(t.status);
   const availableTabs = [

--- a/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ConfirmDialogProvider } from "@/components/tls/ConfirmDialog";
+
+// Diese Seite ist mit ueber 2000 Zeilen die groesste im Frontend und schreibt
+// Turnierdaten. Der Test haelt fest, dass sie mit realistischen API-Antworten
+// laedt, ihre Reiter bedienbar bleiben und dass eine Statusaenderung genau
+// einen PATCH mit dem gewaehlten Status ausloest. Damit hat die geplante
+// Zerlegung in Unterkomponenten ein Sicherheitsnetz.
+
+const apiMock = {
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock("@/lib/api", () => ({
+  API: "http://test.local/api",
+  api: apiMock,
+  formatApiError: (error, fallback) => fallback || String(error),
+  formatRequestError: (error, fallback) => fallback || String(error),
+  resolveMediaUrl: (value) => value || "",
+}));
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({ isAdmin: true, isModerator: true, user: { id: "admin-1", display_name: "Admin" } }),
+}));
+
+vi.mock("@/hooks/useApiInvalidation", () => ({ useApiInvalidation: () => {} }));
+
+vi.mock("@/components/tls/AdminLayout", () => ({
+  AdminLayout: ({ children }) => <div data-testid="admin-layout">{children}</div>,
+}));
+vi.mock("@/components/tls/BracketTree", () => ({ BracketTree: () => <div data-testid="bracket-tree" /> }));
+vi.mock("@/components/tls/ImageUpload", () => ({ ImageUpload: () => <div data-testid="image-upload" /> }));
+vi.mock("@/components/tls/MarkdownEditor", () => ({ MarkdownEditor: () => <div data-testid="markdown-editor" /> }));
+vi.mock("@/components/tls/AccessLinksPanel", () => ({ AccessLinksPanel: () => <div data-testid="access-links" /> }));
+vi.mock("@/components/tls/TournamentFlowStepper", () => ({ TournamentFlowStepper: () => <div data-testid="flow-stepper" /> }));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() } }));
+
+const { AdminTournamentEditPage } = await import("./AdminTournamentEditPage").then((module) => ({
+  AdminTournamentEditPage: module.default || module.AdminTournamentEditPage,
+}));
+
+const TOURNAMENT = {
+  id: "t-1",
+  slug: "winter-cup",
+  title: "Winter Cup 2026",
+  status: "registration_open",
+  game: "rocket_league",
+  format: "single_elimination",
+  team_size: 3,
+  max_teams: 16,
+  registration_enabled: true,
+  can_manage_structure: true,
+};
+
+function routeFor(url) {
+  if (url.includes("/registrations")) return { data: [] };
+  if (url.includes("/bracket")) return { data: { rounds: [] } };
+  if (url.includes("/stages")) return { data: [] };
+  if (url.includes("/matches-v2")) return { data: [] };
+  if (url.includes("/groups")) return { data: [] };
+  if (url.includes("/staff")) return { data: [] };
+  if (url.includes("/assignable-users")) return { data: [] };
+  if (url.includes("/stations")) return { data: [] };
+  if (url.startsWith("/users")) return { data: [] };
+  if (url.startsWith("/teams")) return { data: [] };
+  if (url.includes("/tournaments/t-1")) return { data: TOURNAMENT };
+  return { data: [] };
+}
+
+function renderPage() {
+  return render(
+    <ConfirmDialogProvider>
+      <MemoryRouter initialEntries={["/admin/tournaments/t-1"]}>
+        <Routes>
+          <Route path="/admin/tournaments/:id" element={<AdminTournamentEditPage />} />
+        </Routes>
+      </MemoryRouter>
+    </ConfirmDialogProvider>
+  );
+}
+
+beforeEach(() => {
+  apiMock.get.mockImplementation((url) => Promise.resolve(routeFor(String(url))));
+  apiMock.post.mockResolvedValue({ data: {} });
+  apiMock.patch.mockImplementation((_url, body) => Promise.resolve({ data: { ...TOURNAMENT, ...body } }));
+  apiMock.delete.mockResolvedValue({ data: {} });
+});
+
+test("laedt das Turnier und zeigt Titel und Status", async () => {
+  renderPage();
+
+  expect(await screen.findByRole("heading", { name: "Winter Cup 2026" })).toBeInTheDocument();
+  await waitFor(() => expect(apiMock.get).toHaveBeenCalledWith(expect.stringContaining("/tournaments/t-1")));
+  expect(screen.getByTestId("admin-tr-status-select")).toHaveValue("registration_open");
+});
+
+test("die Arbeitsreiter sind vorhanden und lassen sich wechseln", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  for (const key of ["participants", "bracket", "stages", "staff", "edit"]) {
+    expect(screen.getByTestId(`admin-tr-tab-${key}`)).toBeInTheDocument();
+  }
+
+  const editTab = screen.getByTestId("admin-tr-tab-edit");
+  await user.click(editTab);
+
+  expect(editTab.className).toContain("border-b-2");
+});
+
+test("der Gruppenreiter erscheint nur bei Gruppenformat", async () => {
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  expect(screen.queryByTestId("admin-tr-tab-groups")).not.toBeInTheDocument();
+});
+
+test("eine Statusaenderung schickt genau einen Aufruf mit dem neuen Status", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+  apiMock.post.mockClear();
+
+  await user.selectOptions(screen.getByTestId("admin-tr-status-select"), "registration_closed");
+
+  await waitFor(() => expect(apiMock.post).toHaveBeenCalledWith(
+    expect.stringContaining("/tournaments/t-1/status"),
+    expect.objectContaining({ status: "registration_closed" })
+  ));
+  const statusCalls = apiMock.post.mock.calls.filter(([url]) => String(url).includes("/status"));
+  expect(statusCalls).toHaveLength(1);
+});
+
+test("ein Ladefehler wird angezeigt statt endlos zu laden", async () => {
+  apiMock.get.mockRejectedValue(new Error("Backend nicht erreichbar"));
+
+  renderPage();
+
+  expect(await screen.findByTestId("admin-tr-load-error")).toBeInTheDocument();
+  expect(screen.queryByRole("heading", { name: "Winter Cup 2026" })).not.toBeInTheDocument();
+});
+
+test("ein Ausfall der Nebendaten blockiert das Turnier nicht", async () => {
+  // Nur Personal-, Nutzer- und Teamlisten fallen aus: die Seite muss trotzdem stehen.
+  apiMock.get.mockImplementation((url) => {
+    const path = String(url);
+    if (path.includes("/staff") || path.startsWith("/users") || path.startsWith("/teams")) {
+      return Promise.reject(new Error("Teil-API nicht erreichbar"));
+    }
+    return Promise.resolve(routeFor(path));
+  });
+
+  renderPage();
+
+  expect(await screen.findByRole("heading", { name: "Winter Cup 2026" })).toBeInTheDocument();
+  expect(screen.queryByTestId("admin-tr-load-error")).not.toBeInTheDocument();
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     restoreMocks: true,
+    setupFiles: ["./src/setupTests.js"],
     include: ["src/**/*.{test,spec}.{js,jsx,ts,tsx}"],
     coverage: { reporter: ["text", "lcov"] },
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.4.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.5.0.tgz#b5b71a25a4d16afa2482592ddfa62fccc60bc7d1"
+  integrity sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -28,6 +33,15 @@
     is-potential-custom-element-name "^1.0.1"
     lru-cache "^11.5.2"
 
+"@babel/code-frame@^7.10.4":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/helper-string-parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
@@ -44,6 +58,11 @@
   integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
   dependencies:
     "@babel/types" "^7.29.8"
+
+"@babel/runtime@^7.12.5":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/types@^7.29.7", "@babel/types@^7.29.8":
   version "7.29.8"
@@ -995,6 +1014,44 @@
   resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
   integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
+"@testing-library/dom@^10.4.1":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
+"@testing-library/jest-dom@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz#649a9a8b2039f28d29f9f7a46eba9a8b727f811e"
+  integrity sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==
+  dependencies:
+    "@adobe/css-tools" "^4.4.0"
+    aria-query "^5.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.3"
+    picocolors "^1.1.1"
+    redent "^3.0.0"
+
+"@testing-library/react@^16.3.3":
+  version "16.3.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.3.tgz#426907e7716f37038dab8aa69d8f0459f9ec24b2"
+  integrity sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@testing-library/user-event@^14.6.7":
+  version "14.6.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.7.tgz#c453ccfcaffed110cc79048ed18fccb0f4224f3b"
+  integrity sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==
+
 "@tiptap/core@3.31.3":
   version "3.31.3"
   resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-3.31.3.tgz#97e1a5aa228ee8bce19b23d6570d4985446a0b9b"
@@ -1215,6 +1272,11 @@
     "@tiptap/extensions" "3.31.3"
     "@tiptap/pm" "3.31.3"
 
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
+
 "@types/chai@^5.2.2":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
@@ -1414,12 +1476,22 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -1451,7 +1523,14 @@ aria-hidden@^1.2.4:
   dependencies:
     tslib "^2.0.0"
 
-aria-query@^5.3.2:
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
+aria-query@^5.0.0, aria-query@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
@@ -1809,6 +1888,11 @@ css-tree@^3.0.0, css-tree@^3.2.1:
     mdn-data "2.27.1"
     source-map-js "^1.2.1"
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -1982,6 +2066,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
@@ -2008,6 +2097,16 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-accessibility-api@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
+  integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -2720,6 +2819,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 input-otp@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/input-otp/-/input-otp-1.5.0.tgz#3374c67458084b9bad5ee75d09204bce5a9ebdc3"
@@ -2988,7 +3092,7 @@ js-tokens@^10.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
   integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3204,6 +3308,11 @@ lucide-react@^0.577.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.577.0.tgz#8ae89edd8415f99c6319a38b40d9c513f6fa5062"
   integrity sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.30.21:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
@@ -3261,6 +3370,11 @@ mime-types@^2.1.35:
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.1.2, minimatch@^3.1.5:
   version "3.1.5"
@@ -3485,7 +3599,7 @@ pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -3590,6 +3704,15 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 prop-types@^15.8.1:
   version "15.8.1"
@@ -3755,6 +3878,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 "react-redux@8.x.x || 9.x.x":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.2.0.tgz#96c3ab23fb9a3af2cb4654be4b51c989e32366f5"
@@ -3845,6 +3973,14 @@ recharts@^3.10.1:
     tiny-invariant "^1.3.3"
     use-sync-external-store "^1.2.2"
     victory-vendor "^37.0.2"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redux-thunk@^3.1.0:
   version "3.1.0"
@@ -4203,6 +4339,13 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Zwei Teile, ein Thema: das fehlende Sicherheitsnetz im Frontend

### Teil 1 — Overlays per Tastatur bedienbar

Die vier Overlays, die **nicht** über Radix laufen, ließen sich per Tastatur nicht schließen: kein Escape, kein Fokus im Dialog, kein Rückweg zum auslösenden Element. Beim `ConfirmDialog` betrifft das ausgerechnet die Bestätigung destruktiver Admin-Aktionen.

Neuer Hook `useModalBehavior` — Escape schließt, Tab bleibt im Overlay (in beide Richtungen), der Fokus kehrt zurück, wo er herkam. Angewendet auf `ConfirmDialog`, `CrownCelebration`, `LevelUpCelebration` und `AchievementUnlockOverlay`; letzteres hatte zusätzlich gar keine Dialogrolle.

`autoFocus` im ConfirmDialog konnte entfallen — der Hook setzt den Fokus ohnehin auf das erste bedienbare Element.

**a11y-Restliste: 91 → 79.** Die vier Overlays stehen nicht mehr drin. Wo ein Klick daneben schließt, steht eine begründete Ausnahme im Code statt eines Schuldenpostens — der Tastaturweg existiert ja jetzt.

### Teil 2 — Testinfrastruktur und die ersten echten Seitentests

`vitest` und `jsdom` standen bereit, aber **React Testing Library war nicht installiert** — Komponententests waren schlicht unmöglich. Jetzt drin, inklusive `setupTests.js`.

Damit die ersten Tests für die größte Seite des Frontends (`AdminTournamentEditPage`, 2259 Zeilen, bisher **null** Tests). Beim Schreiben sind **zwei echte Fehler** aufgefallen:

1. **`load()` wurde ohne `catch` aufgerufen** (in `useEffect` und `useApiInvalidation`). War das Backend nicht erreichbar, blieb die Seite stumm auf „Lade…" stehen und die Rejection landete unbehandelt in der Konsole. Jetzt wird der Fehler angezeigt.
2. **Der Admin-Zweig der Ladefunktion hatte kein `try/catch`** — anders als der Moderator-Zweig direkt darunter. Eine fehlschlagende Nutzer- oder Teamliste machte damit das ganze Turnier unsichtbar, obwohl die Turnierdaten längst geladen waren.

Der Statuswechsel-Test hat außerdem gleich meine eigene falsche Annahme korrigiert: der Wechsel läuft über `POST /status`, nicht über `PATCH`.

Dazu 27 Tests für den **Speicherpfad, den sich die großen Admin-Seiten teilen**: `dirtyPayload` entscheidet, was überhaupt an die API geht (ein Fehler dort = verlorene Änderungen oder ungewolltes Überschreiben), `datetime` wandelt Formulareingaben um und bestimmt den Anmeldestatus. Beide waren ungetestet.

## Nachweise

- Frontend: **83 Tests grün** (vorher 34), Produktionsbuild sauber, `yarn lint` 0 Fehler
- Kein E2E-Test berührt die geänderten Overlays

## Was in Phase 2 noch offen bleibt

`AdminSettingsPage` und `ProfilePage` sowie die RNTL-Tests für die Mobile-Screens — beides eigene PRs, damit dieser hier reviewbar bleibt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)