### PR TITLE
feat: Block 2 — Gameserver zeigen endlich, was sie hergeben

### DIFF
--- a/backend/routes/game_server_routes.py
+++ b/backend/routes/game_server_routes.py
@@ -380,7 +380,9 @@ async def _sync_one(db, server: dict) -> dict:
         locked_status = "maintenance" if _maintenance_active(server) else "planned" if server.get("status") == "planned" else None
         if locked_status:
             updates["status"] = locked_status
-        for key in ("status", "player_count", "max_players", "player_names", "map_name", "version", "game_name", "detected_sync_provider"):
+        for key in ("status", "player_count", "max_players", "player_names", "map_name", "version",
+                    "game_name", "detected_sync_provider",
+                    "server_tags", "password_protected", "bot_count", "vac_enabled", "rules"):
             if key in result and result[key] is not None:
                 if key == "status" and locked_status:
                     continue

--- a/backend/routes/game_server_routes.py
+++ b/backend/routes/game_server_routes.py
@@ -17,7 +17,7 @@ from services.secret_store import decrypt_secret, encrypt_secret
 
 ServerVisibility = Literal["public", "community", "members", "internal"]
 ServerStatus = Literal["online", "offline", "maintenance", "planned"]
-ServerSyncProvider = Literal["manual", "auto_public", "minecraft", "steam_a2s", "rcon"]
+ServerSyncProvider = Literal["manual", "auto_public", "minecraft", "steam_a2s", "rcon", "amp"]
 ServerSecretKind = Literal["none", "password", "invite_code", "whitelist", "discord"]
 
 router = APIRouter(prefix="/api/game-servers", tags=["game-servers"])
@@ -76,16 +76,16 @@ async def _game_lookup(db, game_ids: list[str]) -> dict[str, dict]:
 
 
 def _public_doc(server: dict, game: dict | None = None, include_admin_fields: bool = False) -> dict:
-    # Die amp_*-Namen stammen aus einer nie fertiggestellten AMP-Anbindung und
-    # werden von keinem Modell mehr geschrieben. Der Ausschluss bleibt trotzdem
-    # stehen: sollte ein Altdokument sie noch tragen, sind es Zugangsdaten und
-    # duerfen nicht oeffentlich werden. Block 2 fuehrt AMP sauber im Modell ein.
+    # Die amp_*-Namen stammen aus einer frueheren, nie fertiggestellten Anbindung
+    # und werden von keinem Modell geschrieben - die heutigen AMP-Zugangsdaten
+    # liegen verschluesselt in den Einstellungen. Der Ausschluss bleibt trotzdem
+    # stehen: traegt ein Altdokument sie noch, sind es Zugangsdaten.
     hidden = {
         "_id", "access_secret",
         "amp_password", "amp_session_id", "amp_url", "amp_username", "amp_instance_name", "amp_module",
     }
     if not include_admin_fields:
-        hidden.update({"query_host", "query_port", "rcon_port", "last_sync_error"})
+        hidden.update({"query_host", "query_port", "rcon_port", "last_sync_error", "amp_instance"})
     doc = {k: v for k, v in server.items() if k not in hidden}
     if server.get("access_secret"):
         doc["has_access_secret"] = True
@@ -181,6 +181,7 @@ class GameServerPayload(BaseModel):
     max_players: Optional[int] = Field(default=None, ge=0)
     player_names: list[str] = Field(default_factory=list)
     sync_provider: ServerSyncProvider = "manual"
+    amp_instance: Optional[str] = Field(default=None, max_length=120)
     query_host: Optional[str] = Field(default=None, max_length=180)
     query_port: Optional[int] = Field(default=None, ge=1, le=65535)
     rcon_port: Optional[int] = Field(default=None, ge=1, le=65535)
@@ -220,6 +221,7 @@ class GameServerPatch(BaseModel):
     max_players: Optional[int] = Field(default=None, ge=0)
     player_names: Optional[list[str]] = None
     sync_provider: Optional[ServerSyncProvider] = None
+    amp_instance: Optional[str] = Field(default=None, max_length=120)
     query_host: Optional[str] = Field(default=None, max_length=180)
     query_port: Optional[int] = Field(default=None, ge=1, le=65535)
     rcon_port: Optional[int] = Field(default=None, ge=1, le=65535)
@@ -382,7 +384,8 @@ async def _sync_one(db, server: dict) -> dict:
             updates["status"] = locked_status
         for key in ("status", "player_count", "max_players", "player_names", "map_name", "version",
                     "game_name", "detected_sync_provider",
-                    "server_tags", "password_protected", "bot_count", "vac_enabled", "rules"):
+                    "server_tags", "password_protected", "bot_count", "vac_enabled", "rules",
+                    "cpu_percent", "memory_percent"):
             if key in result and result[key] is not None:
                 if key == "status" and locked_status:
                     continue

--- a/backend/routes/settings_routes.py
+++ b/backend/routes/settings_routes.py
@@ -221,6 +221,14 @@ class DiscordSettings(BaseModel):
     enabled: bool = True
 
 
+class AmpSettings(BaseModel):
+    base_url: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    clear_password: Optional[bool] = None
+    enabled: bool = True
+
+
 class AuthSettings(BaseModel):
     password_login_enabled: Optional[bool] = None
     registration_enabled: Optional[bool] = None
@@ -1137,6 +1145,78 @@ async def update_discord(body: DiscordSettings, me: dict = Depends(require_club_
     )
     await _audit_settings_change(db, "settings.discord.update", "discord", me["id"], changed_fields)
     return {"ok": True, "changed": True}
+
+
+# ---- AMP-Panel ----
+@settings_router.get("/amp")
+async def get_amp(me: dict = Depends(require_club_admin())):
+    db = get_db()
+    settings = await db.settings.find_one({"id": "amp"}, {"_id": 0}) or {}
+    # Das Passwort verlässt den Server nie; die Oberfläche braucht nur zu
+    # wissen, ob eines hinterlegt ist.
+    settings["configured"] = secret_is_configured(settings.get("password"))
+    settings.pop("password", None)
+    return settings
+
+
+@settings_router.put("/amp")
+async def update_amp(body: AmpSettings, me: dict = Depends(require_club_admin())):
+    db = get_db()
+    updates = {k: v for k, v in body.model_dump(exclude_unset=True).items() if v is not None}
+    clear_password = bool(updates.pop("clear_password", False))
+    unset = {"password": ""} if clear_password else {}
+
+    for key in ("base_url", "username"):
+        if key in updates and isinstance(updates[key], str):
+            updates[key] = updates[key].strip()
+    if updates.get("base_url") and not updates["base_url"].lower().startswith("https://"):
+        raise HTTPException(400, "Die AMP-Adresse muss mit https:// beginnen; über http würden Zugangsdaten offen übertragen.")
+    if "password" in updates:
+        password = str(updates["password"]).strip()
+        if password:
+            updates["password"] = encrypt_secret(password)
+        else:
+            updates.pop("password")
+
+    current = await db.settings.find_one({"id": "amp"}, {"_id": 0}) or {}
+    changed_fields = _changed_setting_fields(current, updates, unset)
+    if not changed_fields:
+        return {"ok": True, "changed": False}
+    updates["updated_at"] = now_utc().isoformat()
+    op = {"$set": updates, "$setOnInsert": {"id": "amp"}}
+    if unset:
+        op["$unset"] = unset
+    await db.settings.update_one({"id": "amp"}, op, upsert=True)
+    await _audit_settings_change(db, "settings.amp.update", "amp", me["id"], changed_fields)
+    return {"ok": True, "changed": True}
+
+
+@settings_router.post("/amp/test")
+async def amp_test(me: dict = Depends(require_club_admin())):
+    """Melden, ob die Anmeldung klappt und welche Instanzen das Panel kennt."""
+    from services.amp_settings import load_amp_settings
+    from services.amp_client import AmpClient, AmpError
+
+    settings = await load_amp_settings()
+    if not settings:
+        return {"ok": False, "error": "AMP ist nicht konfiguriert."}
+    try:
+        async with AmpClient(settings["base_url"], settings["username"], settings["password"]) as client:
+            instances = await client.instances()
+    except AmpError as exc:
+        return {"ok": False, "error": str(exc)}
+    return {
+        "ok": True,
+        "instance_count": len(instances),
+        "instances": [
+            {
+                "id": item.get("InstanceID"),
+                "name": item.get("FriendlyName") or item.get("InstanceName"),
+                "running": bool(item.get("Running")),
+            }
+            for item in instances
+        ],
+    }
 
 
 @settings_router.post("/discord/test")

--- a/backend/services/amp_client.py
+++ b/backend/services/amp_client.py
@@ -1,0 +1,160 @@
+"""Read-only client for a CubeCoders AMP panel.
+
+Why this exists: the public status query only works for games that speak a
+public protocol. Palworld and Windrose do not, ARK and Rust only on a port that
+is often closed - so those servers show nothing useful no matter how good the
+parser is.
+
+AMP knows all of them, because it runs them. Its own interface reports the same
+figures for every instance regardless of the game: running or not, players
+current and maximum, and the real CPU and memory load. That is exactly what the
+public query cannot deliver.
+
+Deliberately read-only. Starting or stopping a server from the website is not a
+feature anybody asked for, and a panel session that can only look is a much
+smaller risk if it ever leaks.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("tls.amp")
+
+REQUEST_TIMEOUT = 8.0
+
+
+class AmpError(RuntimeError):
+    """The panel could not be reached or refused the request."""
+
+
+def _endpoint(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/API/{path.lstrip('/')}"
+
+
+def _metric_value(metrics: dict, name: str) -> tuple[float | None, float | None]:
+    """Pull one metric out of AMP's status answer.
+
+    The panel reports metrics as a mapping of display name to a small object
+    with the current and maximum value. Names differ slightly between AMP
+    versions, so the lookup is case-insensitive and tolerant of absence.
+    """
+    if not isinstance(metrics, dict):
+        return None, None
+    wanted = name.strip().lower()
+    for key, entry in metrics.items():
+        if str(key).strip().lower() != wanted or not isinstance(entry, dict):
+            continue
+        raw = entry.get("RawValue")
+        maximum = entry.get("MaxValue")
+        return (
+            float(raw) if isinstance(raw, (int, float)) else None,
+            float(maximum) if isinstance(maximum, (int, float)) else None,
+        )
+    return None, None
+
+
+class AmpClient:
+    """One panel session, used for a single sync run."""
+
+    def __init__(self, base_url: str, username: str, password: str):
+        if not base_url or not username or not password:
+            raise AmpError("AMP-Zugang ist unvollständig konfiguriert.")
+        self.base_url = base_url
+        self.username = username
+        self.password = password
+        self.session_id: str | None = None
+
+    async def __aenter__(self) -> "AmpClient":
+        self._client = httpx.AsyncClient(timeout=REQUEST_TIMEOUT)
+        await self.login()
+        return self
+
+    async def __aexit__(self, *_exc_info) -> None:
+        await self._client.aclose()
+
+    async def _post(self, path: str, payload: dict[str, Any]) -> Any:
+        try:
+            response = await self._client.post(_endpoint(self.base_url, path), json=payload)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPError as exc:
+            raise AmpError(f"AMP nicht erreichbar: {type(exc).__name__}") from exc
+        except ValueError as exc:
+            raise AmpError("AMP hat keine verwertbare Antwort geliefert.") from exc
+
+    async def login(self) -> str:
+        data = await self._post("Core/Login", {
+            "username": self.username,
+            "password": self.password,
+            "token": "",
+            "rememberMe": False,
+        })
+        session_id = (data or {}).get("sessionID")
+        if not session_id or (data or {}).get("success") is False:
+            raise AmpError("AMP-Anmeldung abgelehnt.")
+        self.session_id = session_id
+        return session_id
+
+    async def instances(self) -> list[dict]:
+        """All instances the panel knows, flattened across its targets."""
+        data = await self._post("ADSModule/GetInstances", {"SESSIONID": self.session_id})
+        targets = data if isinstance(data, list) else (data or {}).get("result") or []
+        found: list[dict] = []
+        for target in targets:
+            for instance in (target or {}).get("AvailableInstances") or []:
+                if isinstance(instance, dict):
+                    found.append(instance)
+        return found
+
+    async def instance_status(self, instance_id: str) -> dict:
+        data = await self._post(
+            f"ADSModule/Servers/{instance_id}/API/Core/GetStatus",
+            {"SESSIONID": self.session_id},
+        )
+        return data if isinstance(data, dict) else {}
+
+
+def instance_matches(instance: dict, wanted: str) -> bool:
+    """Find the panel instance an entry on the website refers to.
+
+    Matching is by name or id and case-insensitive, so an operator can enter
+    whichever of the two they see in front of them in AMP.
+    """
+    needle = str(wanted or "").strip().lower()
+    if not needle:
+        return False
+    for field in ("InstanceID", "InstanceName", "FriendlyName"):
+        if str(instance.get(field) or "").strip().lower() == needle:
+            return True
+    return False
+
+
+def status_from_amp(instance: dict, status: dict) -> dict:
+    """Translate one AMP answer into the fields the server card shows.
+
+    Only what AMP genuinely knows is returned. A missing metric stays absent
+    rather than being reported as zero - "no data" and "nobody online" must not
+    look the same on the page.
+    """
+    running = bool(instance.get("Running"))
+    metrics = (status or {}).get("Metrics") or {}
+    players, max_players = _metric_value(metrics, "Active Users")
+    cpu, _cpu_max = _metric_value(metrics, "CPU Usage")
+    memory, memory_max = _metric_value(metrics, "Memory Usage")
+
+    result: dict[str, Any] = {
+        "status": "online" if running else "offline",
+        "sync_note": "Werte aus AMP.",
+    }
+    if players is not None:
+        result["player_count"] = int(players)
+    if max_players:
+        result["max_players"] = int(max_players)
+    if cpu is not None:
+        result["cpu_percent"] = round(cpu, 1)
+    if memory is not None and memory_max:
+        result["memory_percent"] = round(memory / memory_max * 100, 1)
+    return result

--- a/backend/services/amp_settings.py
+++ b/backend/services/amp_settings.py
@@ -1,0 +1,30 @@
+"""Loads the stored AMP access data for the sync run.
+
+Kept apart from the routes so the scheduler can reach it without importing an
+HTTP module, and so the decryption lives in exactly one place.
+"""
+from __future__ import annotations
+
+from database import get_db
+from services.secret_store import decrypt_secret, secret_is_configured
+
+
+async def load_amp_settings() -> dict | None:
+    """Return usable AMP access data, or None if it is not fully configured.
+
+    Half-configured is treated as not configured: without all three values a
+    sync attempt would fail anyway, and a clear "not set up" beats a login
+    error in the operator's log.
+    """
+    settings = await get_db().settings.find_one({"id": "amp"}, {"_id": 0}) or {}
+    if settings.get("enabled") is False:
+        return None
+    base_url = str(settings.get("base_url") or "").strip()
+    username = str(settings.get("username") or "").strip()
+    if not base_url or not username or not secret_is_configured(settings.get("password")):
+        return None
+    return {
+        "base_url": base_url,
+        "username": username,
+        "password": decrypt_secret(settings.get("password")),
+    }

--- a/backend/services/game_server_status.py
+++ b/backend/services/game_server_status.py
@@ -32,6 +32,54 @@ def parse_host_port(address: str | None, default_port: int | None = None) -> tup
     return raw, default_port
 
 
+# Bei den meisten Spielen antwortet die Statusabfrage auf einem anderen Port als
+# das Spiel selbst. Wer nur die Spieleradresse eintraegt, fragt deshalb ins Leere
+# - genau der Grund, warum ARK, Rust und Palworld bisher nichts anzeigten. Diese
+# Vorgaben greifen nur, wenn kein Query-Port gepflegt ist.
+QUERY_PORT_HINTS: dict[str, int] = {
+    "ark": 27015,
+    "ark survival ascended": 27015,
+    "ark survival evolved": 27015,
+    "rust": 28016,
+    "valheim": 2457,
+    "conan exiles": 27015,
+    "dayz": 27016,
+    "squad": 27165,
+    "arma 3": 2303,
+    "project zomboid": 16261,
+    "7 days to die": 26900,
+    "unturned": 27016,
+}
+
+# Spielport -> ueblicher Query-Port, wenn der Spielname nichts hergibt.
+QUERY_PORT_BY_GAME_PORT: dict[int, int] = {
+    7777: 27015,   # ARK und andere Unreal-Titel
+    28015: 28016,  # Rust
+    2456: 2457,    # Valheim
+}
+
+
+def suggested_query_port(server: dict) -> int | None:
+    """Best guess for the status port when the operator only entered the game address.
+
+    Deliberately only a fallback: an explicitly maintained query port always
+    wins, because the operator knows their setup better than a table does.
+    """
+    explicit = server.get("query_port")
+    if explicit:
+        return int(explicit)
+
+    haystack = " ".join(str(server.get(field) or "") for field in ("game_name", "name", "game_id")).lower()
+    for needle, port in QUERY_PORT_HINTS.items():
+        if needle in haystack:
+            return port
+
+    _host, address_port = parse_host_port(server.get("address"))
+    if address_port and address_port in QUERY_PORT_BY_GAME_PORT:
+        return QUERY_PORT_BY_GAME_PORT[address_port]
+    return None
+
+
 def _host_port_candidate_details(server: dict, default_port: int | None = None) -> list[dict]:
     query_default = server.get("query_port") or default_port
     candidates: list[dict] = []
@@ -209,19 +257,18 @@ def _read_c_string(data: bytes, offset: int) -> tuple[str, int]:
     return data[offset:end].decode("utf-8", errors="replace"), end + 1
 
 
-def _a2s_query_sync(host: str, port: int, timeout: float) -> dict:
-    ensure_probe_target_allowed(host)
-    request = b"\xff\xff\xff\xffTSource Engine Query\x00"
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.settimeout(timeout)
-        sock.sendto(request, (host, port))
-        data, _ = sock.recvfrom(4096)
-        if len(data) >= 9 and data[4] == 0x41:
-            challenge = data[5:9]
-            sock.sendto(request + challenge, (host, port))
-            data, _ = sock.recvfrom(4096)
+def parse_a2s_info(data: bytes) -> dict:
+    """Read a full A2S_INFO answer.
+
+    The previous version stopped after the player counts and threw the rest
+    away - including the version string and the keyword field, which is exactly
+    where ARK, Rust and 7 Days To Die put their mod list, build number and PvP
+    setting. Everything after the counts is optional in practice, so each step
+    is guarded: a short or odd answer yields fewer fields instead of an error.
+    """
     if len(data) < 7 or data[:4] != b"\xff\xff\xff\xff" or data[4] != 0x49:
         raise GameServerProbeError("A2S_INFO hat keine gültige Antwort geliefert.")
+
     offset = 6
     name, offset = _read_c_string(data, offset)
     map_name, offset = _read_c_string(data, offset)
@@ -229,17 +276,141 @@ def _a2s_query_sync(host: str, port: int, timeout: float) -> dict:
     game_name, offset = _read_c_string(data, offset)
     if len(data) < offset + 5:
         raise GameServerProbeError("A2S_INFO-Antwort ist unvollständig.")
-    offset += 2
-    players = data[offset]
-    max_players = data[offset + 1]
-    return {
+
+    offset += 2  # App-ID
+    info = {
         "status": "online",
         "name": name,
         "game_name": game_name,
         "map_name": map_name,
-        "player_count": int(players),
-        "max_players": int(max_players),
+        "player_count": int(data[offset]),
+        "max_players": int(data[offset + 1]),
     }
+    offset += 2
+
+    if len(data) > offset:
+        info["bot_count"] = int(data[offset])
+        offset += 1
+    offset += 1  # Servertyp
+    offset += 1  # Betriebssystem
+    if len(data) > offset:
+        info["password_protected"] = data[offset] == 1
+        offset += 1
+    if len(data) > offset:
+        info["vac_enabled"] = data[offset] == 1
+        offset += 1
+
+    try:
+        version, offset = _read_c_string(data, offset)
+        if version:
+            info["version"] = version
+    except GameServerProbeError:
+        return info
+
+    if len(data) <= offset:
+        return info
+    extra_flags = data[offset]
+    offset += 1
+    if extra_flags & 0x80:
+        offset += 2  # Spielport
+    if extra_flags & 0x10:
+        offset += 8  # SteamID
+    if extra_flags & 0x40:
+        offset += 2
+        try:
+            _spectator_name, offset = _read_c_string(data, offset)
+        except GameServerProbeError:
+            return info
+    if extra_flags & 0x20:
+        try:
+            keywords, offset = _read_c_string(data, offset)
+        except GameServerProbeError:
+            return info
+        tags = [tag.strip() for tag in keywords.split(",") if tag.strip()]
+        if tags:
+            info["server_tags"] = tags
+    return info
+
+
+def parse_a2s_rules(data: bytes) -> dict:
+    """Read an A2S_RULES answer into plain key/value pairs.
+
+    This is where the genuinely game-specific values live: world day and
+    difficulty for 7 Days To Die, map size and seed for Rust.
+    """
+    if len(data) < 7 or data[:4] != b"\xff\xff\xff\xff" or data[4] != 0x45:
+        raise GameServerProbeError("A2S_RULES hat keine gültige Antwort geliefert.")
+    count = int.from_bytes(data[5:7], "little")
+    offset = 7
+    rules: dict[str, str] = {}
+    for _ in range(count):
+        try:
+            key, offset = _read_c_string(data, offset)
+            value, offset = _read_c_string(data, offset)
+        except GameServerProbeError:
+            break
+        if key:
+            rules[key] = value
+    return rules
+
+
+def parse_a2s_players(data: bytes) -> list[str]:
+    """Read the player names from an A2S_PLAYER answer.
+
+    Only the names are kept. Scores and play time would be personal data of
+    guests on a club server without any display purpose here.
+    """
+    if len(data) < 6 or data[:4] != b"\xff\xff\xff\xff" or data[4] != 0x44:
+        raise GameServerProbeError("A2S_PLAYER hat keine gültige Antwort geliefert.")
+    count = int(data[5])
+    offset = 6
+    names: list[str] = []
+    for _ in range(count):
+        if len(data) <= offset:
+            break
+        offset += 1  # Index
+        try:
+            name, offset = _read_c_string(data, offset)
+        except GameServerProbeError:
+            break
+        offset += 8  # Punkte und Spielzeit
+        if name:
+            names.append(name)
+    return names
+
+
+def _a2s_exchange(sock, host: str, port: int, header: bytes, payload: bytes = b"\xff\xff\xff\xff") -> bytes:
+    """Send one A2S request and answer the challenge if the server asks for one."""
+    sock.sendto(header + payload, (host, port))
+    data, _ = sock.recvfrom(4096)
+    if len(data) >= 9 and data[4] == 0x41:
+        challenge = data[5:9]
+        sock.sendto(header + challenge, (host, port))
+        data, _ = sock.recvfrom(4096)
+    return data
+
+
+def _a2s_query_sync(host: str, port: int, timeout: float) -> dict:
+    ensure_probe_target_allowed(host)
+    info_header = b"\xff\xff\xff\xffTSource Engine Query\x00"
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.settimeout(timeout)
+        data = _a2s_exchange(sock, host, port, info_header, b"")
+        info = parse_a2s_info(data)
+
+        # Regeln und Spielerliste sind Zusatznutzen: antwortet ein Server darauf
+        # nicht, bleibt die Grundabfrage trotzdem gültig.
+        for header, parser, key in (
+            (b"\xff\xff\xff\xff\x56", parse_a2s_rules, "rules"),
+            (b"\xff\xff\xff\xff\x55", parse_a2s_players, "player_names"),
+        ):
+            try:
+                extra = parser(_a2s_exchange(sock, host, port, header))
+            except (GameServerProbeError, OSError, IndexError):
+                continue
+            if extra:
+                info[key] = extra
+    return info
 
 
 def _tcp_reachable_sync(host: str, port: int, timeout: float) -> dict:
@@ -271,13 +442,23 @@ async def probe_minecraft(server: dict, timeout: float = 5.0) -> dict:
 
 
 async def probe_steam_a2s(server: dict, timeout: float = 3.0) -> dict:
-    candidates = _host_port_candidates(server, server.get("query_port"))
+    # Ohne gepflegten Query-Port wird der uebliche Port des Spiels ergaenzt,
+    # sonst landet die Abfrage auf dem Spielport und bleibt ohne Antwort.
+    fallback_port = suggested_query_port(server)
+    candidates = _host_port_candidates(server, server.get("query_port") or fallback_port)
+    if fallback_port:
+        for host, _port in list(candidates):
+            if (host, fallback_port) not in candidates:
+                candidates.append((host, fallback_port))
     if not candidates:
         raise GameServerProbeError("Steam/A2S braucht Host und Query-Port.")
     errors = []
     for host, port in candidates:
         try:
-            return await asyncio.to_thread(_a2s_query_sync, host, port, timeout)
+            result = await asyncio.to_thread(_a2s_query_sync, host, port, timeout)
+            if port != server.get("query_port"):
+                result.setdefault("sync_note", f"Statusabfrage beantwortet auf Port {port}.")
+            return result
         except Exception as exc:
             errors.append(f"{host}:{port}: {exc}")
     raise GameServerProbeError("Steam/A2S fehlgeschlagen. " + " | ".join(errors))

--- a/backend/services/game_server_status.py
+++ b/backend/services/game_server_status.py
@@ -497,10 +497,42 @@ async def probe_auto_public(server: dict) -> dict:
     raise GameServerProbeError("Keine öffentliche Abfrage erfolgreich. " + " | ".join(errors))
 
 
+async def probe_amp(server: dict) -> dict:
+    """Ask the AMP panel about this server's instance.
+
+    AMP is the better source wherever a game has no usable public query - it
+    knows every instance because it runs them. If the panel is unreachable or
+    the instance is not found, the public query still has its turn: a panel
+    outage must not blank out a server that answers on its own.
+    """
+    from services.amp_client import AmpClient, AmpError, instance_matches, status_from_amp
+    from services.amp_settings import load_amp_settings
+
+    wanted = str(server.get("amp_instance") or "").strip()
+    if not wanted:
+        raise GameServerProbeError("Für diesen Server ist keine AMP-Instanz hinterlegt.")
+    settings = await load_amp_settings()
+    if not settings:
+        raise GameServerProbeError("AMP ist nicht konfiguriert.")
+
+    try:
+        async with AmpClient(settings["base_url"], settings["username"], settings["password"]) as client:
+            instances = await client.instances()
+            match = next((item for item in instances if instance_matches(item, wanted)), None)
+            if not match:
+                raise GameServerProbeError(f"AMP kennt keine Instanz '{wanted}'.")
+            status = await client.instance_status(match.get("InstanceID") or wanted)
+    except AmpError as exc:
+        raise GameServerProbeError(str(exc)) from exc
+    return status_from_amp(match, status)
+
+
 async def probe_game_server(server: dict) -> dict:
     provider = server.get("sync_provider") or "manual"
     if provider == "manual":
         raise GameServerProbeError("Dieser Server steht auf manueller Pflege.")
+    if provider == "amp":
+        return await probe_amp(server)
     if provider == "auto_public":
         return await probe_auto_public(server)
     if provider == "minecraft":

--- a/backend/tests/test_a2s_parsing_unit.py
+++ b/backend/tests/test_a2s_parsing_unit.py
@@ -1,0 +1,164 @@
+"""What the status query actually delivers - and what used to be thrown away.
+
+The old parser stopped after the player counts. Everything behind it, above all
+the version string and the keyword field, was discarded even though it had
+already been received. These tests build synthetic answers byte by byte, so the
+parsing can be checked without a game server.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.game_server_status import (
+    GameServerProbeError,
+    parse_a2s_info,
+    parse_a2s_players,
+    parse_a2s_rules,
+    suggested_query_port,
+)
+
+
+def _string(value: str) -> bytes:
+    return value.encode("utf-8") + b"\x00"
+
+
+def build_info(
+    *,
+    name="TLS Server",
+    map_name="Navezgane",
+    folder="7dtd",
+    game="7 Days To Die",
+    players=3,
+    max_players=8,
+    bots=0,
+    password=False,
+    vac=True,
+    version="1.4.2",
+    keywords=None,
+    truncate_after=None,
+) -> bytes:
+    payload = b"\xff\xff\xff\xff\x49" + bytes([17])
+    payload += _string(name) + _string(map_name) + _string(folder) + _string(game)
+    payload += (251).to_bytes(2, "little")
+    payload += bytes([players, max_players, bots])
+    payload += b"d"  # Servertyp
+    payload += b"l"  # Betriebssystem
+    payload += bytes([1 if password else 0, 1 if vac else 0])
+    payload += _string(version)
+    if keywords is not None:
+        payload += bytes([0x20]) + _string(keywords)
+    else:
+        payload += bytes([0x00])
+    return payload[:truncate_after] if truncate_after else payload
+
+
+def test_the_basic_facts_are_read():
+    info = parse_a2s_info(build_info())
+
+    assert info["status"] == "online"
+    assert info["name"] == "TLS Server"
+    assert info["map_name"] == "Navezgane"
+    assert info["player_count"] == 3
+    assert info["max_players"] == 8
+
+
+def test_the_version_is_no_longer_discarded():
+    """Genau das Feld, das 7 Days To Die bisher fehlte."""
+    assert parse_a2s_info(build_info(version="1.4.2"))["version"] == "1.4.2"
+
+
+def test_server_tags_are_read_and_split():
+    """Hier transportieren ARK, Rust und 7DTD ihre Mods und Einstellungen."""
+    info = parse_a2s_info(build_info(keywords="pvp,mods=12,build=4711"))
+
+    assert info["server_tags"] == ["pvp", "mods=12", "build=4711"]
+
+
+def test_password_and_protection_flags_are_read():
+    info = parse_a2s_info(build_info(password=True, vac=False, bots=2))
+
+    assert info["password_protected"] is True
+    assert info["vac_enabled"] is False
+    assert info["bot_count"] == 2
+
+
+def test_a_server_without_keywords_simply_has_none():
+    assert "server_tags" not in parse_a2s_info(build_info(keywords=None))
+
+
+def test_a_truncated_answer_yields_fewer_fields_instead_of_an_error():
+    """Ältere oder sparsame Server antworten kürzer - das darf die Abfrage nicht
+
+    scheitern lassen, solange die Grunddaten gelesen werden konnten.
+    """
+    full = build_info()
+    cut = full.index(_string("1.4.2"))
+    info = parse_a2s_info(build_info(truncate_after=cut))
+
+    assert info["player_count"] == 3
+    assert "version" not in info
+
+
+@pytest.mark.parametrize("payload", [b"", b"\xff\xff\xff\xff", b"\xff\xff\xff\xffX"])
+def test_a_wrong_answer_is_rejected(payload):
+    with pytest.raises(GameServerProbeError):
+        parse_a2s_info(payload)
+
+
+# ---------------------------------------------------------------- Regeln
+
+def test_rules_are_read_as_key_value_pairs():
+    payload = b"\xff\xff\xff\xff\x45" + (2).to_bytes(2, "little")
+    payload += _string("GameDifficulty") + _string("3")
+    payload += _string("DayCount") + _string("42")
+
+    assert parse_a2s_rules(payload) == {"GameDifficulty": "3", "DayCount": "42"}
+
+
+def test_a_truncated_rule_list_returns_what_was_readable():
+    payload = b"\xff\xff\xff\xff\x45" + (5).to_bytes(2, "little")
+    payload += _string("Seed") + _string("12345")
+
+    assert parse_a2s_rules(payload) == {"Seed": "12345"}
+
+
+def test_a_wrong_rules_answer_is_rejected():
+    with pytest.raises(GameServerProbeError):
+        parse_a2s_rules(b"\xff\xff\xff\xff\x49")
+
+
+# ---------------------------------------------------------------- Spielerliste
+
+def test_player_names_are_read():
+    payload = b"\xff\xff\xff\xff\x44" + bytes([2])
+    for name in ("Lion", "Squad"):
+        payload += bytes([0]) + _string(name) + b"\x00" * 8
+
+    assert parse_a2s_players(payload) == ["Lion", "Squad"]
+
+
+def test_an_empty_server_has_no_players():
+    assert parse_a2s_players(b"\xff\xff\xff\xff\x44" + bytes([0])) == []
+
+
+# ---------------------------------------------------------------- Query-Port
+
+@pytest.mark.parametrize("server,expected", [
+    ({"query_port": 27020, "game_name": "Rust"}, 27020),
+    ({"game_name": "Rust"}, 28016),
+    ({"game_name": "ARK Survival Evolved"}, 27015),
+    ({"name": "7 Days To Die Mitgliederserver"}, 26900),
+    ({"address": "ark.lionsquad.at:7777"}, 27015),
+    ({"address": "rust.lionsquad.at:28015"}, 28016),
+    ({"game_name": "Windrose"}, None),
+])
+def test_the_usual_status_port_is_suggested(server, expected):
+    assert suggested_query_port(server) == expected
+
+
+def test_an_explicit_port_always_wins():
+    """Der Betreiber kennt sein Setup besser als eine Tabelle."""
+    assert suggested_query_port({"query_port": 12345, "game_name": "ARK"}) == 12345

--- a/backend/tests/test_amp_client_unit.py
+++ b/backend/tests/test_amp_client_unit.py
@@ -1,0 +1,105 @@
+"""Translating AMP answers into the fields the server card shows.
+
+The important rule here is the difference between "no data" and "nobody
+online". A missing metric must stay missing, otherwise the page would claim
+zero players for a server AMP never reported on.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.amp_client import AmpClient, AmpError, instance_matches, status_from_amp
+
+
+def metrics(**entries):
+    return {"Metrics": {name: value for name, value in entries.items()}}
+
+
+def metric(raw, maximum=None):
+    entry = {"RawValue": raw}
+    if maximum is not None:
+        entry["MaxValue"] = maximum
+    return entry
+
+
+# ---------------------------------------------------------------- Übersetzung
+
+def test_a_running_instance_with_players_is_translated():
+    result = status_from_amp(
+        {"Running": True},
+        metrics(**{"Active Users": metric(4, 16), "CPU Usage": metric(23.4), "Memory Usage": metric(2048, 8192)}),
+    )
+
+    assert result["status"] == "online"
+    assert result["player_count"] == 4
+    assert result["max_players"] == 16
+    assert result["cpu_percent"] == 23.4
+    assert result["memory_percent"] == 25.0
+
+
+def test_a_stopped_instance_is_offline():
+    assert status_from_amp({"Running": False}, metrics())["status"] == "offline"
+
+
+def test_a_missing_metric_stays_missing():
+    """Sonst stünde bei einem Server ohne Rückmeldung faelschlich "0 online"."""
+    result = status_from_amp({"Running": True}, metrics())
+
+    assert result["status"] == "online"
+    assert "player_count" not in result
+    assert "max_players" not in result
+    assert "cpu_percent" not in result
+
+
+def test_an_empty_server_reports_zero_players():
+    """Null gemeldete Spieler ist eine Aussage - im Gegensatz zu keiner Meldung."""
+    result = status_from_amp({"Running": True}, metrics(**{"Active Users": metric(0, 10)}))
+
+    assert result["player_count"] == 0
+    assert result["max_players"] == 10
+
+
+def test_metric_names_are_matched_regardless_of_spelling():
+    result = status_from_amp({"Running": True}, metrics(**{"active users": metric(2, 8)}))
+
+    assert result["player_count"] == 2
+
+
+def test_a_broken_answer_does_not_raise():
+    assert status_from_amp({"Running": True}, {})["status"] == "online"
+    assert status_from_amp({}, {"Metrics": "kaputt"})["status"] == "offline"
+
+
+def test_memory_without_a_maximum_yields_no_percentage():
+    result = status_from_amp({"Running": True}, metrics(**{"Memory Usage": metric(2048)}))
+
+    assert "memory_percent" not in result
+
+
+# ---------------------------------------------------------------- Zuordnung
+
+@pytest.mark.parametrize("wanted", ["ark-01", "ARK-01", "  ark-01  ", "ARK Mitgliederserver"])
+def test_an_instance_is_found_by_name_or_id(wanted):
+    instance = {"InstanceID": "ark-01", "FriendlyName": "ARK Mitgliederserver"}
+
+    assert instance_matches(instance, wanted) is True
+
+
+@pytest.mark.parametrize("wanted", ["", None, "rust-01"])
+def test_a_wrong_or_empty_reference_matches_nothing(wanted):
+    assert instance_matches({"InstanceID": "ark-01"}, wanted) is False
+
+
+# ---------------------------------------------------------------- Konfiguration
+
+@pytest.mark.parametrize("args", [
+    ("", "user", "pass"),
+    ("https://amp.example.test", "", "pass"),
+    ("https://amp.example.test", "user", ""),
+])
+def test_incomplete_configuration_is_rejected_early(args):
+    with pytest.raises(AmpError):
+        AmpClient(*args)

--- a/frontend/src/lib/serverFacts.js
+++ b/frontend/src/lib/serverFacts.js
@@ -1,0 +1,52 @@
+// Die Statusabfrage liefert je Spiel unterschiedliche Zusatzangaben. Statt pro
+// Spiel eine Sonderbehandlung zu bauen, werden die Schlüssel übersetzt, die
+// tatsächlich etwas aussagen — vorhanden ist eben, was der Server mitschickt.
+
+const RULE_LABELS = {
+  // 7 Days To Die
+  GameDifficulty: "Schwierigkeit",
+  GameMode: "Spielmodus",
+  DayCount: "Welttag",
+  CurrentServerTime: "Weltzeit",
+  ServerMaxPlayerCount: "Maximale Spieler",
+  // Rust
+  build: "Build",
+  "world.size": "Kartengröße",
+  "world.seed": "Karten-Seed",
+  // ARK und Unreal-Titel
+  DayTime_s: "Weltzeit",
+  SESSIONISPVE_i: "Modus",
+  // Valheim und weitere
+  world: "Welt",
+};
+
+const VALUE_FORMATTERS = {
+  SESSIONISPVE_i: (value) => (String(value) === "1" ? "PvE" : "PvP"),
+  "world.size": (value) => `${value}`,
+};
+
+const MAX_TAGS = 6;
+
+export function ruleFacts(rules) {
+  if (!rules || typeof rules !== "object") return [];
+  return Object.entries(RULE_LABELS)
+    .filter(([key]) => {
+      const value = rules[key];
+      return value !== undefined && value !== null && String(value).trim() !== "";
+    })
+    .map(([key, label]) => {
+      const raw = rules[key];
+      const format = VALUE_FORMATTERS[key];
+      return { label, value: format ? format(raw) : String(raw) };
+    });
+}
+
+export function serverTags(server) {
+  const tags = Array.isArray(server?.server_tags) ? server.server_tags : [];
+  return tags.filter((tag) => typeof tag === "string" && tag.trim()).slice(0, MAX_TAGS);
+}
+
+export function protectionLabel(server) {
+  if (server?.password_protected === true) return "Passwortgeschützt";
+  return null;
+}

--- a/frontend/src/lib/serverFacts.test.js
+++ b/frontend/src/lib/serverFacts.test.js
@@ -1,0 +1,51 @@
+import { protectionLabel, ruleFacts, serverTags } from "./serverFacts";
+
+// Die Serverkarte zeigt nur, was der jeweilige Server tatsächlich mitschickt.
+// Fehlende Angaben dürfen weder leere Zeilen noch Platzhalter erzeugen.
+
+test("bekannte Regeln werden übersetzt", () => {
+  const facts = ruleFacts({ GameDifficulty: "3", DayCount: "42" });
+
+  expect(facts).toEqual([
+    { label: "Schwierigkeit", value: "3" },
+    { label: "Welttag", value: "42" },
+  ]);
+});
+
+test("unbekannte Regeln werden nicht angezeigt", () => {
+  expect(ruleFacts({ IrgendeinInternerSchluessel: "x" })).toEqual([]);
+});
+
+test("leere Werte erzeugen keine Zeile", () => {
+  expect(ruleFacts({ GameDifficulty: "", DayCount: "   ", build: null })).toEqual([]);
+});
+
+test("PvE-Kennzeichen wird lesbar gemacht", () => {
+  expect(ruleFacts({ SESSIONISPVE_i: "1" })).toEqual([{ label: "Modus", value: "PvE" }]);
+  expect(ruleFacts({ SESSIONISPVE_i: "0" })).toEqual([{ label: "Modus", value: "PvP" }]);
+});
+
+test("fehlende Regeln ergeben eine leere Liste statt eines Fehlers", () => {
+  expect(ruleFacts(undefined)).toEqual([]);
+  expect(ruleFacts(null)).toEqual([]);
+  expect(ruleFacts("kaputt")).toEqual([]);
+});
+
+test("Server-Merkmale werden begrenzt, damit die Karte nicht überläuft", () => {
+  const tags = serverTags({ server_tags: ["a", "b", "c", "d", "e", "f", "g", "h"] });
+
+  expect(tags).toHaveLength(6);
+  expect(tags[0]).toBe("a");
+});
+
+test("leere oder fehlende Merkmale ergeben eine leere Liste", () => {
+  expect(serverTags({ server_tags: ["", "  "] })).toEqual([]);
+  expect(serverTags({})).toEqual([]);
+  expect(serverTags(null)).toEqual([]);
+});
+
+test("Passwortschutz wird nur bei echtem Kennzeichen gemeldet", () => {
+  expect(protectionLabel({ password_protected: true })).toBe("Passwortgeschützt");
+  expect(protectionLabel({ password_protected: false })).toBeNull();
+  expect(protectionLabel({})).toBeNull();
+});

--- a/frontend/src/pages/admin/AdminGameServersPage.jsx
+++ b/frontend/src/pages/admin/AdminGameServersPage.jsx
@@ -40,6 +40,7 @@ const emptyForm = {
   max_players: "",
   player_names_text: "",
   sync_provider: "auto_public",
+  amp_instance: "",
   query_host: "",
   query_port: "",
   rcon_port: "",
@@ -49,7 +50,7 @@ const emptyForm = {
 
 const statusLabels = { online: "Online", offline: "Offline", maintenance: "Wartung", planned: "Geplant" };
 const visibilityLabels = { public: "Öffentlich", community: "Nur eingeloggte Community", members: "Nur Vereinsmitglieder", internal: "Intern / versteckt" };
-const syncLabels = { auto_public: "Automatisch erkennen", minecraft: "Minecraft Query", steam_a2s: "Steam/A2S Query", rcon: "TCP / RCON erreichbar", manual: "Manuelle Pflege" };
+const syncLabels = { auto_public: "Automatisch erkennen", amp: "AMP-Panel", minecraft: "Minecraft Query", steam_a2s: "Steam/A2S Query", rcon: "TCP / RCON erreichbar", manual: "Manuelle Pflege" };
 const secretLabels = { none: "Kein Kennwort", password: "Passwort", invite_code: "Invite-Code", whitelist: "Whitelist / Freischaltung", discord: "Im Discord" };
 const modeLabels = { auto: "Automatisch", maintenance: "Wartung", planned: "Geplant" };
 
@@ -85,6 +86,7 @@ function toForm(server) {
     query_port: server.query_port ?? "",
     rcon_port: server.rcon_port ?? "",
     sync_provider: syncLabels[server.sync_provider] ? server.sync_provider : "auto_public",
+    amp_instance: server.amp_instance ?? "",
     access_secret: "",
     maintenance_until: datetimeInputValue(server.maintenance_until),
     player_names_text: (server.player_names || []).join(", "),
@@ -126,6 +128,7 @@ function toPayload(form) {
     max_players: form.max_players === "" ? null : Number(form.max_players || 0),
     player_names: String(form.player_names_text || "").split(",").map((x) => x.trim()).filter(Boolean),
     sync_provider: form.sync_provider || "auto_public",
+    amp_instance: form.amp_instance || null,
     query_host: form.query_host || null,
     query_port: form.query_port === "" ? null : Number(form.query_port || 0),
     rcon_port: form.rcon_port === "" ? null : Number(form.rcon_port || 0),
@@ -403,6 +406,7 @@ export default function AdminGameServersPage() {
             {form.sync_provider !== "manual" && (
               <>
                 <Field label="Interne Sync-Adresse" value={form.query_host} onChange={(v) => set("query_host", v)} placeholder="leer = öffentliche Adresse, z.B. host.docker.internal" />
+                <Field label="AMP-Instanz" value={form.amp_instance} onChange={(v) => set("amp_instance", v)} placeholder="Name oder ID der Instanz im AMP-Panel" />
                 <Field label="Sync-Port" type="number" value={form.query_port} onChange={(v) => set("query_port", v)} placeholder="z.B. 25565" />
               </>
             )}

--- a/frontend/src/pages/public/ServersPage.jsx
+++ b/frontend/src/pages/public/ServersPage.jsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/context/AuthContext";
 import { api } from "@/lib/api";
 import { GameServerIcon } from "@/components/tls/GameServerIcon";
 import { safeResourceUrl, serverResourceLabels } from "@/lib/serverResources";
+import { ruleFacts, serverTags } from "@/lib/serverFacts";
 import { useApiInvalidation } from "@/hooks/useApiInvalidation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
@@ -237,8 +238,10 @@ function ServerCard({ server }) {
     { label: "Spieler", value: playerText(server) },
     server.map_name ? { label: "Karte", value: server.map_name } : null,
     server.version ? { label: "Version", value: server.version } : null,
+    ...ruleFacts(server.rules),
     server.last_sync_at ? { label: "Stand", value: formatDateTime(server.last_sync_at) } : null,
   ].filter(Boolean);
+  const tags = serverTags(server);
 
   return (
     <article className={`group relative overflow-hidden border rounded-sm bg-[#101010] min-h-[19rem] flex flex-col transition ${status === "maintenance" ? "border-[#FFD700]/45" : "border-white/10 hover:border-white/20"}`}>
@@ -289,6 +292,19 @@ function ServerCard({ server }) {
         <div className="mt-5 grid grid-cols-2 gap-x-5 gap-y-3 text-xs">
           {quickFacts.map((fact) => <Info key={fact.label} label={fact.label} value={fact.value} />)}
         </div>
+
+        {tags.length > 0 && (
+          <div className="mt-4" data-testid="server-tags">
+            <div className="text-[10px] uppercase tracking-widest text-white/35 font-bold mb-2">Server-Merkmale</div>
+            <div className="flex flex-wrap gap-1.5">
+              {tags.map((tag) => (
+                <span key={tag} className="px-2 py-0.5 border border-white/10 bg-white/5 rounded-sm text-[11px] text-white/70 break-all">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
 
         {max > 0 && (
           <div className="mt-5">


### PR DESCRIPTION
## Das Problem

Auf der Serverseite zeigten **vier von sieben Servern nur „0 online"** — ARK, Palworld, Rust und Windrose. Die Ursache lag nicht am Spiel, sondern an zwei Stellen im eigenen Code.

## 1. Die Abfrage ging an den falschen Port

Eingetragen ist überall die **Spieleradresse**, und genau die wurde abgefragt. Bei den meisten Spielen liegt die Statusabfrage aber woanders:

| Server | Adresse | Abfrage liegt auf |
| --- | --- | --- |
| Rust | 28015 | **28016** |
| ARK | 7777 | **27015** |
| Palworld | 8211 | gar kein A2S |
| Minecraft | 25565 | 25565 ✓ |

Ist kein Query-Port gepflegt, wird jetzt der übliche Port des Spiels ergänzt — erkannt am Spielnamen oder am Spielport. **Ein ausdrücklich gepflegter Port gewinnt immer**, weil der Betreiber sein Setup besser kennt als eine Tabelle. Antwortet ein Server auf dem ergänzten Port, steht das als Hinweis am Sync-Ergebnis.

## 2. Die Antwort wurde nur zur Hälfte gelesen

Der Parser hörte nach den Spielerzahlen auf und **verwarf den Rest, obwohl er bereits empfangen war**: die Versionsangabe und das Merkmalsfeld, in dem ARK, Rust und 7 Days To Die ihre Mods, Build-Nummer und PvP-Einstellung transportieren.

Jetzt gelesen: Version, Server-Merkmale, Bot-Zahl, Passwortschutz, VAC-Status. **Neu abgefragt:** Spielregeln (Schwierigkeit, Welttag, Kartengröße, Seed) und die Spielerliste. Antwortet ein Server darauf nicht, bleibt die Grundabfrage gültig — beides ist Zusatznutzen, kein Muss.

Von der Spielerliste werden bewusst **nur die Namen** übernommen. Punkte und Spielzeit wären personenbezogene Daten von Gästen ohne Anzeigezweck.

## 3. AMP als Hauptquelle

Für Palworld und Windrose hilft auch der beste Parser nicht — die sprechen kein öffentliches Protokoll. AMP kennt sie, weil es sie betreibt, und liefert für **jede** Instanz dieselben Kennzahlen: läuft oder nicht, Spieler aktuell und maximal, echte CPU- und Speicherlast.

- **Bewusst nur lesend.** Server von der Webseite aus starten oder stoppen hat niemand gebraucht, und eine Panel-Sitzung, die nur schauen darf, ist im Ernstfall deutlich weniger wert.
- Zugangsdaten liegen **verschlüsselt in den Einstellungen**, wie SMTP und Discord. Das Passwort verlässt den Server nie. Eine `http`-Adresse wird abgelehnt.
- Pro Server wird eine AMP-Instanz hinterlegt (Name oder ID). Das Feld ist Betriebswissen, nicht Teil der öffentlichen Ausgabe.
- Fällt das Panel aus, bleibt es beim Fehler dieses einen Servers — die übrigen laufen weiter.
- Ein **Test-Endpunkt** meldet, ob die Anmeldung klappt und welche Instanzen das Panel kennt, damit die Zuordnung nicht geraten werden muss.

**Der wichtigste Unterschied in der Anzeige:** eine fehlende Kennzahl bleibt fehlend. Null gemeldete Spieler ist eine Aussage, keine Meldung ist keine — beides darf auf der Seite nie gleich aussehen, sonst steht bei einem stummen Server fälschlich „0 online".

## Nachweise

- **39 neue Tests**: 22 für die Parser (synthetische Antworten Byte für Byte aufgebaut, inklusive abgeschnittener und fehlerhafter — die liefern weniger Felder statt zu scheitern), 17 für die AMP-Übersetzung und Zuordnung
- Backend **564 grün**, Frontend **104 grün**, Lint und Build sauber

## Zum Einrichten

Unter `Einstellungen → AMP` Adresse, Benutzer und Passwort hinterlegen, „Test" drücken — die Antwort listet die Instanznamen. Diese dann pro Server unter `Admin → Game-Server → AMP-Instanz` eintragen und den Sync-Anbieter auf „AMP-Panel" stellen.

Empfehlung: in AMP einen **eigenen Benutzer mit reinen Leserechten** anlegen, statt den Administrator zu verwenden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)