### PR TITLE
test: Speicherpfade von Einstellungen und Profil absichern

### DIFF
--- a/frontend/src/pages/admin/AdminSettingsPage.test.jsx
+++ b/frontend/src/pages/admin/AdminSettingsPage.test.jsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ConfirmDialogProvider } from "@/components/tls/ConfirmDialog";
+
+// Diese Seite pflegt Mail-, Discord- und Branding-Zugaenge. Der wichtigste
+// Punkt hier ist eine Sicherheitszusage aus der Dokumentation: ein leer
+// gelassenes Secret-Feld darf gespeicherte Zugangsdaten NICHT ueberschreiben.
+// Ginge das schief, wuerde ein harmloses Speichern der Absenderadresse in
+// Produktion den SMTP- oder Resend-Zugang loeschen.
+
+const apiMock = { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() };
+const toastMock = { success: vi.fn(), error: vi.fn(), info: vi.fn(), message: vi.fn() };
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+  formatApiError: (detail) => String(detail || "Fehler"),
+  formatRequestError: (error, fallback) => fallback || String(error),
+  resolveMediaUrl: (value) => value || "",
+}));
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({ isAdmin: true, isSuperadmin: false, user: { id: "admin-1" } }),
+}));
+vi.mock("@/hooks/useApiInvalidation", () => ({ useApiInvalidation: () => {} }));
+vi.mock("@/lib/brandingEvents", () => ({ setCachedBranding: vi.fn() }));
+vi.mock("@/components/tls/AdminLayout", () => ({
+  AdminLayout: ({ children }) => <div data-testid="admin-layout">{children}</div>,
+}));
+vi.mock("@/components/tls/ImageUpload", () => ({
+  ImageUpload: () => <div data-testid="image-upload" />,
+  useImageUploadBusy: () => false,
+}));
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+const AdminSettingsPage = (await import("./AdminSettingsPage")).default;
+
+const EMAIL_SETTINGS = {
+  enabled: true,
+  sender_name: "THE LION SQUAD",
+  sender_email: "noreply@lionsquad.at",
+  reply_to_email: "office@lionsquad.at",
+  resend_api_key_masked: "re_****abcd",
+};
+
+function responseFor(url) {
+  const path = String(url);
+  if (path.startsWith("/settings/email/logs")) return { data: [] };
+  if (path.startsWith("/settings/email")) return { data: EMAIL_SETTINGS };
+  if (path.startsWith("/settings/branding")) return { data: { club_name: "THE LION SQUAD" } };
+  if (path.startsWith("/settings/discord")) return { data: { enabled: false } };
+  if (path.startsWith("/settings/smtp")) return { data: { smtp_host: "192.168.2.106", smtp_pass_masked: "****" } };
+  return { data: [] };
+}
+
+function renderPage() {
+  return render(
+    <ConfirmDialogProvider>
+      <MemoryRouter initialEntries={["/admin/settings?tab=email"]}>
+        <AdminSettingsPage />
+      </MemoryRouter>
+    </ConfirmDialogProvider>
+  );
+}
+
+beforeEach(() => {
+  apiMock.get.mockImplementation((url) => Promise.resolve(responseFor(url)));
+  apiMock.put.mockResolvedValue({ data: {} });
+  apiMock.post.mockResolvedValue({ data: {} });
+});
+
+async function waitForLoadedEmailTab() {
+  await waitFor(() => expect(screen.getByTestId("email-sender-name")).toHaveValue("THE LION SQUAD"));
+}
+
+test("laedt die Mail-Einstellungen in die Felder", async () => {
+  renderPage();
+
+  await waitForLoadedEmailTab();
+  expect(screen.getByTestId("email-sender-email")).toHaveValue("noreply@lionsquad.at");
+  expect(screen.getByTestId("email-reply-to")).toHaveValue("office@lionsquad.at");
+});
+
+test("das Secret-Feld startet leer, damit der gespeicherte Key nicht im Browser landet", async () => {
+  renderPage();
+  await waitForLoadedEmailTab();
+
+  expect(screen.getByTestId("email-api-key")).toHaveValue("");
+});
+
+test("ein leeres Secret-Feld ueberschreibt den gespeicherten Key nicht", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForLoadedEmailTab();
+
+  await user.clear(screen.getByTestId("email-sender-name"));
+  await user.type(screen.getByTestId("email-sender-name"), "TLS Turnierleitung");
+  await user.click(screen.getByTestId("email-save"));
+
+  await waitFor(() => expect(apiMock.put).toHaveBeenCalledWith("/settings/email", expect.anything()));
+  const [, payload] = apiMock.put.mock.calls.at(-1);
+  expect(payload.sender_name).toBe("TLS Turnierleitung");
+  expect("resend_api_key" in payload).toBe(false);
+});
+
+test("ein ausgefuelltes Secret-Feld wird dagegen gespeichert", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForLoadedEmailTab();
+
+  await user.type(screen.getByTestId("email-api-key"), "re_neuer_key");
+  await user.click(screen.getByTestId("email-save"));
+
+  await waitFor(() => expect(apiMock.put).toHaveBeenCalled());
+  const [, payload] = apiMock.put.mock.calls.at(-1);
+  expect(payload.resend_api_key).toBe("re_neuer_key");
+});
+
+test("nur geaenderte Felder werden geschickt", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForLoadedEmailTab();
+
+  await user.clear(screen.getByTestId("email-reply-to"));
+  await user.type(screen.getByTestId("email-reply-to"), "turniere@lionsquad.at");
+  await user.click(screen.getByTestId("email-save"));
+
+  await waitFor(() => expect(apiMock.put).toHaveBeenCalled());
+  const [, payload] = apiMock.put.mock.calls.at(-1);
+  expect(payload).toEqual({ reply_to_email: "turniere@lionsquad.at" });
+});
+
+test("ohne Aenderung wird gar nicht gespeichert", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForLoadedEmailTab();
+
+  await user.click(screen.getByTestId("email-save"));
+
+  await waitFor(() => expect(toastMock.info).toHaveBeenCalledWith("Keine Änderungen zum Speichern."));
+  expect(apiMock.put).not.toHaveBeenCalled();
+});
+
+test("ein Ausfall einzelner Bereiche legt die Seite nicht lahm", async () => {
+  apiMock.get.mockImplementation((url) => {
+    const path = String(url);
+    if (path.includes("mail-queue") || path.includes("system-status") || path.includes("streams/status")) {
+      return Promise.reject(new Error("Teilbereich nicht erreichbar"));
+    }
+    return Promise.resolve(responseFor(path));
+  });
+
+  renderPage();
+
+  await waitForLoadedEmailTab();
+  expect(screen.getByTestId("admin-layout")).toBeInTheDocument();
+});

--- a/frontend/src/pages/user/ProfilePage.test.jsx
+++ b/frontend/src/pages/user/ProfilePage.test.jsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ConfirmDialogProvider } from "@/components/tls/ConfirmDialog";
+
+// Das Profil ist die Seite, die jedes Mitglied selbst bearbeitet. Getestet wird
+// der Speicherpfad: es darf nur schicken, was wirklich geaendert wurde, und die
+// Sichtbarkeitseinstellung muss verlaesslich mitgehen - ein Fehler dort macht
+// ein privates Profil oeffentlich.
+
+const apiMock = { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() };
+const toastMock = { success: vi.fn(), error: vi.fn(), info: vi.fn(), message: vi.fn() };
+const refreshMock = vi.fn();
+
+const USER = {
+  id: "u-1",
+  username: "lionfan",
+  display_name: "Lion Fan",
+  email: "fan@lionsquad.at",
+  bio: "Kurze Vorstellung.",
+  privacy_public_profile: false,
+  favorite_games: ["rocket_league"],
+  main_platforms: [],
+  input_devices: [],
+  gaming_subscriptions: [],
+  game_ids: {},
+};
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+  formatRequestError: (error, fallback) => fallback || String(error),
+  resolveMediaUrl: (value) => value || "",
+}));
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({ user: USER, refresh: refreshMock, isClubMember: true }),
+}));
+vi.mock("@/hooks/useApiInvalidation", () => ({ useApiInvalidation: () => {} }));
+vi.mock("@/hooks/usePublicSiteSettings", () => ({ usePublicSiteSettings: () => ({ settings: {}, loading: false }) }));
+vi.mock("@/components/tls/PublicLayout", () => ({
+  PublicLayout: ({ children }) => <div data-testid="public-layout">{children}</div>,
+}));
+vi.mock("@/components/tls/ImageUpload", () => ({ ImageUpload: () => <div data-testid="image-upload" /> }));
+vi.mock("@/components/tls/MultiSelect", () => ({ MultiSelect: () => <div data-testid="multi-select" /> }));
+vi.mock("@/components/tls/AchievementGroups", () => ({ AchievementGroupsView: () => <div data-testid="achievement-groups" /> }));
+vi.mock("@/components/tls/AchievementUnlockOverlay", () => ({ AchievementUnlockOverlay: () => null }));
+vi.mock("@/components/tls/GermanDateField", () => ({ GermanDateField: () => <div data-testid="german-date" /> }));
+vi.mock("@/components/tls/GoogleAuthButton", () => ({ GoogleAuthButton: () => <div data-testid="google-auth" /> }));
+vi.mock("@/components/tls/MfaSetupPanel", () => ({ MfaSetupPanel: () => <div data-testid="mfa-panel" /> }));
+vi.mock("@/components/tls/PasskeysPanel", () => ({ PasskeysPanel: () => <div data-testid="passkeys-panel" /> }));
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+const ProfilePage = (await import("./ProfilePage")).default;
+
+function renderPage() {
+  return render(
+    <ConfirmDialogProvider>
+      <MemoryRouter initialEntries={["/profile"]}>
+        <ProfilePage />
+      </MemoryRouter>
+    </ConfirmDialogProvider>
+  );
+}
+
+beforeEach(() => {
+  apiMock.get.mockResolvedValue({ data: [] });
+  apiMock.post.mockResolvedValue({ data: {} });
+  apiMock.patch.mockImplementation((_url, body) => Promise.resolve({ data: { ...USER, ...body } }));
+});
+
+async function waitForForm() {
+  await waitFor(() => expect(screen.getByTestId("profile-bio")).toHaveValue("Kurze Vorstellung."));
+}
+
+async function openPrivacyTab(user) {
+  await user.click(screen.getByRole("button", { name: /Privatsphäre/i }));
+  return screen.findByTestId("profile-privacy");
+}
+
+test("laedt die eigenen Profildaten in das Formular", async () => {
+  const user = userEvent.setup();
+  renderPage();
+
+  await waitForForm();
+  expect(await openPrivacyTab(user)).not.toBeChecked();
+});
+
+test("speichert nur das tatsaechlich geaenderte Feld", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForForm();
+
+  await user.clear(screen.getByTestId("profile-bio"));
+  await user.type(screen.getByTestId("profile-bio"), "Neue Vorstellung.");
+  await user.click(screen.getByTestId("profile-save"));
+
+  await waitFor(() => expect(apiMock.patch).toHaveBeenCalledWith("/users/me", expect.anything()));
+  const [, payload] = apiMock.patch.mock.calls.at(-1);
+  expect(payload).toEqual({ bio: "Neue Vorstellung." });
+});
+
+test("die Sichtbarkeitseinstellung wird mitgeschickt", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForForm();
+
+  await user.click(await openPrivacyTab(user));
+  await user.click(screen.getByTestId("profile-save"));
+
+  await waitFor(() => expect(apiMock.patch).toHaveBeenCalled());
+  const [, payload] = apiMock.patch.mock.calls.at(-1);
+  expect(payload.privacy_public_profile).toBe(true);
+});
+
+test("ohne Aenderung wird nicht gespeichert", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForForm();
+
+  await user.click(screen.getByTestId("profile-save"));
+
+  await waitFor(() => expect(toastMock.info).toHaveBeenCalledWith("Keine Änderungen zum Speichern."));
+  expect(apiMock.patch).not.toHaveBeenCalled();
+});
+
+test("nach dem Speichern wird die Sitzung aktualisiert", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await waitForForm();
+
+  await user.type(screen.getByTestId("profile-bio"), " Ergaenzung.");
+  await user.click(screen.getByTestId("profile-save"));
+
+  await waitFor(() => expect(refreshMock).toHaveBeenCalled());
+  expect(toastMock.success).toHaveBeenCalledWith("Profil gespeichert.");
+});
+
+test("ein Speicherfehler meldet sich und laesst die Eingabe stehen", async () => {
+  const user = userEvent.setup();
+  apiMock.patch.mockRejectedValue(new Error("Serverfehler"));
+  renderPage();
+  await waitForForm();
+
+  await user.clear(screen.getByTestId("profile-bio"));
+  await user.type(screen.getByTestId("profile-bio"), "Bleibt erhalten.");
+  await user.click(screen.getByTestId("profile-save"));
+
+  await waitFor(() => expect(toastMock.error).toHaveBeenCalledWith("Profil konnte nicht gespeichert werden."));
+  expect(screen.getByTestId("profile-bio")).toHaveValue("Bleibt erhalten.");
+});


### PR DESCRIPTION
## Worum es geht

Die beiden verbleibenden Monster-Seiten aus Phase 2 (`AdminSettingsPage` 2101 Zeilen, `ProfilePage` 1801 Zeilen) hatten keinen einzigen Test. Beide speichern über `buildDirtyPayload` — also genau dort, wo ein Fehler entweder Änderungen verliert oder Bestehendes überschreibt.

## AdminSettingsPage

Der wichtigste Test ist sicherheitsrelevant und hielt bisher nur die Dokumentation fest: **ein leer gelassenes Secret-Feld darf gespeicherte Zugänge nicht überschreiben.**

Der Test belegt, dass beim Speichern der Absenderadresse kein `resend_api_key` mitgeht. Ginge das schief, würde eine harmlose Änderung in Produktion den Mailversand abschalten — dasselbe Muster schützt SMTP-Passwort, Discord-Webhook und Twitch-Secret.

Dazu:
- Das Secret-Feld startet leer (der gespeicherte Key landet nie im Browser)
- Ein *ausgefülltes* Feld wird sehr wohl gespeichert
- Nur geänderte Felder gehen raus
- Ohne Änderung wird gar nicht geschrieben
- Ein Ausfall einzelner Teilbereiche (`Promise.allSettled`) legt die Seite nicht lahm

## ProfilePage

- Speichern schickt nur das tatsächlich geänderte Feld
- Die Sichtbarkeitseinstellung geht verlässlich mit — ein Fehler dort macht ein privates Profil öffentlich
- Ohne Änderung wird nicht geschrieben
- Nach dem Speichern wird die Sitzung aktualisiert
- Ein Serverfehler lässt die Eingabe stehen, statt sie zu verwerfen

## Nachweise

- Frontend: **96 Tests grün** (vorher 83), Build sauber, `yarn lint` 0 Fehler
- Keine Produktivänderung in diesem PR — reine Testabdeckung

## Danach

Damit sind die drei im Audit benannten Web-Seiten abgedeckt. Als Nächstes die RNTL-Tests für die Mobile-Screens; dort ist zuerst ein Infrastruktur-Schritt nötig, weil in `mobile/` noch kein Testframework installiert ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)