### PR TITLE
feat: Block 0 — Sicherheitsnetz für die Turnier-Vereinheitlichung

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -130,6 +130,11 @@ async def init_indexes():
     # operations when multiple API workers receive the same action at once.
     await db.mutation_locks.create_index("resource", unique=True)
     await db.mutation_locks.create_index("expires_at", expireAfterSeconds=0)
+    # Which competition write path actually runs.  Needed to decide - with
+    # numbers instead of assumptions - when the classic store may be retired.
+    await db.competition_write_usage.create_index([("created_at", -1)])
+    await db.competition_write_usage.create_index([("engine", 1), ("capability", 1), ("created_at", -1)])
+    await db.competition_write_usage.create_index("created_at", expireAfterSeconds=180 * 24 * 3600)
     # Auth helpers
     await db.password_reset_tokens.create_index("expires_at", expireAfterSeconds=0)
     await db.email_verification_tokens.create_index("token_hash", unique=True)

--- a/backend/routes/match_routes.py
+++ b/backend/routes/match_routes.py
@@ -38,6 +38,7 @@ from services.rate_limit import enforce_rate_limit
 from services.station_labels import attach_station_info
 from services.user_notifications import create_user_notification
 from services.v2_result_submission import submit_v2_result
+from services.competition_usage import engine_for_match, record_write
 
 router = APIRouter(prefix="/api/matches", tags=["matches"])
 STAFF_ROLES = {"moderator", "tournament_admin", "club_admin", "superadmin"}
@@ -196,6 +197,14 @@ def _score_report_resolution(match: dict, reports: list[dict]) -> dict | None:
 
 
 async def _audit_match_action(db, action: str, match: dict, actor_id: str | None, data: dict | None = None) -> None:
+    # Jede auditierte Match-Aenderung ist zugleich ein Schreibvorgang einer der
+    # beiden Engines. Die Messung hängt deshalb hier und nicht an jedem
+    # einzelnen Aufrufer.
+    await record_write(
+        engine_for_match(match),
+        action,
+        tournament_id=match.get("tournament_id"),
+    )
     await db.audit_logs.insert_one({
         "id": new_id(),
         "action": action,

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -77,6 +77,7 @@ from bracket_extensions import (
 )
 from services.user_notifications import create_user_notification
 from services.query_filters import safe_regex
+from services.competition_usage import record_write
 
 router = APIRouter(prefix="/api/tournaments", tags=["tournaments"])
 logger = logging.getLogger("tls.tournament")
@@ -881,6 +882,14 @@ async def _enrich_game_identity(db, game: dict | None) -> dict | None:
 
 async def _audit_tournament_action(db, action: str, actor_id: str | None,
                                    target_id: str, data: dict | None = None) -> None:
+    # Strukturarbeit ist der zweite Schreibweg neben den Ergebnissen; welche
+    # Engine dabei bedient wurde, steht in den mitgegebenen Daten.
+    await record_write(
+        (data or {}).get("engine") or "unknown",
+        action,
+        tournament_id=target_id,
+        format_key=(data or {}).get("format"),
+    )
     await db.audit_logs.insert_one({
         "id": new_id(),
         "action": action,

--- a/backend/services/competition_capabilities.py
+++ b/backend/services/competition_capabilities.py
@@ -1,0 +1,165 @@
+"""Inventory of everything a tournament can do today, and in which engine.
+
+This file exists for one reason: the platform runs two competition write models
+side by side (``classic`` on ``matches``, ``graph`` on ``matches_v2``), and they
+are supposed to become one. During that consolidation the honest question after
+every step is "did anything a user could do yesterday stop working today?".
+
+An inventory answers that question only if it is checked by a test rather than
+maintained by good intentions, so ``test_tournament_capability_inventory.py``
+verifies three things against the running application:
+
+  * every endpoint listed here still exists,
+  * every endpoint of the competition routers appears in exactly one capability,
+  * the engine support recorded here matches what is actually wired up.
+
+That makes the file fail loudly when a route is removed, when a new one is added
+without being classified, and when a gap is closed - the last one on purpose:
+closing a gap should require saying so here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+CLASSIC = "classic"
+GRAPH = "graph"
+ENGINE_NEUTRAL = "neutral"
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One thing a member, staffer or admin can do with a competition."""
+
+    key: str
+    label: str
+    endpoints: tuple[str, ...]
+    engines: tuple[str, ...]
+    note: str = ""
+    gap: str = field(default="")
+
+    @property
+    def is_gap(self) -> bool:
+        return bool(self.gap)
+
+
+def _c(key, label, endpoints, engines, note="", gap=""):
+    return Capability(key=key, label=label, endpoints=tuple(endpoints), engines=tuple(engines), note=note, gap=gap)
+
+
+# Endpoints are written exactly as FastAPI reports them: "METHOD /full/path".
+CAPABILITIES: tuple[Capability, ...] = (
+    # ---------- Turnier-Lebenszyklus (engine-neutral) ----------
+    _c("tournament.browse", "Turniere ansehen",
+       ["GET /api/tournaments", "GET /api/tournaments/{slug_or_id}"], [ENGINE_NEUTRAL]),
+    _c("tournament.create", "Turnier anlegen",
+       ["POST /api/tournaments"], [ENGINE_NEUTRAL]),
+    _c("tournament.edit", "Turnier bearbeiten",
+       ["PUT /api/tournaments/{tid}", "PATCH /api/tournaments/{tid}"], [ENGINE_NEUTRAL]),
+    _c("tournament.delete", "Turnier löschen",
+       ["DELETE /api/tournaments/{tid}"], [ENGINE_NEUTRAL]),
+    _c("tournament.lock", "Turnier sperren und entsperren",
+       ["POST /api/tournaments/{tid}/lock", "POST /api/tournaments/{tid}/unlock"], [ENGINE_NEUTRAL]),
+    _c("tournament.status", "Turnierstatus wechseln",
+       ["POST /api/tournaments/{tid}/status"], [ENGINE_NEUTRAL],
+       note="Löst bei check_in und live zusätzlich Strukturarbeit aus."),
+    _c("tournament.chat", "Turnier-Chat",
+       ["GET /api/tournaments/{tid}/chat", "POST /api/tournaments/{tid}/chat"], [ENGINE_NEUTRAL]),
+
+    # ---------- Teilnahme ----------
+    _c("registration.list", "Anmeldungen einsehen",
+       ["GET /api/tournaments/{tid}/registrations", "GET /api/tournaments/{tid}/assignable-users"], [ENGINE_NEUTRAL]),
+    _c("registration.self", "Selbst anmelden",
+       ["POST /api/tournaments/{tid}/register"], [ENGINE_NEUTRAL]),
+    _c("registration.manage", "Anmeldung anlegen, ändern, entfernen",
+       ["POST /api/tournaments/{tid}/registrations",
+        "PUT /api/tournaments/{tid}/registrations/{reg_id}",
+        "PATCH /api/tournaments/{tid}/registrations/{reg_id}",
+        "DELETE /api/tournaments/{tid}/registrations/{reg_id}"], [ENGINE_NEUTRAL]),
+    _c("registration.checkin", "Check-in",
+       ["POST /api/tournaments/{tid}/registrations/{reg_id}/checkin",
+        "POST /api/tournaments/{tid}/checkin"], [ENGINE_NEUTRAL]),
+    _c("staff.manage", "Turnier-Team verwalten",
+       ["GET /api/tournaments/{tid}/staff", "POST /api/tournaments/{tid}/staff",
+        "PATCH /api/tournaments/{tid}/staff/{assignment_id}",
+        "PUT /api/tournaments/{tid}/staff/{assignment_id}",
+        "DELETE /api/tournaments/{tid}/staff/{assignment_id}"], [ENGINE_NEUTRAL]),
+
+    # ---------- Struktur erzeugen ----------
+    _c("structure.generate.classic", "Turnierbaum erzeugen (klassisch)",
+       ["POST /api/tournaments/{tid}/generate-bracket"], [CLASSIC]),
+    _c("structure.from_format", "Struktur aus Format aufbauen",
+       ["POST /api/tournaments/{tid}/bracket/from-format"], [CLASSIC, GRAPH],
+       note="Wählt je Format die Engine - und wechselt dabei bei Single/Double den Speicher."),
+    _c("structure.reset", "Struktur zurücksetzen",
+       ["POST /api/tournaments/{tid}/reset-bracket"], [CLASSIC, GRAPH]),
+    _c("structure.plan_apply", "Struktur planen und anwenden",
+       ["POST /api/tournaments/{tid}/bracket/plan", "POST /api/tournaments/{tid}/bracket/apply"], [GRAPH],
+       note="Vollständig gebaut, aber ohne Aufrufer - Entscheidung steht in Block 1 an."),
+    _c("structure.stages", "Abschnitte verwalten",
+       ["GET /api/tournaments/{tid}/stages", "POST /api/tournaments/{tid}/stages",
+        "PATCH /api/tournaments/{tid}/stages/{stage_id}", "PUT /api/tournaments/{tid}/stages/{stage_id}",
+        "DELETE /api/tournaments/{tid}/stages/{stage_id}",
+        "POST /api/tournaments/{tid}/stages/{stage_id}/generate"], [GRAPH]),
+    _c("structure.swiss", "Schweizer Runde erzeugen",
+       ["POST /api/tournaments/{tid}/swiss/next-round"], [CLASSIC],
+       gap="Kein Generator im Graph-System - Block 3."),
+    _c("structure.groups", "Gruppen erzeugen",
+       ["POST /api/tournaments/{tid}/groups/generate", "GET /api/tournaments/{tid}/groups"], [CLASSIC],
+       gap="Kein Generator im Graph-System - Block 3."),
+
+    # ---------- Struktur lesen ----------
+    _c("structure.read", "Turnierbaum und Abschnitte lesen",
+       ["GET /api/tournaments/{tid}/bracket", "GET /api/tournaments/{tid}/bracket/display",
+        "GET /api/tournaments/{tid}/matches-v2"], [CLASSIC, GRAPH],
+       note="Liefert bereits die gemeinsame Struktur mit; das Frontend liest sie noch nicht."),
+    _c("standings.read", "Tabelle lesen",
+       ["GET /api/tournaments/{tid}/standings"], [CLASSIC, GRAPH]),
+    _c("planning.check", "Planungsprüfung und Spielplan-Export",
+       ["GET /api/tournaments/{tid}/planning-check", "GET /api/tournaments/{tid}/match-plan.csv"], [CLASSIC, GRAPH]),
+
+    # ---------- Matches lesen ----------
+    _c("match.read", "Match ansehen",
+       ["GET /api/matches/{match_id}", "GET /api/matches/{match_id}/page",
+        "GET /api/matches/upcoming", "GET /api/matches/operations"], [CLASSIC, GRAPH]),
+    _c("match.chat", "Match-Chat",
+       ["GET /api/matches/{match_id}/chat", "POST /api/matches/{match_id}/chat"], [CLASSIC, GRAPH]),
+    _c("match.schedule", "Termin vorschlagen und entscheiden",
+       ["GET /api/matches/{match_id}/schedule-proposals",
+        "POST /api/matches/{match_id}/schedule-proposals",
+        "POST /api/matches/{match_id}/schedule-proposals/{proposal_id}/decision"], [CLASSIC, GRAPH]),
+
+    # ---------- Ergebnisse schreiben ----------
+    _c("result.staff_entry", "Ergebnis durch Turnierleitung eintragen",
+       ["PUT /api/matches/{match_id}", "PATCH /api/matches/{match_id}"], [CLASSIC, GRAPH],
+       note="Verzweigt intern nach Engine; im Graph-Zweig werden Score-Felder verworfen."),
+    _c("result.submit", "Ergebnis melden",
+       ["POST /api/matches/{match_id}/result"], [GRAPH]),
+    _c("result.report", "Ergebnis im Einvernehmen bestätigen",
+       ["POST /api/matches/{match_id}/report"], [CLASSIC],
+       gap="Im Graph-System nicht vorhanden - Block 3."),
+    _c("result.dispute", "Ergebnis anfechten",
+       ["POST /api/matches/{match_id}/dispute"], [CLASSIC],
+       gap="Im Graph-System nicht vorhanden - Block 3."),
+    _c("result.forfeit", "Aufgabe eintragen",
+       ["POST /api/matches/{match_id}/forfeit"], [CLASSIC],
+       gap="Im Graph-System nicht vorhanden - Block 3."),
+    _c("result.recalculate", "Weiterleitung neu berechnen",
+       ["POST /api/tournaments/{tid}/matches-v2/recalculate-advancement"], [GRAPH]),
+)
+
+
+CAPABILITIES_BY_KEY = {capability.key: capability for capability in CAPABILITIES}
+
+
+def declared_endpoints() -> set[str]:
+    return {endpoint for capability in CAPABILITIES for endpoint in capability.endpoints}
+
+
+def capabilities_for_engine(engine: str) -> tuple[Capability, ...]:
+    return tuple(c for c in CAPABILITIES if engine in c.engines or ENGINE_NEUTRAL in c.engines)
+
+
+def open_gaps() -> tuple[Capability, ...]:
+    """Capabilities that exist in one engine only and block the consolidation."""
+    return tuple(c for c in CAPABILITIES if c.is_gap)

--- a/backend/services/competition_usage.py
+++ b/backend/services/competition_usage.py
@@ -1,0 +1,106 @@
+"""Records which competition write path actually runs.
+
+Before the classic store can be switched off, one question has to be answered
+with numbers rather than with confidence: is anything still writing to it? The
+codebase can show that a path *exists*; only measurement shows whether it is
+*used*, and by which format.
+
+Recording is deliberately best-effort. A failed measurement must never turn into
+a failed tournament operation, so every error is swallowed - a missing data point
+is acceptable, a broken result entry is not.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from database import get_db
+from models import now_utc
+
+logger = logging.getLogger("tls.competition.usage")
+
+COLLECTION = "competition_write_usage"
+
+CLASSIC = "classic"
+GRAPH = "graph"
+
+
+def engine_for_match(match: dict | None) -> str:
+    """Tell the two match shapes apart without asking the database again.
+
+    Graph matches carry a stage and slots; classic ones carry the fixed A/B
+    participant fields. Anything else is recorded as unknown rather than guessed
+    into one of the two - a wrong number here would be worse than a missing one.
+    """
+    if not match:
+        return "unknown"
+    if match.get("stage_id") or match.get("slots") is not None:
+        return GRAPH
+    if "participant_a_id" in match or "score_a" in match:
+        return CLASSIC
+    return "unknown"
+
+
+async def record_write(
+    engine: str,
+    capability: str,
+    *,
+    tournament_id: str | None = None,
+    format_key: str | None = None,
+    detail: str | None = None,
+) -> None:
+    """Note that one competition write happened. Never raises."""
+    try:
+        await get_db()[COLLECTION].insert_one({
+            "engine": engine,
+            "capability": capability,
+            "tournament_id": tournament_id,
+            "format": format_key,
+            "detail": detail,
+            "created_at": now_utc(),
+        })
+    except Exception as exc:
+        logger.debug("[usage] not recorded capability=%s type=%s", capability, type(exc).__name__)
+
+
+async def usage_summary(days: int = 30) -> dict:
+    """Counts per engine and capability for the given window.
+
+    This is the number the consolidation decisions hang on: as long as the
+    classic engine shows writes, switching it off would remove something that is
+    still in use.
+    """
+    since = now_utc() - timedelta(days=max(1, days))
+    db = get_db()
+    rows = await db[COLLECTION].aggregate([
+        {"$match": {"created_at": {"$gte": since}}},
+        {"$group": {
+            "_id": {"engine": "$engine", "capability": "$capability"},
+            "count": {"$sum": 1},
+            "last_at": {"$max": "$created_at"},
+            "tournaments": {"$addToSet": "$tournament_id"},
+        }},
+    ]).to_list(500)
+
+    by_engine: dict[str, int] = {}
+    capabilities = []
+    for row in rows:
+        engine = row["_id"].get("engine") or "unknown"
+        by_engine[engine] = by_engine.get(engine, 0) + row["count"]
+        capabilities.append({
+            "engine": engine,
+            "capability": row["_id"].get("capability") or "unknown",
+            "count": row["count"],
+            "last_at": row.get("last_at"),
+            "tournament_count": len([t for t in row.get("tournaments", []) if t]),
+        })
+
+    capabilities.sort(key=lambda item: (-item["count"], item["capability"]))
+    return {
+        "window_days": days,
+        "total": sum(by_engine.values()),
+        "by_engine": by_engine,
+        "classic_writes": by_engine.get(CLASSIC, 0),
+        "graph_writes": by_engine.get(GRAPH, 0),
+        "capabilities": capabilities,
+    }

--- a/backend/services/v2_result_submission.py
+++ b/backend/services/v2_result_submission.py
@@ -9,6 +9,7 @@ from models import now_utc
 from services.match_notifications import notify_match_result_confirmed
 from services.match_v2_results import build_v2_result_application, is_v2_result_replay, normalize_v2_results
 from services.station_runtime import release_station_for_match
+from services.competition_usage import GRAPH, record_write
 
 
 logger = logging.getLogger("tls.match_results")
@@ -48,6 +49,8 @@ async def _upsert_result_audit(
     force: bool,
     created_at: str,
 ) -> None:
+    # Gegenstueck zur Messung im klassischen Pfad: hier laeuft die Graph-Engine.
+    await record_write(GRAPH, audit_action, tournament_id=match.get("tournament_id"))
     await db.audit_logs.update_one(
         {"id": f"audit-{report_id}"},
         {"$setOnInsert": {

--- a/backend/tests/test_competition_usage_unit.py
+++ b/backend/tests/test_competition_usage_unit.py
@@ -1,0 +1,98 @@
+"""The measurement must never cost a tournament operation.
+
+Recording which engine wrote is useful, but it is bookkeeping. If the bookkeeping
+fails, the result entry it accompanies still has to succeed - otherwise a
+monitoring feature would become an outage. These tests pin that guarantee.
+"""
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services import competition_usage
+from services.competition_usage import CLASSIC, GRAPH, engine_for_match
+
+
+class _ExplodingCollection:
+    async def insert_one(self, _document):
+        raise RuntimeError("Datenbank nicht erreichbar")
+
+
+class _ExplodingDb:
+    def __getitem__(self, _name):
+        return _ExplodingCollection()
+
+
+class _RecordingCollection:
+    def __init__(self):
+        self.documents = []
+
+    async def insert_one(self, document):
+        self.documents.append(document)
+
+
+class _RecordingDb:
+    def __init__(self):
+        self.collection = _RecordingCollection()
+
+    def __getitem__(self, _name):
+        return self.collection
+
+
+# ---------------------------------------------------------------- Engine-Erkennung
+
+@pytest.mark.parametrize("match,expected", [
+    ({"stage_id": "s1"}, GRAPH),
+    ({"slots": []}, GRAPH),
+    ({"participant_a_id": "r1", "participant_b_id": "r2"}, CLASSIC),
+    ({"score_a": 3, "score_b": 1}, CLASSIC),
+    ({"id": "m1"}, "unknown"),
+    (None, "unknown"),
+])
+def test_engine_is_derived_from_the_match_shape(match, expected):
+    assert engine_for_match(match) == expected
+
+
+def test_a_graph_match_is_not_mistaken_for_a_classic_one():
+    """Graph matches may still carry legacy-looking fields; the stage decides."""
+    mixed = {"stage_id": "s1", "score_a": 2}
+    assert engine_for_match(mixed) == GRAPH
+
+
+# ---------------------------------------------------------------- Ausfallsicherheit
+
+def test_a_failing_database_does_not_raise(monkeypatch):
+    monkeypatch.setattr(competition_usage, "get_db", lambda: _ExplodingDb())
+
+    asyncio.run(competition_usage.record_write(CLASSIC, "match.result.update", tournament_id="t1"))
+
+
+def test_a_missing_database_does_not_raise(monkeypatch):
+    def boom():
+        raise RuntimeError("keine Verbindung")
+
+    monkeypatch.setattr(competition_usage, "get_db", boom)
+
+    asyncio.run(competition_usage.record_write(GRAPH, "match.result.update"))
+
+
+# ---------------------------------------------------------------- Inhalt
+
+def test_the_recorded_entry_carries_what_the_decision_needs(monkeypatch):
+    db = _RecordingDb()
+    monkeypatch.setattr(competition_usage, "get_db", lambda: db)
+
+    asyncio.run(competition_usage.record_write(
+        CLASSIC, "match.forfeit", tournament_id="t1", format_key="single_elim", detail="force",
+    ))
+
+    assert len(db.collection.documents) == 1
+    entry = db.collection.documents[0]
+    assert entry["engine"] == CLASSIC
+    assert entry["capability"] == "match.forfeit"
+    assert entry["tournament_id"] == "t1"
+    assert entry["format"] == "single_elim"
+    assert entry["created_at"] is not None

--- a/backend/tests/test_tournament_capability_inventory.py
+++ b/backend/tests/test_tournament_capability_inventory.py
@@ -1,0 +1,151 @@
+"""The safety net for the competition consolidation.
+
+Two write models are being merged into one. After every step of that work the
+question is the same: can a user still do everything they could do before? These
+tests answer it mechanically instead of by inspection.
+
+They fail when an endpoint disappears, when a new competition endpoint is added
+without being classified, and when a known gap is closed without recording it.
+The last one is deliberate - closing a gap is progress and should be written
+down, not slip through silently.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from routes.match_routes import router as match_router
+from routes.match_v2_routes import router as match_v2_router
+from routes.tournament_routes import router as tournament_router
+from services.competition_capabilities import (
+    CAPABILITIES,
+    CAPABILITIES_BY_KEY,
+    CLASSIC,
+    GRAPH,
+    declared_endpoints,
+    open_gaps,
+)
+from services.competition_formats import FORMAT_CAPABILITIES
+
+
+COMPETITION_ROUTERS = (tournament_router, match_router)
+
+
+def live_endpoints(*routers) -> set[str]:
+    found = set()
+    for router in routers:
+        for route in router.routes:
+            for method in sorted(getattr(route, "methods", []) or []):
+                if method in {"HEAD", "OPTIONS"}:
+                    continue
+                found.add(f"{method} {route.path}")
+    return found
+
+
+# ---------------------------------------------------------------- Vollständigkeit
+
+def test_every_declared_endpoint_exists():
+    """Nothing in the inventory may vanish unnoticed - this is the core promise."""
+    missing = sorted(declared_endpoints() - live_endpoints(*COMPETITION_ROUTERS, match_v2_router))
+    assert missing == [], (
+        "Diese Fähigkeiten sind im Inventar beschrieben, aber im Code nicht mehr vorhanden. "
+        "Entweder wurde eine Funktion entfernt, oder das Inventar muss angepasst werden."
+    )
+
+
+def test_every_competition_endpoint_is_classified():
+    """A new endpoint has to be classified, otherwise the inventory rots."""
+    unclassified = sorted(live_endpoints(*COMPETITION_ROUTERS) - declared_endpoints())
+    assert unclassified == [], (
+        "Diese Endpunkte gehören zu keiner Fähigkeit im Inventar. "
+        "Bitte in services/competition_capabilities.py einordnen."
+    )
+
+
+def test_capability_keys_are_unique():
+    keys = [capability.key for capability in CAPABILITIES]
+    assert len(keys) == len(set(keys))
+
+
+def test_every_capability_has_a_german_label_and_engines():
+    for capability in CAPABILITIES:
+        assert capability.label.strip(), capability.key
+        assert capability.endpoints, capability.key
+        assert capability.engines, capability.key
+
+
+# ---------------------------------------------------------------- Bekannte Lücken
+
+EXPECTED_GAPS = {
+    "structure.swiss",
+    "structure.groups",
+    "result.report",
+    "result.dispute",
+    "result.forfeit",
+}
+
+
+def test_known_gaps_are_exactly_the_recorded_ones():
+    """Block 3 closes these. When one is closed, this set has to shrink with it."""
+    assert {capability.key for capability in open_gaps()} == EXPECTED_GAPS
+
+
+@pytest.mark.parametrize("key", sorted(EXPECTED_GAPS))
+def test_each_gap_is_classic_only_today(key):
+    capability = CAPABILITIES_BY_KEY[key]
+    assert capability.engines == (CLASSIC,), (
+        f"{key} gilt als Lücke, ist aber nicht mehr nur klassisch verfuegbar. "
+        "Wenn die Lücke geschlossen wurde: Engines hier und EXPECTED_GAPS anpassen."
+    )
+
+
+# ---------------------------------------------------------------- Der tote Zwilling
+
+def test_match_v2_router_is_a_duplicate_without_own_capabilities():
+    """Documents that /api/matches-v2/* mirrors /api/matches/* and owns nothing.
+
+    Block 1 removes this router. Once it is gone the test has to be removed with
+    it - which is exactly the reminder we want at that moment.
+    """
+    v2_paths = {path.split(" ", 1)[1] for path in live_endpoints(match_v2_router)}
+    classic_paths = {path.split(" ", 1)[1] for path in live_endpoints(match_router)}
+
+    mirrored = {path.replace("/api/matches-v2", "/api/matches") for path in v2_paths}
+    assert mirrored <= classic_paths, "Der v2-Router hat eigene Pfade bekommen - vor dem Entfernen prüfen."
+
+    declared = declared_endpoints()
+    assert not any(path.startswith("/api/matches-v2") for path in
+                   {endpoint.split(" ", 1)[1] for endpoint in declared}), (
+        "Keine Fähigkeit darf auf den v2-Router zeigen, sonst kann Block 1 ihn nicht entfernen."
+    )
+
+
+# ---------------------------------------------------------------- Format-Abgleich
+
+def test_no_format_claims_to_be_write_ready_yet():
+    """Guards the migration order: a format may only be marked ready once its
+
+    gaps are closed. If this fails, somebody flipped the flag ahead of the work.
+    """
+    premature = [key for key, cap in FORMAT_CAPABILITIES.items() if cap.canonical_write_ready]
+    assert premature == [], (
+        "Diese Formate sind als schreibfertig markiert, obwohl die Vereinheitlichung laeuft: "
+        f"{premature}. Vor dem Setzen müssen die Lücken aus EXPECTED_GAPS geschlossen sein."
+    )
+
+
+def test_formats_that_switch_engine_on_rebuild_are_visible():
+    """Single/Double start classic and silently move to the graph store on rebuild.
+
+    Block 4 stops that. Until then the behaviour must at least be declared.
+    """
+    switching = [
+        key for key, cap in FORMAT_CAPABILITIES.items()
+        if cap.initial_preview_engine == "legacy" and cap.rebuild_engine == "stage"
+    ]
+    assert sorted(switching) == ["double_elim", "single_elim"], (
+        "Die Liste der Formate mit stillem Speicherwechsel hat sich geändert - "
+        "das ist genau der Punkt, den Block 4 abstellt."
+    )

--- a/scripts/route-inventory.py
+++ b/scripts/route-inventory.py
@@ -1,0 +1,71 @@
+"""Dump the application's HTTP route table for before/after comparison.
+
+A refactor that only moves code must not change a single route. Proving that by
+reading a diff of two thousand moved lines is hopeless; comparing two sorted
+route tables takes a second:
+
+    python scripts/route-inventory.py > before.txt
+    # ... refactor ...
+    python scripts/route-inventory.py > after.txt
+    diff before.txt after.txt
+
+Empty output from diff is the proof. This was used for the extras_routes split
+and is kept because the tournament consolidation will need it repeatedly.
+"""
+import os
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[1] / "backend"
+
+# Import-time configuration only; nothing here reaches a real database.
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET", "route-inventory-secret-with-at-least-32-chars")
+os.environ.setdefault("FRONTEND_URL", "http://localhost:3000")
+os.environ.setdefault("CORS_ORIGINS", "http://localhost:3000")
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "NQBHeGtQg5HYMo1HzvJtSQPN7X8YpJrZDvw-XMz0Bm8=")
+
+sys.path.insert(0, str(BACKEND))
+
+
+def main() -> int:
+    try:
+        from server import app
+    except Exception as exc:  # pragma: no cover - depends on local environment
+        print(f"# Anwendung nicht ladbar: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    rows: list[str] = []
+    collect(app.routes, rows)
+
+    for row in sorted(rows):
+        print(row)
+    print(f"# {len(rows)} Routen")
+    return 0
+
+
+def collect(routes, rows: list[str]) -> None:
+    """Walk the route tree.
+
+    Included routers are not flattened into the application in this FastAPI
+    version - they stay as wrapper objects that carry the original router. A
+    flat scan therefore finds only the routes defined in server.py itself, so
+    the wrappers have to be followed explicitly.
+    """
+    for route in routes or []:
+        original = getattr(route, "original_router", None)
+        if original is not None:
+            collect(getattr(original, "routes", []), rows)
+            continue
+        nested = getattr(route, "routes", None)
+        if nested and not getattr(route, "methods", None):
+            collect(nested, rows)
+            continue
+        for method in sorted(getattr(route, "methods", []) or []):
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            rows.append(f"{method:7} {route.path} -> {getattr(route, 'name', '')}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Worum es geht

Erster Block der verbindlichen Reihenfolge. Bevor an den zwei Turniersystemen gearbeitet wird, entsteht das, was die Zusage **„keine Funktion geht verloren"** überhaupt erst prüfbar macht.

**Dieses Paket ändert kein Verhalten.** Es legt nur fest, was es gibt, und misst, was benutzt wird.

## 1. Funktionsinventar

`services/competition_capabilities.py` listet **jede Turnierfähigkeit einmal auf**: welche Endpunkte sie umsetzen, welche Engine sie beherrscht, ob sie eine bekannte Lücke ist.

Der zugehörige Test prüft das gegen die laufende Anwendung und schlägt in drei Fällen an:
- ein beschriebener Endpunkt **verschwindet** — das ist die eigentliche Zusage
- ein neuer Wettbewerbs-Endpunkt wird **nicht eingeordnet** — verhindert, dass das Inventar verrottet
- eine als Lücke geführte Fähigkeit ist **plötzlich in beiden Engines** vorhanden

Der letzte Fall ist Absicht: eine geschlossene Lücke soll bewusst eingetragen werden, statt still durchzurutschen.

Damit sind auch die **fünf echten Lücken** schriftlich festgehalten — Schweizer System, Gruppen, Ergebnismeldung, Einspruch und Aufgabe gibt es nur klassisch — sowie der **stille Speicherwechsel** bei Single- und Double-Elimination.

## 2. Nutzungsmessung

`services/competition_usage.py` schreibt mit, welcher Schreibweg tatsächlich läuft. Ohne diese Zahlen bliebe „das alte System braucht keiner" eine Vermutung, und Block 7 dürfte nichts entfernen.

- Angehängt an die **drei vorhandenen Audit-Stellen** statt an zwölf einzelne Aufrufer
- Die Engine wird aus der **Form des Matches** abgeleitet (Stage/Slots gegen A/B-Felder), nicht geraten — Unklares wird als `unknown` gezählt statt in einen Topf geworfen
- **Ausdrücklich ausfallsicher:** schlägt die Messung fehl, läuft der Turniervorgang trotzdem durch. Zwei Tests halten das fest, weil ein Überwachungsfeature niemals ein Ausfall werden darf
- TTL-Index begrenzt die Messdaten auf 180 Tage

## 3. Routen-Werkzeug

`scripts/route-inventory.py` macht den Vorher-/Nachher-Vergleich der Routentabelle wiederholbar, der sich schon beim Modul-Split bewährt hat.

Dabei ein Fund: **eingebundene Router werden in dieser FastAPI-Version nicht flachgelegt.** Ein naiver Scan findet nur die 11 in `server.py` selbst definierten Routen. Das Werkzeug steigt deshalb bewusst rekursiv ab und findet alle **535**.

## Nachweise

- **525 Backend-Tests grün** (23 neu), unverändert 19 übersprungen
- flake8-Gate, Secret-Scan, Doc-Link-Prüfung, Shell-Syntax und Compile sauber

## Danach

Block 1 entfernt den toten Match-Zwilling (618 Zeilen) und entscheidet über die schlafenden Plan/Apply-Endpunkte — beides jetzt mit dem Inventar als Rückversicherung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)