### PR TITLE
feat: Block 3 — Ergebnismeldung, Einspruch und Aufgabe auch im Graph-System

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -611,8 +611,12 @@ MatchStatus = Literal[
 
 
 class MatchScoreReport(BaseModel):
-    score_a: int = Field(ge=0)
-    score_b: int = Field(ge=0)
+    # Klassische Duelle melden zwei Punktstände. Graph-Matches können mehr als
+    # zwei Teilnehmer haben und melden deshalb eine Platzierungsliste; welches
+    # Feld gilt, entscheidet die Engine des Matches.
+    score_a: int = Field(default=0, ge=0)
+    score_b: int = Field(default=0, ge=0)
+    results: Optional[List["MatchV2ResultEntry"]] = None
     screenshot_url: Optional[str] = None
     note: Optional[str] = None
 
@@ -633,6 +637,8 @@ class MatchV2ResultSubmit(BaseModel):
     proof_url: Optional[str] = None
     note: Optional[str] = None
 
+
+MatchScoreReport.model_rebuild()
 
 ScheduleProposalAction = Literal["accept", "decline", "counter"]
 

--- a/backend/routes/match_routes.py
+++ b/backend/routes/match_routes.py
@@ -38,6 +38,15 @@ from services.rate_limit import enforce_rate_limit
 from services.station_labels import attach_station_info
 from services.user_notifications import create_user_notification
 from services.v2_result_submission import submit_v2_result
+from services.v2_match_flows import (
+    dispute_entry,
+    is_duplicate_dispute,
+    is_duplicate_report,
+    report_consensus,
+    report_entry,
+    results_for_forfeit,
+    validate_forfeit_note,
+)
 from services.competition_usage import engine_for_match, record_write
 
 router = APIRouter(prefix="/api/matches", tags=["matches"])
@@ -725,7 +734,7 @@ async def create_schedule_proposal(match_id: str, body: MatchScheduleProposalCre
         "updated_at": now_iso,
     }
     await db.match_schedule_proposals.insert_one(doc)
-    await db[collection].update_one({"id": match_id}, {"$set": {
+    await getattr(db, collection).update_one({"id": match_id}, {"$set": {
         "schedule_status": "proposed",
         "schedule_deadline_at": _schedule_deadline(match, tournament),
         "updated_at": now_iso,
@@ -791,7 +800,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
             "decision_note": normalized_note,
             "updated_at": now_iso,
         }})
-        await db[collection].update_one({"id": match_id}, {"$set": {
+        await getattr(db, collection).update_one({"id": match_id}, {"$set": {
             "scheduled_at": scheduled_at,
             "schedule_status": "accepted",
             "status": "scheduled" if match.get("status") in {"pending", "ready", "preview"} else match.get("status"),
@@ -805,7 +814,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
             "decision_note": normalized_note,
             "updated_at": now_iso,
         }})
-        await db[collection].update_one({"id": match_id}, {"$set": {"schedule_status": "declined", "updated_at": now_iso}})
+        await getattr(db, collection).update_one({"id": match_id}, {"$set": {"schedule_status": "declined", "updated_at": now_iso}})
         return {"ok": True, "status": "declined", "idempotent_replay": False}
     if not body.scheduled_at:
         raise HTTPException(status_code=400, detail="Gegenvorschlag braucht Datum und Uhrzeit")
@@ -832,7 +841,7 @@ async def decide_schedule_proposal(match_id: str, proposal_id: str, body: MatchS
         "updated_at": now_iso,
     }
     await db.match_schedule_proposals.insert_one(counter)
-    await db[collection].update_one({"id": match_id}, {"$set": {
+    await getattr(db, collection).update_one({"id": match_id}, {"$set": {
         "schedule_status": "proposed",
         "schedule_deadline_at": _schedule_deadline(match),
         "updated_at": now_iso,
@@ -1113,18 +1122,78 @@ async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_
     return m
 
 
+async def _report_v2(db, match: dict, body: MatchScoreReport, me: dict) -> dict:
+    """Take one participant's view of a graph match result.
+
+    Nothing is decided by a single report. Only when two different participants
+    submit the same ranking does the result get written - the same rule the
+    classic flow follows, so a player cannot rank themselves into the next
+    round on their own.
+    """
+    if not body.results:
+        raise HTTPException(
+            status_code=422,
+            detail="Für dieses Match wird eine Platzierungsliste gemeldet, keine zwei Punktstände.",
+        )
+    my_registration = await _user_registration_for_match(match, me)
+    if not my_registration:
+        raise HTTPException(status_code=403, detail="Nicht Teilnehmer dieses Matches")
+
+    results = [entry.model_dump(exclude_none=True) for entry in body.results]
+    if is_duplicate_report(match, me["id"], results):
+        match.pop("_id", None)
+        match["idempotent_replay"] = True
+        return match
+
+    entry = report_entry(me["id"], my_registration["id"], results)
+    await getattr(db, "matches_v2").update_one(
+        {"id": match["id"]},
+        {"$push": {"reports": entry}, "$set": {"updated_at": now_utc().isoformat()}},
+    )
+    await _audit_match_action(db, "match.result.report", match, me.get("id"), {
+        "result_count": len(results),
+    })
+
+    stored = await getattr(db, "matches_v2").find_one({"id": match["id"]}, {"_id": 0}) or match
+    agreed = report_consensus(stored.get("reports") or [])
+    if not agreed:
+        stored["idempotent_replay"] = False
+        stored["awaiting_confirmation"] = True
+        return stored
+
+    try:
+        outcome = await submit_v2_result(
+            db,
+            stored,
+            agreed,
+            actor_id=me["id"],
+            proof_url=body.screenshot_url,
+            note=body.note,
+            force=False,
+            audit_action="match.result.auto_resolution",
+        )
+    except MatchV2ResultError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    confirmed = outcome.get("match") or stored
+    confirmed["idempotent_replay"] = bool(outcome.get("idempotent_replay"))
+    confirmed["awaiting_confirmation"] = False
+    return confirmed
+
+
 @router.post("/{match_id}/report")
 async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends(get_current_user),
                        _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
-    m = await db.matches.find_one({"id": match_id})
-    if not m:
-        raise HTTPException(status_code=404)
+    m, collection = await _find_match_any(match_id)
     await _ensure_match_tournament_unlocked(db, m)
     await ensure_tournament_accepts_results(db, m["tournament_id"])
     tournament = await db.tournaments.find_one({"id": m.get("tournament_id")}, {"_id": 0})
     stage = await db.tournament_stages.find_one({"id": m.get("stage_id")}, {"_id": 0}) if m.get("stage_id") else None
-    policy = _match_policy(m, "matches", tournament, stage)
+    policy = _match_policy(m, collection, tournament, stage)
+    if collection == "matches_v2":
+        if not _players_can_report(policy):
+            raise HTTPException(status_code=403, detail="Ergebnisse werden für dieses Match durch die Turnierleitung eingetragen")
+        return await _report_v2(db, m, body, me)
     if not _players_can_report(policy):
         raise HTTPException(status_code=403, detail="Ergebnisse werden für dieses Match durch die Turnierleitung eingetragen")
     # Verify user is participant
@@ -1203,29 +1272,25 @@ async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends
 async def dispute(match_id: str, body: MatchDispute, me: dict = Depends(get_current_user),
                   _mutation: None = Depends(_serialized_match_write)):
     db = get_db()
-    m = await db.matches.find_one({"id": match_id})
-    if not m:
-        raise HTTPException(status_code=404, detail="Match nicht gefunden")
+    # Engine-unabhaengig: ein Einspruch muss in beiden Speichern moeglich sein,
+    # sonst kann ein Turnier im Graph-System nicht vollstaendig gespielt werden.
+    m, collection = await _find_match_any(match_id)
     await _ensure_match_tournament_unlocked(db, m)
     if not _is_staff(me) and not await _user_registration_for_match(m, me):
         raise HTTPException(status_code=403, detail="Nicht Teilnehmer dieses Matches")
     reason = body.reason.strip()
-    if any(
-        item.get("user_id") == me["id"] and (item.get("reason") or "").strip() == reason
-        for item in m.get("disputes") or []
-    ):
+    if is_duplicate_dispute(m, me["id"], reason):
         m.pop("_id", None)
         m["idempotent_replay"] = True
         return m
-    await db.matches.update_one({"id": match_id}, {
-        "$push": {"disputes": {"user_id": me["id"], "reason": reason,
-                                 "at": now_utc().isoformat()}},
+    await getattr(db, collection).update_one({"id": match_id}, {
+        "$push": {"disputes": dispute_entry(me["id"], reason)},
         "$set": {"status": "disputed", "updated_at": now_utc().isoformat()},
     })
     await _audit_match_action(db, "match.dispute.open", m, me.get("id"), {
         "reason_length": len((body.reason or "").strip()),
     })
-    m = await db.matches.find_one({"id": match_id}, {"_id": 0})
+    m = await getattr(db, collection).find_one({"id": match_id}, {"_id": 0})
     # Phase B v4.1: trigger negative achievement for the user who disputed
     try:
         from badges import on_dispute_opened
@@ -1236,6 +1301,53 @@ async def dispute(match_id: str, body: MatchDispute, me: dict = Depends(get_curr
     return m
 
 
+async def _forfeit_v2(db, match: dict, body: dict, me: dict, force: bool) -> dict:
+    """Record a walkover on a graph match.
+
+    Which participant gave up can be stated directly, or derived when only the
+    survivor is named and the match has exactly two sides - that keeps the call
+    identical to the classic one for the common duel case.
+    """
+    try:
+        note = validate_forfeit_note(body.get("note") or body.get("reason"))
+        forfeiting = (body.get("forfeit_registration_id") or "").strip()
+        if not forfeiting:
+            survivor = (body.get("winner_id") or "").strip()
+            others = [item for item in _registration_ids_for_match(match) if item != survivor]
+            if not survivor or len(others) != 1:
+                raise MatchV2ResultError(
+                    "Bitte forfeit_registration_id angeben - bei mehr als zwei Teilnehmern "
+                    "lässt sich der Aufgebende nicht aus dem Sieger ableiten."
+                )
+            forfeiting = others[0]
+        results = results_for_forfeit(match, forfeiting)
+    except MatchV2ResultError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    outcome = await submit_v2_result(
+        db,
+        match,
+        results,
+        actor_id=me["id"],
+        proof_url=None,
+        note=note,
+        force=force,
+        audit_action="match.forfeit",
+    )
+    updated = outcome.get("match") or match
+    await getattr(db, "matches_v2").update_one({"id": match["id"]}, {"$set": {
+        "status": "forfeit",
+        "forfeit_registration_id": forfeiting,
+        "admin_decision_note": note,
+        "admin_decision_by": me["id"],
+        "admin_decision_at": now_utc().isoformat(),
+        "updated_at": now_utc().isoformat(),
+    }})
+    result = await getattr(db, "matches_v2").find_one({"id": match["id"]}, {"_id": 0}) or updated
+    result["idempotent_replay"] = bool(outcome.get("idempotent_replay"))
+    return result
+
+
 @router.post("/{match_id}/forfeit")
 async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user),
                   force: bool = False,
@@ -1244,14 +1356,18 @@ async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user
 
     P0 — Penalty Transparency: a justification note (≥5 chars) is mandatory and
     will be visible to the affected player in /api/penalties/me.
+
+    Graph matches take the same route: there the walkover is expressed as an
+    ordinary ranking with the forfeiting participant last, so advancement,
+    standings and exports need no special case for it.
     """
     db = get_db()
-    m = await db.matches.find_one({"id": match_id})
-    if not m:
-        raise HTTPException(status_code=404)
+    m, collection = await _find_match_any(match_id)
     await _ensure_match_tournament_unlocked(db, m)
     await ensure_tournament_accepts_results(db, m["tournament_id"])
     await _require_result_permission(me, m)
+    if collection == "matches_v2":
+        return await _forfeit_v2(db, m, body, me, force)
     note = (body.get("note") or body.get("reason") or "").strip()
     if len(note) < 5:
         raise HTTPException(

--- a/backend/services/competition_capabilities.py
+++ b/backend/services/competition_capabilities.py
@@ -138,14 +138,16 @@ CAPABILITIES: tuple[Capability, ...] = (
     _c("result.submit", "Ergebnis melden",
        ["POST /api/matches/{match_id}/result"], [GRAPH]),
     _c("result.report", "Ergebnis im Einvernehmen bestätigen",
-       ["POST /api/matches/{match_id}/report"], [CLASSIC],
-       gap="Im Graph-System nicht vorhanden - Block 3."),
+       ["POST /api/matches/{match_id}/report"], [CLASSIC, GRAPH],
+       note="Block 3: auch im Graph-System. Zwei übereinstimmende Meldungen entscheiden, "
+            "eine einzelne nie - sonst könnte sich jemand allein weiterschreiben."),
     _c("result.dispute", "Ergebnis anfechten",
-       ["POST /api/matches/{match_id}/dispute"], [CLASSIC],
-       gap="Im Graph-System nicht vorhanden - Block 3."),
+       ["POST /api/matches/{match_id}/dispute"], [CLASSIC, GRAPH],
+       note="Block 3: derselbe Endpunkt bedient beide Speicher."),
     _c("result.forfeit", "Aufgabe eintragen",
-       ["POST /api/matches/{match_id}/forfeit"], [CLASSIC],
-       gap="Im Graph-System nicht vorhanden - Block 3."),
+       ["POST /api/matches/{match_id}/forfeit"], [CLASSIC, GRAPH],
+       note="Block 3: im Graph-System als gewöhnliche Platzierung mit dem Aufgebenden auf dem "
+            "letzten Platz - dadurch brauchen Weiterleitung, Tabelle und Export keinen Sonderfall."),
     _c("result.recalculate", "Weiterleitung neu berechnen",
        ["POST /api/tournaments/{tid}/matches-v2/recalculate-advancement"], [GRAPH]),
 )

--- a/backend/services/v2_match_flows.py
+++ b/backend/services/v2_match_flows.py
@@ -1,0 +1,119 @@
+"""Report, dispute and forfeit for graph matches.
+
+These three existed only for classic matches. A tournament running on the graph
+engine could be played but not contested: no way to report a result together,
+no way to object to one, no way to record a walkover. That gap is why no format
+could move over, so it is closed here before anything migrates.
+
+The flows deliberately produce the same shapes the classic ones do - a
+``reports`` list, a ``disputes`` list, a decided result - so the read model and
+the interface do not have to tell the two apart. Forfeits do not write a result
+themselves: they build the ranking and hand it to the one existing result
+writer, which owns the advancement cascade.
+"""
+from __future__ import annotations
+
+from models import now_utc
+from services.match_v2_results import MatchV2ResultError
+
+
+FORFEIT_NOTE_MIN_LENGTH = 5
+
+
+def filled_slots(match: dict) -> list[dict]:
+    return [slot for slot in (match.get("slots") or []) if slot.get("registration_id")]
+
+
+def participant_ids(match: dict) -> list[str]:
+    return [slot["registration_id"] for slot in filled_slots(match)]
+
+
+def results_for_forfeit(match: dict, forfeiting_registration_id: str) -> list[dict]:
+    """Rank a walkover: whoever gave up comes last, the rest keep their order.
+
+    Expressing a forfeit as an ordinary ranking means the advancement cascade,
+    the standings and the exports need no special case for it - a forfeited
+    match looks like any other decided match, just with a note attached.
+    """
+    participants = participant_ids(match)
+    if not participants:
+        raise MatchV2ResultError("Match hat keine belegten Slots")
+    if forfeiting_registration_id not in participants:
+        raise MatchV2ResultError("Der angegebene Teilnehmer gehört nicht zu diesem Match")
+    if len(participants) < 2:
+        raise MatchV2ResultError("Ein Forfeit braucht mindestens zwei Teilnehmer")
+
+    remaining = [item for item in participants if item != forfeiting_registration_id]
+    results = [{"registration_id": item, "rank": index + 1} for index, item in enumerate(remaining)]
+    results.append({"registration_id": forfeiting_registration_id, "rank": len(participants)})
+    return results
+
+
+def is_duplicate_dispute(match: dict, user_id: str, reason: str) -> bool:
+    """Same person, same reason - already recorded."""
+    needle = (reason or "").strip()
+    return any(
+        item.get("user_id") == user_id and (item.get("reason") or "").strip() == needle
+        for item in match.get("disputes") or []
+    )
+
+
+def dispute_entry(user_id: str, reason: str) -> dict:
+    return {"user_id": user_id, "reason": (reason or "").strip(), "at": now_utc().isoformat()}
+
+
+def report_entry(user_id: str, registration_id: str | None, results: list[dict]) -> dict:
+    return {
+        "user_id": user_id,
+        "registration_id": registration_id,
+        "results": results,
+        "at": now_utc().isoformat(),
+    }
+
+
+def _ranking_signature(results: list[dict]) -> tuple:
+    """Compare two reports by who finished where, ignoring order and extras."""
+    return tuple(sorted(
+        (str(entry.get("registration_id") or ""), int(entry.get("rank") or 0))
+        for entry in results or []
+    ))
+
+
+def is_duplicate_report(match: dict, user_id: str, results: list[dict]) -> bool:
+    signature = _ranking_signature(results)
+    return any(
+        item.get("user_id") == user_id and _ranking_signature(item.get("results")) == signature
+        for item in match.get("reports") or []
+    )
+
+
+def report_consensus(reports: list[dict]) -> list[dict] | None:
+    """Decide whether the reports agree, using each reporter's latest one.
+
+    Consensus needs two different reporters saying the same thing. Anything
+    else - a single report, or two that differ - waits for staff instead of
+    guessing, which is the same rule the classic flow follows.
+    """
+    latest_by_reporter: dict[str, dict] = {}
+    for report in reports or []:
+        key = report.get("registration_id") or report.get("user_id")
+        if key:
+            latest_by_reporter[key] = report
+    if len(latest_by_reporter) < 2:
+        return None
+
+    recent = list(latest_by_reporter.values())[-2:]
+    first, second = recent[0], recent[1]
+    if _ranking_signature(first.get("results")) != _ranking_signature(second.get("results")):
+        return None
+    return second.get("results") or None
+
+
+def validate_forfeit_note(note: str | None) -> str:
+    """A walkover is a penalty; the affected player is entitled to a reason."""
+    text = (note or "").strip()
+    if len(text) < FORFEIT_NOTE_MIN_LENGTH:
+        raise MatchV2ResultError(
+            f"Bei einem Forfeit ist eine Begründung (mind. {FORFEIT_NOTE_MIN_LENGTH} Zeichen) Pflicht."
+        )
+    return text

--- a/backend/tests/test_match_idempotency_unit.py
+++ b/backend/tests/test_match_idempotency_unit.py
@@ -26,6 +26,13 @@ class _MutableMatchCollection:
         self.document.update(deepcopy(update.get("$set") or {}))
 
 
+class _EmptyCollection:
+    """Der andere Speicher, in dem dieses Match nicht liegt."""
+
+    async def find_one(self, _query, _projection=None):
+        return None
+
+
 def test_dispute_exact_replay_skips_write_audit_and_badge(monkeypatch):
     match = {
         "id": "match-1",
@@ -34,7 +41,7 @@ def test_dispute_exact_replay_skips_write_audit_and_badge(monkeypatch):
         "disputes": [{"user_id": "user-1", "reason": "Falsches Ergebnis"}],
     }
     matches = _MutableMatchCollection(match)
-    db = SimpleNamespace(matches=matches)
+    db = SimpleNamespace(matches=matches, matches_v2=_EmptyCollection())
     audit = AsyncMock()
 
     monkeypatch.setattr(match_routes, "get_db", lambda: db)
@@ -65,7 +72,7 @@ def test_forfeit_exact_replay_skips_advancement_and_notifications(monkeypatch):
         "admin_decision_note": "Nicht erschienen",
     }
     matches = _MutableMatchCollection(match)
-    db = SimpleNamespace(matches=matches)
+    db = SimpleNamespace(matches=matches, matches_v2=_EmptyCollection())
     advance = Mock(side_effect=AssertionError("replay must not advance again"))
     notify = AsyncMock()
 
@@ -102,7 +109,7 @@ def test_non_result_update_on_completed_match_does_not_repeat_completion_hooks(m
         "admin_note": None,
     }
     matches = _MutableMatchCollection(match)
-    db = SimpleNamespace(matches=matches)
+    db = SimpleNamespace(matches=matches, matches_v2=_EmptyCollection())
     advance = Mock(side_effect=AssertionError("non-result update must not advance again"))
     audit = AsyncMock()
 
@@ -148,6 +155,7 @@ def test_score_report_exact_replay_skips_second_report_and_audit(monkeypatch):
     matches = _MutableMatchCollection(match)
     db = SimpleNamespace(
         matches=matches,
+        matches_v2=_EmptyCollection(),
         tournaments=SimpleNamespace(find_one=AsyncMock(return_value={})),
         tournament_stages=SimpleNamespace(find_one=AsyncMock()),
         tournament_registrations=SimpleNamespace(find_one=AsyncMock(return_value={"id": "reg-a"})),

--- a/backend/tests/test_tournament_capability_inventory.py
+++ b/backend/tests/test_tournament_capability_inventory.py
@@ -80,9 +80,6 @@ def test_every_capability_has_a_german_label_and_engines():
 EXPECTED_GAPS = {
     "structure.swiss",
     "structure.groups",
-    "result.report",
-    "result.dispute",
-    "result.forfeit",
 }
 
 

--- a/backend/tests/test_v2_match_flows_unit.py
+++ b/backend/tests/test_v2_match_flows_unit.py
@@ -1,0 +1,168 @@
+"""Report, dispute and forfeit for graph matches.
+
+These three flows decide who advances and who is recorded as having given up,
+so the rules they follow have to be pinned rather than assumed - especially the
+one where reports disagree, which must wait for staff instead of guessing.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.match_v2_results import MatchV2ResultError
+from services.v2_match_flows import (
+    dispute_entry,
+    is_duplicate_dispute,
+    is_duplicate_report,
+    report_consensus,
+    report_entry,
+    results_for_forfeit,
+    validate_forfeit_note,
+)
+
+
+def match_with(*registration_ids, **extra):
+    return {
+        "id": "m1",
+        "slots": [{"registration_id": item, "slot_index": index} for index, item in enumerate(registration_ids)],
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------- Forfeit
+
+def test_the_forfeiting_participant_is_ranked_last():
+    results = results_for_forfeit(match_with("reg-a", "reg-b"), "reg-b")
+
+    assert results == [
+        {"registration_id": "reg-a", "rank": 1},
+        {"registration_id": "reg-b", "rank": 2},
+    ]
+
+
+def test_the_other_participants_keep_their_order():
+    """Bei mehr als zwei Teilnehmern gibt der Forfeit nur den letzten Platz vor."""
+    results = results_for_forfeit(match_with("a", "b", "c", "d"), "b")
+
+    assert [item["registration_id"] for item in results] == ["a", "c", "d", "b"]
+    assert [item["rank"] for item in results] == [1, 2, 3, 4]
+
+
+def test_empty_slots_are_ignored():
+    match = {"slots": [{"registration_id": "a"}, {"registration_id": None}, {"registration_id": "b"}]}
+
+    assert len(results_for_forfeit(match, "b")) == 2
+
+
+def test_a_stranger_cannot_forfeit_this_match():
+    with pytest.raises(MatchV2ResultError):
+        results_for_forfeit(match_with("a", "b"), "fremder")
+
+
+def test_a_match_without_an_opponent_cannot_be_forfeited():
+    with pytest.raises(MatchV2ResultError):
+        results_for_forfeit(match_with("a"), "a")
+
+
+@pytest.mark.parametrize("note", [None, "", "   ", "kurz"])
+def test_a_forfeit_without_a_real_reason_is_rejected(note):
+    """Ein Forfeit ist eine Sanktion - der Betroffene hat ein Recht auf Begründung."""
+    with pytest.raises(MatchV2ResultError):
+        validate_forfeit_note(note)
+
+
+def test_a_proper_reason_is_accepted_and_trimmed():
+    assert validate_forfeit_note("  nicht angetreten  ") == "nicht angetreten"
+
+
+# ---------------------------------------------------------------- Einspruch
+
+def test_the_same_objection_twice_is_recognised():
+    match = {"disputes": [{"user_id": "u1", "reason": "Falscher Score"}]}
+
+    assert is_duplicate_dispute(match, "u1", "Falscher Score") is True
+    assert is_duplicate_dispute(match, "u1", "  Falscher Score  ") is True
+
+
+def test_a_different_person_or_reason_is_a_new_objection():
+    match = {"disputes": [{"user_id": "u1", "reason": "Falscher Score"}]}
+
+    assert is_duplicate_dispute(match, "u2", "Falscher Score") is False
+    assert is_duplicate_dispute(match, "u1", "Gegner nicht erschienen") is False
+
+
+def test_an_objection_records_who_when_and_why():
+    entry = dispute_entry("u1", "  Falscher Score  ")
+
+    assert entry["user_id"] == "u1"
+    assert entry["reason"] == "Falscher Score"
+    assert entry["at"]
+
+
+# ---------------------------------------------------------------- Ergebnismeldung
+
+def _results(first, second):
+    return [{"registration_id": first, "rank": 1}, {"registration_id": second, "rank": 2}]
+
+
+def test_two_matching_reports_decide_the_match():
+    reports = [
+        report_entry("u1", "reg-a", _results("reg-a", "reg-b")),
+        report_entry("u2", "reg-b", _results("reg-a", "reg-b")),
+    ]
+
+    assert report_consensus(reports) == _results("reg-a", "reg-b")
+
+
+def test_the_order_within_a_report_does_not_matter():
+    reports = [
+        report_entry("u1", "reg-a", _results("reg-a", "reg-b")),
+        report_entry("u2", "reg-b", list(reversed(_results("reg-a", "reg-b")))),
+    ]
+
+    assert report_consensus(reports) is not None
+
+
+def test_conflicting_reports_wait_for_staff():
+    """Bei Widerspruch wird nicht geraten - genau wie im klassischen Ablauf."""
+    reports = [
+        report_entry("u1", "reg-a", _results("reg-a", "reg-b")),
+        report_entry("u2", "reg-b", _results("reg-b", "reg-a")),
+    ]
+
+    assert report_consensus(reports) is None
+
+
+def test_a_single_report_decides_nothing():
+    assert report_consensus([report_entry("u1", "reg-a", _results("reg-a", "reg-b"))]) is None
+    assert report_consensus([]) is None
+
+
+def test_the_same_reporter_twice_is_still_only_one_voice():
+    reports = [
+        report_entry("u1", "reg-a", _results("reg-a", "reg-b")),
+        report_entry("u1", "reg-a", _results("reg-a", "reg-b")),
+    ]
+
+    assert report_consensus(reports) is None
+
+
+def test_a_corrected_report_replaces_the_earlier_one():
+    """Wer sich korrigiert, dessen letzte Meldung zaehlt."""
+    reports = [
+        report_entry("u1", "reg-a", _results("reg-b", "reg-a")),
+        report_entry("u2", "reg-b", _results("reg-a", "reg-b")),
+        report_entry("u1", "reg-a", _results("reg-a", "reg-b")),
+    ]
+
+    assert report_consensus(reports) == _results("reg-a", "reg-b")
+
+
+def test_an_identical_repeat_report_is_recognised():
+    match = {"reports": [report_entry("u1", "reg-a", _results("reg-a", "reg-b"))]}
+
+    assert is_duplicate_report(match, "u1", _results("reg-a", "reg-b")) is True
+    assert is_duplicate_report(match, "u1", _results("reg-b", "reg-a")) is False
+    assert is_duplicate_report(match, "u2", _results("reg-a", "reg-b")) is False


### PR DESCRIPTION
## Die Lücke

Ergebnismeldung, Einspruch und Aufgabe gab es bisher **nur klassisch**. Ein Turnier im Graph-System ließ sich damit spielen, aber nicht bestreiten — kein Weg, ein Ergebnis gemeinsam zu melden, keiner, ihm zu widersprechen, keiner, eine Aufgabe festzuhalten.

Genau deshalb konnte bisher **kein Format wechseln**: das Zielsystem konnte weniger als das alte.

## Dieselben Endpunkte, beide Engines

`/report`, `/dispute` und `/forfeit` suchen das Match jetzt in beiden Speichern und verzweigen intern. **Es kommen keine neuen Routen dazu** — die Routentabelle für `/api/matches` ist unverändert (nachgeprüft).

Das ist die Richtung, in die die Vereinheitlichung geht: ein Endpunkt pro Fachaufgabe, nicht einer je Speicher. Genau das Gegenteil des Zwillings, den Block 1 entfernt hat.

## Wie die drei im Graph-System funktionieren

**Aufgabe** wird als *gewöhnliche Platzierung* ausgedrückt, mit dem Aufgebenden auf dem letzten Platz. Dadurch brauchen Weiterleitung, Tabelle und Export keinen Sonderfall, und geschrieben wird über den **einen vorhandenen Ergebnisweg** statt über einen zweiten. Wer aufgegeben hat, kann direkt benannt oder bei zwei Teilnehmern aus dem Sieger abgeleitet werden.

Die Begründungspflicht gilt unverändert: ein Forfeit ist eine Sanktion, der Betroffene hat ein Recht darauf zu erfahren, warum.

**Eine einzelne Ergebnismeldung entscheidet nie etwas.** Erst wenn zwei *verschiedene* Teilnehmer dieselbe Platzierung melden, wird geschrieben — sonst könnte sich jemand allein in die nächste Runde schreiben. Widersprechen sich die Meldungen, wartet das Match auf die Turnierleitung statt zu raten. Dieselbe Regel wie im klassischen Ablauf. Eine korrigierte Meldung ersetzt die früheren desselben Melders.

Meldungen für Matches mit mehr als zwei Teilnehmern brauchen eine Platzierungsliste statt zweier Punktstände; das Meldemodell nimmt beides an, die Engine des Matches entscheidet.

## Inventar

**Drei der fünf Lücken sind geschlossen** und im Inventar eingetragen — der Test erzwingt das, eine stillschweigend geschlossene Lücke hätte ihn rot gemacht. Offen bleiben Schweizer System und Gruppen, die folgen als eigener Schritt.

## Nachweise

- **20 neue Tests** für Platzierung bei Aufgabe, Einspruchs-Dopplungen und Meldungs-Konsens — darunter der Fall widersprechender Meldungen und der eines Melders, der zweimal dasselbe schickt
- Backend **581 grün**, Match-Routen nachweislich unverändert

Zwei Test-Fakes mussten erweitert werden: sie kannten nur den klassischen Speicher, was seit dieser Änderung nicht mehr der Wirklichkeit entspricht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)