### PR TITLE
Turniere: Schweizer System und Gruppen auch im Graph-System (Block 3, Teil 2)

### DIFF
--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -32,8 +32,17 @@ from services.tournament_permissions import (
     is_global_tournament_admin,
     require_tournament_staff_permission,
 )
-from services.custom_bracket import BracketSchemaError, build_matches_v2_from_schema
+from services.custom_bracket import (
+    BracketSchemaError,
+    build_matches_v2_from_schema,
+    groups_from_generated_matches,
+)
 from services.competition_formats import find_format_capability
+from services.graph_swiss import (
+    next_round_number,
+    open_matches as open_swiss_matches,
+    swiss_round_documents,
+)
 from services.competition_graph_validation import validate_competition_graph
 from services.competition_read import load_competition_read_model, observe_structure_read
 from services.competition_snapshot import build_structure_snapshot
@@ -529,6 +538,9 @@ def _stage_defaults_for_tournament_format(tournament: dict, body: TournamentBrac
     match_type = (body.match_type if body else None) or default_match_type
     settings.setdefault("match_size", 4 if match_type == "ffa" else 2)
     settings.setdefault("min_players", 2)
+    if stage_type == "round_robin_groups":
+        # Eine Gruppe ist ein Round Robin, mehrere sind eine Gruppenphase.
+        settings.setdefault("group_count", 4 if fmt == "groups" else 1)
     settings.setdefault("qualifiers_per_match", 2 if match_type == "ffa" else 1)
     settings.setdefault("duration_minutes", int(tournament.get("match_duration_minutes") or 30))
     settings.setdefault("score_type", "points")
@@ -3612,6 +3624,103 @@ async def standings(tid: str, access: str | None = None, user=Depends(get_option
 
 
 # ---------- Swiss / Groups specific ----------
+async def _competition_engine(db, tid: str) -> str:
+    """Which store this tournament already writes to.
+
+    Deliberately reads the existing documents instead of the format: a
+    tournament stays in the engine it was built in until it is migrated, so
+    neither generator can move a running tournament to the other store behind
+    the organiser's back.
+    """
+    if await db.tournament_stages.count_documents({"tournament_id": tid}):
+        return "graph"
+    if await db.matches_v2.count_documents({"tournament_id": tid}):
+        return "graph"
+    return "classic"
+
+
+async def _dedicated_stage(db, tournament: dict, stage_type: str, settings: dict,
+                           name: str, actor_id: str | None) -> dict:
+    """Find or create the one stage a Swiss or group tournament runs in."""
+    tid = tournament["id"]
+    stage = await db.tournament_stages.find_one(
+        {"tournament_id": tid, "stage_type": stage_type}, {"_id": 0})
+    if stage:
+        merged = {**(stage.get("settings") or {}), **settings}
+        if merged != (stage.get("settings") or {}):
+            await db.tournament_stages.update_one(
+                {"id": stage["id"]},
+                {"$set": {"settings": merged, "updated_at": now_utc().isoformat()}},
+            )
+            stage["settings"] = merged
+        return stage
+    number = await db.tournament_stages.count_documents({"tournament_id": tid}) + 1
+    stage = {
+        "id": new_id(),
+        "tournament_id": tid,
+        "name": name,
+        "number": number,
+        "stage_type": stage_type,
+        "match_type": "duel",
+        "settings": {
+            "min_players": 2,
+            "match_size": 2,
+            "qualifiers_per_match": 1,
+            "score_type": "points",
+            "calculation": "points",
+            "duration_minutes": int(tournament.get("match_duration_minutes") or 30),
+            **settings,
+        },
+        "status": "pending",
+        "created_at": now_utc().isoformat(),
+        "updated_at": now_utc().isoformat(),
+        "created_by": actor_id,
+    }
+    await db.tournament_stages.insert_one(dict(stage))
+    return stage
+
+
+async def _swiss_next_round_graph(db, tournament: dict, actor_id: str | None) -> dict:
+    tid = tournament["id"]
+    stage = await _dedicated_stage(db, tournament, "swiss", {}, "Schweizer System", actor_id)
+    played = await db.matches_v2.find({"stage_id": stage["id"]}, {"_id": 0}).to_list(3000)
+    round_number = next_round_number(played)
+    still_open = open_swiss_matches(played, round_number - 1)
+    if still_open:
+        raise HTTPException(status_code=400, detail=f"{len(still_open)} Matches sind noch offen")
+
+    regs = await db.tournament_registrations.find(
+        {"tournament_id": tid, "status": {"$in": ["approved", "checked_in"]}},
+        {"_id": 0},
+    ).to_list(500)
+    documents = swiss_round_documents(
+        tournament, stage, regs, played, round_number=round_number,
+    )
+    if not documents:
+        raise HTTPException(status_code=400, detail="Mindestens 2 Teilnehmer benötigt")
+
+    await db.matches_v2.insert_many(documents)
+    await db.tournament_stages.update_one(
+        {"id": stage["id"]},
+        {"$set": {"status": "ready", "updated_at": now_utc().isoformat()}},
+    )
+    await persist_competition_versions(db, tournament, "graph")
+    if tournament.get("status") == "draft":
+        await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live"}})
+    await _audit_tournament_action(
+        db, "tournament.swiss.next_round", actor_id, tid,
+        {"engine": "graph", "stage_id": stage["id"], "round": round_number,
+         "match_count": len(documents)},
+    )
+    return {
+        "ok": True,
+        "engine": "graph",
+        "stage_id": stage["id"],
+        "round": round_number,
+        "match_count": len(documents),
+    }
+
+
 @router.post("/{tid}/swiss/next-round")
 async def swiss_next_round(tid: str, me: dict = Depends(require_admin()),
                            _mutation_tid: str = Depends(_serialized_tournament_write)):
@@ -3620,6 +3729,8 @@ async def swiss_next_round(tid: str, me: dict = Depends(require_admin()),
     t = await db.tournaments.find_one({"id": tid})
     if not t or t.get("format") != "swiss":
         raise HTTPException(status_code=400, detail="Nur für Swiss-Turniere")
+    if await _competition_engine(db, tid) == "graph":
+        return await _swiss_next_round_graph(db, t, me.get("id"))
     prev = await db.matches.find({"tournament_id": tid}, {"_id": 0}).to_list(2000)
     # Check open matches
     open_count = sum(1 for m in prev if m.get("status") not in ("completed", "forfeit", "cancelled"))
@@ -3636,7 +3747,61 @@ async def swiss_next_round(tid: str, me: dict = Depends(require_admin()),
         await persist_competition_versions(db, t, "classic")
     if t.get("status") == "draft":
         await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live"}})
-    return {"ok": True, "round": next_round_num, "match_count": len(matches)}
+    return {"ok": True, "engine": "classic", "round": next_round_num, "match_count": len(matches)}
+
+
+async def _groups_generate_graph(db, tournament: dict, group_count: int, actor_id: str | None) -> dict:
+    tid = tournament["id"]
+    stage = await _dedicated_stage(
+        db, tournament, "round_robin_groups", {"group_count": group_count}, "Gruppenphase", actor_id)
+    regs = await db.tournament_registrations.find(
+        {"tournament_id": tid, "status": {"$in": ["approved", "checked_in"]}},
+        {"_id": 0},
+    ).to_list(500)
+    if len(regs) < 2:
+        raise HTTPException(status_code=400, detail="Mindestens 2 Teilnehmer benötigt")
+    try:
+        matches = build_matches_v2_from_schema(tournament, stage, regs, preview=False)
+    except BracketSchemaError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not matches:
+        raise HTTPException(status_code=400, detail="Die Gruppenphase erzeugt keine Spiele.")
+
+    groups = groups_from_generated_matches(matches)
+    group_id_by_section = {group["section"]: group["id"] for group in groups}
+    for match in matches:
+        group_id = group_id_by_section.get(match.get("section") or "")
+        if group_id:
+            match["group_id"] = group_id
+
+    old_match_ids = await db.matches_v2.distinct("id", {"stage_id": stage["id"]})
+    if old_match_ids:
+        await db.match_reports_v2.delete_many({"match_id": {"$in": old_match_ids}})
+    await db.matches_v2.delete_many({"stage_id": stage["id"]})
+    await db.tournament_groups.delete_many({"tournament_id": tid})
+    await db.tournament_groups.insert_many([
+        {**group, "tournament_id": tid, "created_at": now_utc().isoformat()}
+        for group in groups
+    ])
+    await db.matches_v2.insert_many(matches)
+    await db.tournament_stages.update_one(
+        {"id": stage["id"]},
+        {"$set": {"status": "ready", "updated_at": now_utc().isoformat()}},
+    )
+    await persist_competition_versions(db, tournament, "graph")
+    await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live"}})
+    await _audit_tournament_action(
+        db, "tournament.groups.generate", actor_id, tid,
+        {"engine": "graph", "stage_id": stage["id"], "group_count": len(groups),
+         "match_count": len(matches)},
+    )
+    return {
+        "ok": True,
+        "engine": "graph",
+        "stage_id": stage["id"],
+        "group_count": len(groups),
+        "match_count": len(matches),
+    }
 
 
 @router.post("/{tid}/groups/generate")
@@ -3648,6 +3813,8 @@ async def groups_generate(tid: str, body: dict, me: dict = Depends(require_admin
     if not t or t.get("format") != "groups":
         raise HTTPException(status_code=400, detail="Nur für Group-Stage")
     group_count = int(body.get("group_count", 4))
+    if await _competition_engine(db, tid) == "graph":
+        return await _groups_generate_graph(db, t, group_count, me.get("id"))
     regs = await db.tournament_registrations.find(
         {"tournament_id": tid, "status": {"$in": ["approved", "checked_in"]}},
         {"_id": 0},
@@ -3665,7 +3832,7 @@ async def groups_generate(tid: str, body: dict, me: dict = Depends(require_admin
         await db.matches.insert_many(res["matches"])
         await persist_competition_versions(db, t, "classic")
     await db.tournaments.update_one({"id": tid}, {"$set": {"status": "live"}})
-    return {"ok": True, "group_count": len(res["groups"]), "match_count": len(res["matches"])}
+    return {"ok": True, "engine": "classic", "group_count": len(res["groups"]), "match_count": len(res["matches"])}
 
 
 @router.get("/{tid}/groups")

--- a/backend/services/competition_capabilities.py
+++ b/backend/services/competition_capabilities.py
@@ -104,11 +104,15 @@ CAPABILITIES: tuple[Capability, ...] = (
         "DELETE /api/tournaments/{tid}/stages/{stage_id}",
         "POST /api/tournaments/{tid}/stages/{stage_id}/generate"], [GRAPH]),
     _c("structure.swiss", "Schweizer Runde erzeugen",
-       ["POST /api/tournaments/{tid}/swiss/next-round"], [CLASSIC],
-       gap="Kein Generator im Graph-System - Block 3."),
+       ["POST /api/tournaments/{tid}/swiss/next-round"], [CLASSIC, GRAPH],
+       note="Block 3: bewusst ohne Schema. Wer in Runde 3 gegen wen spielt, hängt an Runde 2 - "
+            "die Struktur wächst also Runde für Runde. Ein Freilos wird als entschiedenes Match "
+            "mit einem Teilnehmer geschrieben, damit der Punkt dafür in der Tabelle ankommt."),
     _c("structure.groups", "Gruppen erzeugen",
-       ["POST /api/tournaments/{tid}/groups/generate", "GET /api/tournaments/{tid}/groups"], [CLASSIC],
-       gap="Kein Generator im Graph-System - Block 3."),
+       ["POST /api/tournaments/{tid}/groups/generate", "GET /api/tournaments/{tid}/groups"], [CLASSIC, GRAPH],
+       note="Block 3: Gruppen stehen im Voraus fest und passen deshalb ins Schema. Die "
+            "Gruppenzuteilung läuft im Schlangensystem, damit die stärksten Setzplätze nicht "
+            "in derselben Gruppe landen."),
 
     # ---------- Struktur lesen ----------
     _c("structure.read", "Turnierbaum und Abschnitte lesen",

--- a/backend/services/competition_formats.py
+++ b/backend/services/competition_formats.py
@@ -106,7 +106,10 @@ _FORMAT_CAPABILITIES = {
         stage_generator_available=False,
         auto_match_limit="none",
         canonical_write_ready=False,
-        migration_note="Swiss currently uses separate round-generation routes and needs a versioned pairing strategy.",
+        migration_note=(
+            "Block 3: round generation serves both stores. No declarative schema on purpose - "
+            "each round depends on the previous one, so the structure grows round by round."
+        ),
     ),
     "groups": TournamentFormatCapability(
         key="groups",
@@ -117,11 +120,14 @@ _FORMAT_CAPABILITIES = {
         pairing_mode="scheduled_rounds",
         current_write_model="classic",
         initial_preview_engine="none",
-        rebuild_engine="none",
-        stage_generator_available=False,
+        rebuild_engine="stage",
+        stage_generator_available=True,
         auto_match_limit="none",
         canonical_write_ready=False,
-        migration_note="Groups currently use separate generation and standings routes.",
+        migration_note=(
+            "Block 3: the group stage now has a schema generator, so existing group "
+            "tournaments keep the classic store until they are migrated."
+        ),
     ),
     "ffa": TournamentFormatCapability(
         key="ffa",

--- a/backend/services/competition_standings.py
+++ b/backend/services/competition_standings.py
@@ -22,6 +22,20 @@ def _display_name(registration: dict) -> str:
     )
 
 
+def _sole_winner(match: dict) -> str | None:
+    """The single winner, or nothing when the match ended level.
+
+    The graph engine expresses a draw as two participants sharing rank 1, so
+    picking the first winner it finds would silently turn every draw into a win.
+    """
+    winners = [
+        result.get("registration_id")
+        for result in match.get("results") or []
+        if result.get("outcome") == "winner"
+    ]
+    return winners[0] if len(winners) == 1 else None
+
+
 def _duel_entries(match: dict) -> tuple[dict | None, dict | None, dict | None, dict | None]:
     slots = sorted(match.get("slots") or [], key=lambda slot: _safe_int(slot.get("position"), 999))
     slot_a = slots[0] if slots else None
@@ -149,7 +163,7 @@ def round_robin_standings(matches: list[dict], registrations: list[dict]) -> lis
         if registration.get("id")
     }
     for match in matches:
-        if match.get("status") != "completed":
+        if match.get("status") not in TERMINAL_MATCH_STATUSES:
             continue
         slot_a, slot_b, result_a, result_b = _duel_entries(match)
         registration_a = (slot_a or {}).get("registration_id")
@@ -166,14 +180,7 @@ def round_robin_standings(matches: list[dict], registrations: list[dict]) -> lis
             stats[registration_b]["played"] += 1
             stats[registration_b]["score_for"] += score_b
             stats[registration_b]["score_against"] += score_a
-        winner_id = next(
-            (
-                result.get("registration_id")
-                for result in match.get("results") or []
-                if result.get("outcome") == "winner"
-            ),
-            None,
-        )
+        winner_id = _sole_winner(match)
         if winner_id == registration_a and registration_a in stats:
             stats[registration_a]["won"] += 1
             stats[registration_a]["points"] += 3
@@ -214,25 +221,24 @@ def swiss_standings(matches: list[dict], registrations: list[dict]) -> list[dict
         if registration.get("id")
     }
     for match in matches:
-        if match.get("status") != "completed":
+        if match.get("status") not in TERMINAL_MATCH_STATUSES:
             continue
         slot_a, slot_b, _result_a, _result_b = _duel_entries(match)
         registration_a = (slot_a or {}).get("registration_id")
         registration_b = (slot_b or {}).get("registration_id")
+        if registration_a in stats and registration_b is None:
+            # Freilos: zaehlt als voller Punkt, aber gegen niemanden.
+            stats[registration_a]["played"] += 1
+            stats[registration_a]["won"] += 1
+            stats[registration_a]["points"] += 1
+            continue
         if registration_a not in stats or registration_b not in stats:
             continue
         stats[registration_a]["played"] += 1
         stats[registration_b]["played"] += 1
         stats[registration_a]["opponents"].append(registration_b)
         stats[registration_b]["opponents"].append(registration_a)
-        winner_id = next(
-            (
-                result.get("registration_id")
-                for result in match.get("results") or []
-                if result.get("outcome") == "winner"
-            ),
-            None,
-        )
+        winner_id = _sole_winner(match)
         if winner_id == registration_a:
             stats[registration_a]["won"] += 1
             stats[registration_a]["points"] += 1
@@ -289,11 +295,20 @@ def standings_for_structure(
     """Select the existing standings policy over one canonical read model."""
 
     matches = snapshot.get("matches") or []
+    format_key = tournament.get("format")
     stage_matches = [match for match in matches if match.get("source", {}).get("engine") == "stage"]
     if stage_matches:
+        # Der Speicher entscheidet nicht über die Tabelle: ein Schweizer Turnier
+        # braucht Buchholz und ein Gruppenturnier seine Gruppentabellen, egal in
+        # welcher Engine die Matches liegen.
+        if format_key == "swiss":
+            return swiss_standings(stage_matches, registrations)
+        if format_key == "groups":
+            return group_standings(stage_matches, registrations, list(groups))
+        if format_key in {"round_robin", "league"}:
+            return round_robin_standings(stage_matches, registrations)
         return stage_standings(stage_matches, registrations)
     legacy_matches = [match for match in matches if match.get("source", {}).get("engine") == "legacy"]
-    format_key = tournament.get("format")
     if format_key in {"round_robin", "league"}:
         return round_robin_standings(legacy_matches, registrations)
     if format_key == "swiss":

--- a/backend/services/custom_bracket.py
+++ b/backend/services/custom_bracket.py
@@ -349,6 +349,111 @@ def _auto_ffa_custom_schema(slot_count: int, match_size: int, qualifiers_per_mat
     return "\n".join(lines)
 
 
+def distribute_into_groups(slot_count: int, group_count: int) -> list[list[int]]:
+    """Spread the seeds across the groups in snake order.
+
+    Straight distribution would put seeds 1 and 2 in the same group; the snake
+    keeps the strongest apart, which is the point of seeding in the first place.
+    """
+    size = max(2, int(slot_count or 2))
+    count = max(1, min(int(group_count or 1), size // 2 or 1))
+    groups: list[list[int]] = [[] for _ in range(count)]
+    for index in range(size):
+        row, position = divmod(index, count)
+        target = position if row % 2 == 0 else count - 1 - position
+        groups[target].append(index + 1)
+    return [group for group in groups if group]
+
+
+def _round_robin_rounds(seeds: list[int]) -> list[list[tuple[int, int]]]:
+    """Everyone against everyone, spread over matchdays by the circle method.
+
+    Listing the pairings as one flat block would put every match of a group on
+    the same day. The circle method gives each participant exactly one match per
+    matchday, which is what a group stage has to be schedulable as.
+    """
+    players: list[int | None] = list(seeds)
+    if len(players) % 2 == 1:
+        players.append(None)
+    size = len(players)
+    rounds: list[list[tuple[int, int]]] = []
+    for _ in range(max(0, size - 1)):
+        pairs = [
+            (players[index], players[size - 1 - index])
+            for index in range(size // 2)
+            if players[index] is not None and players[size - 1 - index] is not None
+        ]
+        if pairs:
+            rounds.append(pairs)
+        players = [players[0]] + [players[-1]] + players[1:-1]
+    return rounds
+
+
+def group_label(number: int) -> str:
+    return chr(ord("A") + number - 1) if number <= 26 else str(number)
+
+
+def group_section(number: int) -> str:
+    """Section name for one group.
+
+    Deliberately the same ``group_<key>`` shape the classic engine writes into
+    ``bracket``, so the group standings find their matches without having to
+    know which engine produced them.
+    """
+    return f"group_{group_label(number)}"
+
+
+def _auto_groups_schema(slot_count: int, group_count: int) -> str:
+    """Build a group stage: each group its own section, round robin inside.
+
+    Group play is fully known in advance - who meets whom does not depend on
+    any result - so it fits the declarative schema without a dynamic generator.
+    """
+    groups = distribute_into_groups(slot_count, group_count)
+    lines: list[str] = []
+    key_index = 0
+    for number, seeds in enumerate(groups, start=1):
+        label = group_label(number)
+        lines.append(f"[{group_section(number)}]")
+        for matchday, pairs in enumerate(_round_robin_rounds(seeds), start=1):
+            lines.append(f"# Gruppe {label} - Runde {matchday}")
+            for left, right in pairs:
+                key = _match_key(key_index)
+                key_index += 1
+                lines.append(f"{key}=[{left},{right}]")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def groups_from_generated_matches(matches: list[dict]) -> list[dict]:
+    """Read back which participant ended up in which group.
+
+    The seeding happens inside the match builder, so rather than repeating that
+    logic the group roster is derived from the matches it produced - that way
+    the roster can never disagree with the fixtures.
+    """
+    rosters: dict[str, list[str]] = {}
+    for match in sorted(matches, key=lambda item: (item.get("round") or 0, item.get("order") or 0)):
+        section = str(match.get("section") or "")
+        if not section.startswith("group_"):
+            continue
+        roster = rosters.setdefault(section, [])
+        for slot in match.get("slots") or []:
+            registration_id = slot.get("registration_id")
+            if registration_id and registration_id not in roster:
+                roster.append(registration_id)
+    return [
+        {
+            "id": _new_id(),
+            "name": f"Gruppe {section[len('group_'):]}",
+            "group_key": section[len("group_"):],
+            "section": section,
+            "participant_ids": roster,
+        }
+        for section, roster in sorted(rosters.items())
+    ]
+
+
 def _auto_ffa_single_match_schema(slot_count: int) -> str:
     size = max(2, int(slot_count or 2))
     sources = ",".join(str(seed) for seed in range(1, size + 1))
@@ -418,6 +523,9 @@ def _resolve_schema(tournament: dict, stage: dict, registrations: list[dict], pr
             int(settings.get("match_size") or 4),
             int(settings.get("qualifiers_per_match") or 2),
         )
+    if (stage.get("stage_type") or "") == "round_robin_groups":
+        size = int(tournament.get("max_participants") or 2) if preview else max(2, len(registrations))
+        return _auto_groups_schema(size, int(settings.get("group_count") or 2))
     if (stage.get("stage_type") or "") == "simple":
         size = int(tournament.get("max_participants") or 2) if preview else max(2, len(registrations))
         return _auto_ffa_single_match_schema(size)

--- a/backend/services/graph_swiss.py
+++ b/backend/services/graph_swiss.py
@@ -1,0 +1,254 @@
+"""Swiss pairing for the graph engine.
+
+Swiss is the one format that cannot be written down in advance. Who meets whom
+in round three depends on what happened in rounds one and two, so unlike a
+bracket it has no declarative schema - each round is computed when the previous
+one is finished.
+
+The pairing rules are the familiar ones: similar scores meet, nobody plays the
+same opponent twice while an alternative exists, and with an odd number of
+participants one gets a bye. Everything here is pure computation on plain
+dicts so it can be checked without a database.
+"""
+from __future__ import annotations
+
+import random
+import uuid
+from datetime import datetime, timezone
+
+WIN_POINTS = 1.0
+DRAW_POINTS = 0.5
+DECIDED_STATUSES = {"completed", "forfeit"}
+SETTLED_STATUSES = DECIDED_STATUSES | {"cancelled"}
+
+
+def _filled(match: dict) -> list[str]:
+    return [slot["registration_id"] for slot in (match.get("slots") or []) if slot.get("registration_id")]
+
+
+def scores_and_history(participants: list[str], matches: list[dict]) -> tuple[dict[str, float], dict[str, set]]:
+    """Points so far and who already played whom.
+
+    Only decided matches count. A pending round must not influence the next
+    pairing, otherwise a half-entered round would scramble the field.
+    """
+    scores: dict[str, float] = {item: 0.0 for item in participants}
+    opponents: dict[str, set] = {item: set() for item in participants}
+
+    for match in matches:
+        if match.get("status") not in DECIDED_STATUSES:
+            continue
+        present = _filled(match)
+        if len(present) == 1:
+            # Freilos: volle Punktzahl, aber kein Gegner in der Historie.
+            if present[0] in scores:
+                scores[present[0]] += WIN_POINTS
+            continue
+        taking_part = [item for item in present if item in scores]
+        if len(taking_part) < 2:
+            continue
+        for item in taking_part:
+            opponents[item].update(other for other in taking_part if other != item)
+
+        results = match.get("results") or []
+        ranked = sorted(
+            (entry for entry in results if entry.get("registration_id") in scores),
+            key=lambda entry: entry.get("rank") or 999,
+        )
+        if not ranked:
+            continue
+        best_rank = ranked[0].get("rank")
+        winners = [entry for entry in ranked if entry.get("rank") == best_rank]
+        points = WIN_POINTS if len(winners) == 1 else DRAW_POINTS
+        for entry in winners:
+            scores[entry["registration_id"]] += points
+    return scores, opponents
+
+
+def bye_history(matches: list[dict]) -> set[str]:
+    """Who already sat a round out. Nobody should sit out twice."""
+    seated: set[str] = set()
+    for match in matches:
+        present = _filled(match)
+        if len(present) == 1:
+            seated.add(present[0])
+    return seated
+
+
+def _ordered_by_score(scores: dict[str, float], rng: random.Random) -> list[str]:
+    buckets: dict[float, list[str]] = {}
+    for participant, score in scores.items():
+        buckets.setdefault(score, []).append(participant)
+    ordered: list[str] = []
+    for score in sorted(buckets, reverse=True):
+        bucket = sorted(buckets[score])
+        rng.shuffle(bucket)
+        ordered.extend(bucket)
+    return ordered
+
+
+def swiss_pairings(
+    participants: list[str],
+    matches: list[dict],
+    *,
+    seed: int | None = None,
+) -> tuple[list[tuple[str, str]], str | None]:
+    """Pair the next round. Returns the pairs and whoever gets a bye.
+
+    Pairing walks the field from the top and takes the closest opponent that
+    has not been faced yet. Only when every remaining candidate has already
+    been played does it allow a rematch - refusing to pair at all would stall
+    the tournament, which is worse than a repeat.
+    """
+    field = [item for item in participants if item]
+    if len(field) < 2:
+        return [], field[0] if field else None
+
+    rng = random.Random(seed)
+    scores, opponents = scores_and_history(field, matches)
+    ordered = _ordered_by_score(scores, rng)
+
+    bye: str | None = None
+    if len(ordered) % 2 == 1:
+        # Von hinten aufgerollt: das Freilos geht an den Letzten, der noch keines
+        # hatte. Zweimal aussetzen wäre ein Vorteil, den niemand verdient hat.
+        seated = bye_history(matches)
+        bye = next((item for item in reversed(ordered) if item not in seated), ordered[-1])
+        ordered = [item for item in ordered if item != bye]
+
+    pairs: list[tuple[str, str]] = []
+    used: set[str] = set()
+    for index, player in enumerate(ordered):
+        if player in used:
+            continue
+        partner = next(
+            (other for other in ordered[index + 1:]
+             if other not in used and other not in opponents[player]),
+            None,
+        )
+        if partner is None:
+            partner = next((other for other in ordered[index + 1:] if other not in used), None)
+        if partner is None:
+            break
+        used.add(player)
+        used.add(partner)
+        pairs.append((player, partner))
+    return pairs, bye
+
+
+def next_round_number(matches: list[dict]) -> int:
+    rounds = [int(match.get("round") or 0) for match in matches]
+    return (max(rounds) if rounds else 0) + 1
+
+
+def round_is_complete(matches: list[dict], round_number: int) -> bool:
+    """A new round may only start once the current one is fully decided."""
+    return not open_matches(matches, round_number)
+
+
+def open_matches(matches: list[dict], round_number: int) -> list[dict]:
+    """Matches of one round that are neither decided nor called off."""
+    return [
+        match for match in matches
+        if int(match.get("round") or 0) == round_number
+        and match.get("status") not in SETTLED_STATUSES
+    ]
+
+
+def swiss_round_documents(
+    tournament: dict,
+    stage: dict,
+    registrations: list[dict],
+    played: list[dict],
+    *,
+    round_number: int,
+    seed: int | None = None,
+) -> list[dict]:
+    """Build one Swiss round as graph match documents.
+
+    The shape matches what the schema builder produces for every other format,
+    so the read model, the standings and the result flows treat a Swiss match
+    like any other. A bye is written as a decided match with a single
+    participant rather than being dropped, which is how it earns its point.
+    """
+    by_id = {registration["id"]: registration for registration in registrations if registration.get("id")}
+    pairs, bye = swiss_pairings(list(by_id), played, seed=seed)
+    if not pairs and not bye:
+        return []
+
+    settings = stage.get("settings") or {}
+    duration = int(settings.get("duration_minutes") or tournament.get("match_duration_minutes") or 30)
+    now = datetime.now(timezone.utc).isoformat()
+    round_name = f"Swiss Runde {round_number}"
+
+    def slot(index: int, registration_id: str | None) -> dict:
+        registration = by_id.get(registration_id or "") or {}
+        return {
+            "slot": index,
+            "source": {"type": "direct", "raw": "swiss"},
+            "registration_id": registration.get("id"),
+            "user_id": registration.get("user_id"),
+            "seed": registration.get("seed"),
+            "status": "filled" if registration else "bye",
+        }
+
+    documents: list[dict] = []
+    entries: list[tuple[list[dict], bool]] = [
+        ([slot(1, left), slot(2, right)], False) for left, right in pairs
+    ]
+    if bye:
+        entries.append(([slot(1, bye), slot(2, None)], True))
+
+    for order, (slots, is_bye) in enumerate(entries, start=1):
+        document = {
+            "id": str(uuid.uuid4()),
+            "tournament_id": tournament["id"],
+            "stage_id": stage["id"],
+            "stage_number": stage.get("number"),
+            "stage_type": "swiss",
+            "match_type": "duel",
+            "match_key": f"S{round_number}-{order}",
+            "section": "swiss",
+            "round": round_number,
+            "round_name": round_name,
+            "order": order,
+            "slots": slots,
+            "results": [],
+            "advancement": [],
+            "settings": {
+                "min_players": 2,
+                "match_size": 2,
+                "qualifiers_per_match": 1,
+                "score_type": settings.get("score_type") or "points",
+                "calculation": settings.get("calculation") or "points",
+                "duration_minutes": duration,
+                "randomize_advancement_rounds": False,
+            },
+            "status": "ready",
+            "is_preview": False,
+            "generation_mode": "swiss_pairing",
+            "scheduled_at": None,
+            "duration_minutes": duration,
+            "station_id": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+        if is_bye:
+            document["status"] = "completed"
+            document["results"] = [{
+                "registration_id": bye,
+                "user_id": (by_id.get(bye) or {}).get("user_id"),
+                "slot": 1,
+                "rank": 1,
+                "score": None,
+                "points": None,
+                "time_ms": None,
+                "dnf": False,
+                "forfeit": False,
+                "note": "Freilos in dieser Runde",
+                "reported_by": "system",
+                "reported_at": now,
+            }]
+            document["result_meta"] = {"source": "swiss_bye", "updated_at": now}
+        documents.append(document)
+    return documents

--- a/backend/tests/test_competition_formats_unit.py
+++ b/backend/tests/test_competition_formats_unit.py
@@ -42,7 +42,7 @@ def test_catalog_only_targets_known_stage_and_match_types():
         ("double_elim", "classic", "legacy", "stage", "double_elimination", "duel"),
         ("round_robin", "classic", "legacy", "legacy", "round_robin_groups", "duel"),
         ("swiss", "classic", "none", "none", "swiss", "duel"),
-        ("groups", "classic", "none", "none", "round_robin_groups", "duel"),
+        ("groups", "classic", "none", "stage", "round_robin_groups", "duel"),
         ("ffa", "graph", "stage", "stage", "simple", "ffa"),
         ("battle_royale", "graph", "stage", "stage", "simple", "ffa"),
         ("league", "classic", "legacy", "legacy", "league", "duel"),

--- a/backend/tests/test_graph_swiss_groups_unit.py
+++ b/backend/tests/test_graph_swiss_groups_unit.py
@@ -1,0 +1,455 @@
+"""Swiss pairing and group distribution for the graph engine.
+
+These two were the last formats that only existed classically. Swiss decides at
+runtime who meets whom, so its rules have to be pinned: similar scores meet, a
+rematch only when there is no alternative, and a new round only once the
+current one is decided.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.competition_standings import standings_for_structure
+from services.competition_snapshot import build_structure_snapshot
+from services.custom_bracket import (
+    distribute_into_groups,
+    groups_from_generated_matches,
+    infer_rounds,
+    parse_custom_bracket_schema,
+)
+from services.custom_bracket import _auto_groups_schema
+from services.graph_swiss import (
+    bye_history,
+    next_round_number,
+    open_matches,
+    round_is_complete,
+    scores_and_history,
+    swiss_pairings,
+    swiss_round_documents,
+)
+
+
+def decided_match(round_number, winner, loser, status="completed"):
+    return {
+        "round": round_number,
+        "status": status,
+        "slots": [{"registration_id": winner}, {"registration_id": loser}],
+        "results": [
+            {"registration_id": winner, "rank": 1},
+            {"registration_id": loser, "rank": 2},
+        ],
+    }
+
+
+def bye_match(round_number, participant):
+    return {
+        "round": round_number,
+        "status": "completed",
+        "slots": [{"registration_id": participant}, {"registration_id": None}],
+        "results": [{"registration_id": participant, "rank": 1}],
+    }
+
+
+def drawn_match(round_number, first, second):
+    return {
+        "round": round_number,
+        "status": "completed",
+        "slots": [{"registration_id": first}, {"registration_id": second}],
+        "results": [
+            {"registration_id": first, "rank": 1},
+            {"registration_id": second, "rank": 1},
+        ],
+    }
+
+
+# ---------------------------------------------------------------- Punkte
+
+def test_a_win_counts_fully_and_a_draw_by_half():
+    scores, _ = scores_and_history(["a", "b", "c", "d"], [decided_match(1, "a", "b"), drawn_match(1, "c", "d")])
+
+    assert scores == {"a": 1.0, "b": 0.0, "c": 0.5, "d": 0.5}
+
+
+def test_an_undecided_match_does_not_count_yet():
+    """Eine halb eingetragene Runde darf die naechste Paarung nicht verzerren."""
+    pending = {"round": 1, "status": "ready", "slots": [{"registration_id": "a"}, {"registration_id": "b"}], "results": []}
+    scores, opponents = scores_and_history(["a", "b"], [pending])
+
+    assert scores == {"a": 0.0, "b": 0.0}
+    assert opponents["a"] == set()
+
+
+def test_a_forfeit_counts_like_a_decided_match():
+    scores, opponents = scores_and_history(["a", "b"], [decided_match(1, "a", "b", status="forfeit")])
+
+    assert scores["a"] == 1.0
+    assert opponents["a"] == {"b"}
+
+
+def test_a_bye_is_worth_a_full_point_but_adds_no_opponent():
+    """Wer aussetzt, darf dadurch nicht zurueckfallen - aber auch keinen Gegner erben."""
+    scores, opponents = scores_and_history(["a", "b", "c"], [bye_match(1, "c")])
+
+    assert scores["c"] == 1.0
+    assert opponents["c"] == set()
+
+
+# ---------------------------------------------------------------- Paarung
+
+def test_everyone_is_paired_exactly_once():
+    pairs, bye = swiss_pairings(["a", "b", "c", "d"], [], seed=1)
+
+    assert bye is None
+    assert len(pairs) == 2
+    assert sorted(participant for pair in pairs for participant in pair) == ["a", "b", "c", "d"]
+
+
+def test_an_odd_field_gives_exactly_one_bye():
+    pairs, bye = swiss_pairings(["a", "b", "c", "d", "e"], [], seed=1)
+
+    assert bye is not None
+    assert len(pairs) == 2
+    paired = [participant for pair in pairs for participant in pair]
+    assert bye not in paired
+    assert len(set(paired)) == 4
+
+
+def test_a_rematch_is_avoided_while_an_alternative_exists():
+    played = [decided_match(1, "a", "b"), decided_match(1, "c", "d")]
+
+    pairs, _ = swiss_pairings(["a", "b", "c", "d"], played, seed=7)
+
+    assert {"a", "b"} not in [set(pair) for pair in pairs]
+    assert {"c", "d"} not in [set(pair) for pair in pairs]
+
+
+def test_a_rematch_is_allowed_when_nothing_else_is_left():
+    """Gar nicht zu paaren waere schlimmer als eine Wiederholung."""
+    played = [decided_match(1, "a", "b")]
+
+    pairs, bye = swiss_pairings(["a", "b"], played, seed=1)
+
+    assert bye is None
+    assert [set(pair) for pair in pairs] == [{"a", "b"}]
+
+
+def test_players_with_similar_scores_meet():
+    played = [decided_match(1, "a", "b"), decided_match(1, "c", "d")]
+
+    pairs, _ = swiss_pairings(["a", "b", "c", "d"], played, seed=3)
+
+    winners = {"a", "c"}
+    assert any(set(pair) == winners for pair in pairs), "Die beiden Sieger sollten aufeinandertreffen"
+
+
+def test_a_field_too_small_to_pair_yields_nothing():
+    assert swiss_pairings([], [], seed=1) == ([], None)
+    assert swiss_pairings(["allein"], [], seed=1) == ([], "allein")
+
+
+def test_the_pairing_is_reproducible_with_the_same_seed():
+    first, _ = swiss_pairings(["a", "b", "c", "d"], [], seed=42)
+    second, _ = swiss_pairings(["a", "b", "c", "d"], [], seed=42)
+
+    assert first == second
+
+
+def test_nobody_sits_out_twice_while_someone_else_has_not():
+    """Zweimal Freilos waere ein Vorteil, den niemand verdient hat."""
+    played = [bye_match(1, "e"), decided_match(1, "a", "b"), decided_match(1, "c", "d")]
+
+    _pairs, bye = swiss_pairings(["a", "b", "c", "d", "e"], played, seed=5)
+
+    assert bye != "e"
+
+
+def test_a_second_bye_is_allowed_once_everyone_has_had_one():
+    played = [bye_match(1, "a"), bye_match(2, "b"), bye_match(3, "c")]
+
+    _pairs, bye = swiss_pairings(["a", "b", "c"], played, seed=5)
+
+    assert bye in {"a", "b", "c"}
+
+
+def test_who_already_sat_out_is_remembered():
+    assert bye_history([bye_match(1, "a"), decided_match(1, "b", "c")]) == {"a"}
+
+
+# ---------------------------------------------------------------- Rundenwechsel
+
+def test_the_next_round_follows_the_highest_one_played():
+    assert next_round_number([]) == 1
+    assert next_round_number([decided_match(1, "a", "b"), decided_match(2, "a", "c")]) == 3
+
+
+def test_a_new_round_waits_for_the_current_one():
+    pending = {"round": 2, "status": "ready", "slots": [], "results": []}
+
+    assert round_is_complete([decided_match(1, "a", "b")], 1) is True
+    assert round_is_complete([decided_match(2, "a", "b"), pending], 2) is False
+    assert round_is_complete([], 1) is True
+
+
+def test_an_abandoned_match_does_not_block_the_next_round():
+    """Ein abgesagtes Match wird nie entschieden - es darf das Turnier nicht anhalten."""
+    cancelled = {"round": 1, "status": "cancelled", "slots": [], "results": []}
+
+    assert open_matches([decided_match(1, "a", "b"), cancelled], 1) == []
+    assert round_is_complete([cancelled], 1) is True
+
+
+# ---------------------------------------------------------------- Runde als Dokumente
+
+TOURNAMENT = {"id": "t1", "format": "swiss", "match_duration_minutes": 20}
+STAGE = {"id": "s1", "number": 1, "settings": {}}
+
+
+def registrations(*ids):
+    return [{"id": item, "user_id": f"user-{item}"} for item in ids]
+
+
+def test_a_generated_round_is_ready_to_be_played():
+    documents = swiss_round_documents(
+        TOURNAMENT, STAGE, registrations("a", "b", "c", "d"), [], round_number=2)
+
+    assert len(documents) == 2
+    for document in documents:
+        assert document["round"] == 2
+        assert document["stage_id"] == "s1"
+        assert document["tournament_id"] == "t1"
+        assert document["status"] == "ready"
+        assert len(document["slots"]) == 2
+        assert all(slot["status"] == "filled" for slot in document["slots"])
+
+
+def test_match_keys_within_a_round_stay_unique():
+    documents = swiss_round_documents(
+        TOURNAMENT, STAGE, registrations("a", "b", "c", "d", "e", "f"), [], round_number=1)
+
+    keys = [document["match_key"] for document in documents]
+    assert len(keys) == len(set(keys))
+
+
+def test_a_bye_is_written_as_a_decided_match():
+    """Nur so bekommt der Freilos-Punkt ueberhaupt einen Ort, an dem er steht."""
+    documents = swiss_round_documents(
+        TOURNAMENT, STAGE, registrations("a", "b", "c"), [], round_number=1)
+
+    byes = [document for document in documents if document["status"] == "completed"]
+    assert len(byes) == 1
+    assert byes[0]["results"][0]["rank"] == 1
+    assert byes[0]["results"][0]["note"]
+
+
+def test_a_field_of_one_produces_no_playable_match():
+    assert swiss_round_documents(TOURNAMENT, STAGE, registrations("a"), [], round_number=1) != []
+    assert swiss_round_documents(TOURNAMENT, STAGE, [], [], round_number=1) == []
+
+
+def test_the_generated_round_carries_the_users_along():
+    """Ohne user_id kann das Match niemandem angezeigt oder gemeldet werden."""
+    documents = swiss_round_documents(
+        TOURNAMENT, STAGE, registrations("a", "b"), [], round_number=1)
+
+    assert {slot["user_id"] for slot in documents[0]["slots"]} == {"user-a", "user-b"}
+
+
+# ---------------------------------------------------------------- Gruppen
+
+def test_the_strongest_seeds_land_in_different_groups():
+    groups = distribute_into_groups(8, 2)
+
+    assert len(groups) == 2
+    assert 1 in groups[0] and 2 in groups[1]
+
+
+def test_every_participant_is_in_exactly_one_group():
+    groups = distribute_into_groups(12, 4)
+    everyone = [seed for group in groups for seed in group]
+
+    assert sorted(everyone) == list(range(1, 13))
+    assert len(groups) == 4
+
+
+def test_group_sizes_stay_balanced():
+    sizes = {len(group) for group in distribute_into_groups(9, 3)}
+
+    assert sizes == {3}
+
+
+def test_a_group_schema_pairs_everyone_within_a_group():
+    """Vier Teilnehmer in einer Gruppe ergeben sechs Begegnungen."""
+    specs = parse_custom_bracket_schema(_auto_groups_schema(4, 1))
+
+    assert len(specs) == 6
+
+
+def test_two_groups_of_four_yield_twelve_matches():
+    specs = parse_custom_bracket_schema(_auto_groups_schema(8, 2))
+
+    assert len(specs) == 12
+    assert len({spec.section for spec in specs}) == 2
+
+
+@pytest.mark.parametrize("slot_count,group_count", [(4, 2), (8, 2), (9, 3), (16, 4), (6, 1)])
+def test_generated_group_schemas_are_valid(slot_count, group_count):
+    specs = parse_custom_bracket_schema(_auto_groups_schema(slot_count, group_count))
+
+    assert specs
+    for spec in specs:
+        assert len(spec.sources) == 2
+
+
+def test_nobody_plays_twice_on_the_same_matchday():
+    """Sonst waere die Gruppenphase nicht ansetzbar."""
+    specs = parse_custom_bracket_schema(_auto_groups_schema(8, 2))
+    rounds = infer_rounds(specs)
+
+    per_matchday: dict[int, list[int]] = {}
+    for spec in specs:
+        seeds = [source["seed"] for source in spec.sources]
+        per_matchday.setdefault(rounds[spec.key], []).extend(seeds)
+
+    for matchday, seeds in per_matchday.items():
+        assert len(seeds) == len(set(seeds)), f"Setzplatz doppelt an Spieltag {matchday}"
+
+
+def test_a_group_of_four_needs_three_matchdays():
+    specs = parse_custom_bracket_schema(_auto_groups_schema(4, 1))
+
+    assert max(infer_rounds(specs).values()) == 3
+
+
+def test_the_group_sections_are_the_ones_the_standings_look_for():
+    """Die klassische Engine schreibt group_A - die Tabelle sucht genau danach."""
+    specs = parse_custom_bracket_schema(_auto_groups_schema(8, 2))
+
+    assert {spec.section for spec in specs} == {"group_A", "group_B"}
+
+
+# ---------------------------------------------------------------- Gruppen-Rueckgabe
+
+def group_match(section, first, second):
+    return {
+        "section": section,
+        "round": 1,
+        "order": 1,
+        "slots": [{"registration_id": first}, {"registration_id": second}],
+    }
+
+
+def test_the_roster_is_read_back_from_the_fixtures():
+    """Die Setzung passiert im Match-Bau; eine zweite Zuteilung koennte abweichen."""
+    groups = groups_from_generated_matches([
+        group_match("group_A", "r1", "r2"),
+        group_match("group_B", "r3", "r4"),
+        group_match("group_A", "r1", "r5"),
+    ])
+
+    assert [group["group_key"] for group in groups] == ["A", "B"]
+    assert groups[0]["participant_ids"] == ["r1", "r2", "r5"]
+    assert groups[0]["name"] == "Gruppe A"
+
+
+def test_matches_outside_a_group_are_ignored():
+    assert groups_from_generated_matches([group_match("WB", "r1", "r2")]) == []
+
+
+# ---------------------------------------------------------------- Tabelle bleibt Tabelle
+
+def snapshot_of(stage_matches):
+    return build_structure_snapshot("t1", stage_matches=stage_matches)
+
+
+def played(section, first, second, *, winner=None, round_number=1):
+    results = []
+    if winner:
+        loser = second if winner == first else first
+        results = [
+            {"registration_id": winner, "rank": 1},
+            {"registration_id": loser, "rank": 2},
+        ]
+    else:
+        results = [
+            {"registration_id": first, "rank": 1},
+            {"registration_id": second, "rank": 1},
+        ]
+    return {
+        "id": f"{section}-{first}-{second}",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "section": section,
+        "round": round_number,
+        "status": "completed",
+        "match_type": "duel",
+        "slots": [
+            {"slot": 1, "registration_id": first},
+            {"slot": 2, "registration_id": second},
+        ],
+        "results": results,
+    }
+
+
+def test_a_swiss_tournament_in_the_graph_keeps_its_buchholz_table():
+    """Die generische Stage-Tabelle waere hier ein Rueckschritt."""
+    rows = standings_for_structure(
+        {"format": "swiss"},
+        snapshot_of([
+            played("swiss", "a", "b", winner="a"),
+            played("swiss", "c", "d", winner="c"),
+            played("swiss", "a", "c", winner="a", round_number=2),
+        ]),
+        registrations("a", "b", "c", "d"),
+    )
+
+    assert [row["registration_id"] for row in rows][0] == "a"
+    assert all("buchholz" in row for row in rows)
+
+
+def test_a_draw_in_the_graph_stays_a_draw():
+    """Im Graph teilen sich beide Rang 1 - das darf kein Sieg werden."""
+    rows = standings_for_structure(
+        {"format": "swiss"},
+        snapshot_of([played("swiss", "a", "b")]),
+        registrations("a", "b"),
+    )
+
+    assert {row["points"] for row in rows} == {0.5}
+    assert all(row["drawn"] == 1 for row in rows)
+
+
+def test_a_bye_shows_up_in_the_swiss_table():
+    rows = standings_for_structure(
+        {"format": "swiss"},
+        snapshot_of([{
+            "id": "m-bye", "tournament_id": "t1", "stage_id": "s1", "section": "swiss",
+            "round": 1, "status": "completed", "match_type": "duel",
+            "slots": [{"slot": 1, "registration_id": "a"}, {"slot": 2, "registration_id": None}],
+            "results": [{"registration_id": "a", "rank": 1}],
+        }]),
+        registrations("a", "b"),
+    )
+
+    assert next(row for row in rows if row["registration_id"] == "a")["points"] == 1
+
+
+def test_a_group_tournament_in_the_graph_keeps_one_table_per_group():
+    rows = standings_for_structure(
+        {"format": "groups"},
+        snapshot_of([
+            played("group_A", "a", "b", winner="a"),
+            played("group_B", "c", "d", winner="c"),
+        ]),
+        registrations("a", "b", "c", "d"),
+        groups=[
+            {"id": "g1", "group_key": "A", "participant_ids": ["a", "b"]},
+            {"id": "g2", "group_key": "B", "participant_ids": ["c", "d"]},
+        ],
+    )
+
+    assert len(rows) == 2
+    assert [entry["group"]["group_key"] for entry in rows] == ["A", "B"]
+    assert rows[0]["standings"][0]["registration_id"] == "a"

--- a/backend/tests/test_swiss_groups_routes_unit.py
+++ b/backend/tests/test_swiss_groups_routes_unit.py
@@ -1,0 +1,315 @@
+"""The Swiss and group generators as the endpoints actually run them.
+
+The pairing rules are pinned next door in ``test_graph_swiss_groups_unit``. What
+is checked here is the step after: that the endpoints write documents the rest of
+the platform can read, that they pick the engine a tournament already lives in
+instead of moving it, and that a second call does not quietly duplicate a round.
+"""
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from routes.tournament_routes import (
+    _competition_engine,
+    _groups_generate_graph,
+    _swiss_next_round_graph,
+)
+from services.competition_read import load_competition_read_model
+from services.competition_standings import standings_for_structure
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, *_args):
+        return self
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class FakeCollection:
+    def __init__(self, rows=()):
+        self.rows = [dict(row) for row in rows]
+
+    def _matches(self, row, query):
+        for key, expected in query.items():
+            value = row.get(key)
+            if isinstance(expected, dict):
+                if "$in" in expected and value not in expected["$in"]:
+                    return False
+                if "$ne" in expected and value == expected["$ne"]:
+                    return False
+            elif value != expected:
+                return False
+        return True
+
+    def find(self, query, _projection=None):
+        return FakeCursor([dict(row) for row in self.rows if self._matches(row, query)])
+
+    async def find_one(self, query, _projection=None):
+        return next((dict(row) for row in self.rows if self._matches(row, query)), None)
+
+    async def count_documents(self, query):
+        return sum(1 for row in self.rows if self._matches(row, query))
+
+    async def distinct(self, field, query=None):
+        return sorted({row.get(field) for row in self.rows if self._matches(row, query or {})})
+
+    async def insert_one(self, document):
+        self.rows.append(dict(document))
+
+    async def insert_many(self, documents):
+        self.rows.extend(dict(document) for document in documents)
+
+    async def delete_many(self, query):
+        self.rows = [row for row in self.rows if not self._matches(row, query)]
+
+    async def update_one(self, query, update):
+        for row in self.rows:
+            if self._matches(row, query):
+                row.update(update.get("$set") or {})
+                return
+
+
+class FakeDb:
+    def __init__(self, **collections):
+        for name in ("tournaments", "tournament_stages", "tournament_registrations",
+                     "tournament_groups", "matches", "matches_v2", "match_reports_v2",
+                     "audit_logs", "competition_write_events"):
+            setattr(self, name, FakeCollection(collections.get(name, ())))
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+def registrations(tid, count):
+    return [
+        {"id": f"reg{index}", "tournament_id": tid, "user_id": f"user{index}",
+         "status": "approved", "seed": index, "display_name": f"Spieler {index}"}
+        for index in range(1, count + 1)
+    ]
+
+
+def swiss_db(participant_count=6, stages=(), matches_v2=()):
+    tournament = {"id": "t1", "format": "swiss", "status": "draft", "match_duration_minutes": 25}
+    return FakeDb(
+        tournaments=[tournament],
+        tournament_registrations=registrations("t1", participant_count),
+        tournament_stages=stages,
+        matches_v2=matches_v2,
+    ), tournament
+
+
+def groups_db(participant_count=8):
+    tournament = {"id": "t1", "format": "groups", "status": "draft",
+                  "max_participants": participant_count, "seeding_mode": "manual"}
+    return FakeDb(
+        tournaments=[tournament],
+        tournament_registrations=registrations("t1", participant_count),
+    ), tournament
+
+
+# ---------------------------------------------------------------- Enginewahl
+
+def test_a_tournament_without_structure_stays_classic():
+    db = FakeDb(tournaments=[{"id": "t1"}])
+
+    assert run(_competition_engine(db, "t1")) == "classic"
+
+
+def test_an_existing_stage_decides_for_the_graph():
+    db = FakeDb(tournament_stages=[{"id": "s1", "tournament_id": "t1"}])
+
+    assert run(_competition_engine(db, "t1")) == "graph"
+
+
+def test_existing_graph_matches_decide_even_without_a_stage():
+    db = FakeDb(matches_v2=[{"id": "m1", "tournament_id": "t1"}])
+
+    assert run(_competition_engine(db, "t1")) == "graph"
+
+
+def test_classic_matches_do_not_pull_a_tournament_into_the_graph():
+    """Ein laufendes Turnier darf nicht den Speicher wechseln."""
+    db = FakeDb(matches=[{"id": "m1", "tournament_id": "t1"}])
+
+    assert run(_competition_engine(db, "t1")) == "classic"
+
+
+# ---------------------------------------------------------------- Schweizer Runden
+
+def test_the_first_round_creates_its_stage_and_pairs_everyone():
+    db, tournament = swiss_db(6)
+
+    response = run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert response["round"] == 1
+    assert response["match_count"] == 3
+    assert len(db.tournament_stages.rows) == 1
+    assert db.tournament_stages.rows[0]["stage_type"] == "swiss"
+    assert all(match["stage_id"] == response["stage_id"] for match in db.matches_v2.rows)
+
+
+def test_the_tournament_goes_live_with_its_first_round():
+    db, tournament = swiss_db(4)
+
+    run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert db.tournaments.rows[0]["status"] == "live"
+
+
+def test_the_write_model_is_pinned_to_the_graph():
+    db, tournament = swiss_db(4)
+
+    run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert db.tournaments.rows[0]["engine_version"] == "competition.graph.v1"
+
+
+def test_an_odd_field_gets_a_bye_match():
+    db, tournament = swiss_db(5)
+
+    response = run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert response["match_count"] == 3
+    byes = [match for match in db.matches_v2.rows if match["status"] == "completed"]
+    assert len(byes) == 1
+
+
+def test_an_open_round_blocks_the_next_one():
+    """Sonst spielt jemand zwei Runden gleichzeitig."""
+    db, tournament = swiss_db(4)
+    run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    with pytest.raises(Exception) as error:
+        run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert "offen" in str(getattr(error.value, "detail", error.value))
+
+
+def test_a_finished_round_opens_the_next_one():
+    db, tournament = swiss_db(4)
+    run(_swiss_next_round_graph(db, tournament, "admin"))
+    for match in db.matches_v2.rows:
+        first, second = [slot["registration_id"] for slot in match["slots"]]
+        match["status"] = "completed"
+        match["results"] = [
+            {"registration_id": first, "rank": 1},
+            {"registration_id": second, "rank": 2},
+        ]
+
+    response = run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert response["round"] == 2
+    assert len([match for match in db.matches_v2.rows if match["round"] == 2]) == 2
+
+
+def test_too_few_participants_are_refused_instead_of_writing_nothing():
+    db, tournament = swiss_db(0)
+
+    with pytest.raises(Exception) as error:
+        run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    assert "Teilnehmer" in str(getattr(error.value, "detail", error.value))
+
+
+def test_the_swiss_round_is_readable_through_the_shared_read_model():
+    """Was hier geschrieben wird, muss die Turnieransicht auch lesen koennen."""
+    db, tournament = swiss_db(4)
+    run(_swiss_next_round_graph(db, tournament, "admin"))
+
+    snapshot = run(load_competition_read_model(db, "t1")).structure_snapshot()
+
+    assert snapshot["source_engines"] == ["stage"]
+    assert snapshot["mixed_source"] is False
+    assert len(snapshot["matches"]) == 2
+
+
+# ---------------------------------------------------------------- Gruppenphase
+
+def test_the_group_stage_writes_fixtures_groups_and_a_stage():
+    db, tournament = groups_db(8)
+
+    response = run(_groups_generate_graph(db, tournament, 2, "admin"))
+
+    assert response["group_count"] == 2
+    assert response["match_count"] == 12
+    assert len(db.tournament_groups.rows) == 2
+    assert len(db.tournament_stages.rows) == 1
+    assert db.tournament_stages.rows[0]["settings"]["group_count"] == 2
+
+
+def test_every_participant_lands_in_exactly_one_group():
+    db, tournament = groups_db(8)
+
+    run(_groups_generate_graph(db, tournament, 2, "admin"))
+
+    everyone = [
+        registration_id
+        for group in db.tournament_groups.rows
+        for registration_id in group["participant_ids"]
+    ]
+    assert sorted(everyone) == sorted(row["id"] for row in db.tournament_registrations.rows)
+
+
+def test_the_strongest_two_seeds_are_kept_apart():
+    db, tournament = groups_db(8)
+
+    run(_groups_generate_graph(db, tournament, 2, "admin"))
+
+    home = {
+        group["group_key"]: group["participant_ids"]
+        for group in db.tournament_groups.rows
+    }
+    assert not any("reg1" in members and "reg2" in members for members in home.values())
+
+
+def test_every_fixture_knows_its_group():
+    """Ohne group_id findet die Gruppentabelle ihre Spiele nur ueber den Namen."""
+    db, tournament = groups_db(8)
+
+    run(_groups_generate_graph(db, tournament, 2, "admin"))
+
+    group_ids = {group["id"] for group in db.tournament_groups.rows}
+    assert all(match.get("group_id") in group_ids for match in db.matches_v2.rows)
+
+
+def test_regenerating_replaces_instead_of_adding():
+    db, tournament = groups_db(8)
+    run(_groups_generate_graph(db, tournament, 2, "admin"))
+
+    run(_groups_generate_graph(db, tournament, 2, "admin"))
+
+    assert len(db.matches_v2.rows) == 12
+    assert len(db.tournament_groups.rows) == 2
+
+
+def test_the_group_table_finds_its_matches_after_generation():
+    db, tournament = groups_db(8)
+    run(_groups_generate_graph(db, tournament, 2, "admin"))
+    for match in db.matches_v2.rows:
+        winner, loser = [slot["registration_id"] for slot in match["slots"]]
+        match["status"] = "completed"
+        match["results"] = [
+            {"registration_id": winner, "rank": 1},
+            {"registration_id": loser, "rank": 2},
+        ]
+
+    snapshot = run(load_competition_read_model(db, "t1")).structure_snapshot()
+    tables = standings_for_structure(
+        tournament,
+        snapshot,
+        db.tournament_registrations.rows,
+        groups=db.tournament_groups.rows,
+    )
+
+    assert [entry["group"]["group_key"] for entry in tables] == ["A", "B"]
+    for entry in tables:
+        assert sum(row["played"] for row in entry["standings"]) == 12

--- a/backend/tests/test_tournament_capability_inventory.py
+++ b/backend/tests/test_tournament_capability_inventory.py
@@ -77,7 +77,14 @@ def test_every_capability_has_a_german_label_and_engines():
 
 # ---------------------------------------------------------------- Bekannte Lücken
 
-EXPECTED_GAPS = {
+EXPECTED_GAPS: set[str] = set()
+
+# Mit Block 3 geschlossen. Die Namen bleiben stehen, weil eine leere Menge nicht
+# zeigt, was erreicht wurde - und weil ein Rueckfall hier auffallen soll.
+CLOSED_GAPS = {
+    "result.report",
+    "result.dispute",
+    "result.forfeit",
     "structure.swiss",
     "structure.groups",
 }
@@ -95,6 +102,16 @@ def test_each_gap_is_classic_only_today(key):
         f"{key} gilt als Lücke, ist aber nicht mehr nur klassisch verfuegbar. "
         "Wenn die Lücke geschlossen wurde: Engines hier und EXPECTED_GAPS anpassen."
     )
+
+
+@pytest.mark.parametrize("key", sorted(CLOSED_GAPS))
+def test_a_closed_gap_stays_available_in_both_engines(key):
+    capability = CAPABILITIES_BY_KEY[key]
+    assert set(capability.engines) == {CLASSIC, GRAPH}, (
+        f"{key} war einmal in beiden Engines verfuegbar und ist es nicht mehr. "
+        "Das waere ein Rueckschritt in der Vereinheitlichung."
+    )
+    assert not capability.is_gap, f"{key} ist wieder als Luecke markiert."
 
 
 # ---------------------------------------------------------------- Der entfernte Zwilling


### PR DESCRIPTION
Schließt die letzte Funktionslücke zwischen den beiden Turnier-Engines. Vorher konnte das Graph-System Turnierbäume, aber weder Schweizer Runden noch Gruppen — deshalb konnte kein Turnier dieser Formate dorthin umziehen.

## Warum zwei unterschiedliche Wege

**Gruppen** stehen im Voraus fest — wer gegen wen spielt, hängt an keinem Ergebnis. Sie passen deshalb in das vorhandene Schema, ohne Generator zur Laufzeit:

- Zuteilung im **Schlangensystem**, damit Setzplatz 1 und 2 nicht in derselben Gruppe landen
- Begegnungen nach dem **Kreisverfahren** auf Spieltage verteilt, damit niemand zweimal am selben Tag spielt
- Sektionen heißen `group_A` — genau das, wonach die Gruppentabelle sucht
- Die Gruppenaufstellung wird aus den erzeugten Spielen zurückgelesen, statt die Setzung ein zweites Mal zu berechnen. So kann die Aufstellung nie von den Begegnungen abweichen.

**Schweizer Runden** lassen sich nicht vorab aufschreiben — Runde 3 hängt an Runde 2. Sie bekommen deshalb einen Generator zur Laufzeit:

- Ähnliche Punktzahlen treffen aufeinander, eine Wiederholung nur, wenn nichts anderes übrig ist
- Ein **Freilos** wird als entschiedenes Match mit einem Teilnehmer geschrieben statt weggelassen. Nur so kommt der Punkt dafür in der Tabelle an — im klassischen System fiel der Ungerade bisher stillschweigend heraus.
- Niemand setzt zweimal aus, solange ein anderer noch gar nicht ausgesetzt hat
- Eine neue Runde startet erst, wenn die laufende entschieden ist; ein abgesagtes Match blockiert dabei nicht

## Die Tabelle richtet sich nach dem Format, nicht nach dem Speicher

Bisher hätte ein Graph-Turnier automatisch die generische Stage-Tabelle bekommen. Ein Schweizer Turnier behält damit Buchholz, ein Gruppenturnier seine Gruppentabellen — unabhängig davon, in welcher Engine die Spiele liegen.

Dabei ist aufgefallen: Ein **Unentschieden wäre im Graph-System als Sieg gezählt** worden, weil sich dort beide Teilnehmer Rang 1 teilen und die Tabelle einfach den ersten Sieger nahm. Ist mitbehoben. Ebenso zählt ein Forfeit jetzt in Gruppen- und Schweizer-Tabellen mit, statt aus der Wertung zu fallen.

## Kein stiller Speicherwechsel

Beide Endpunkte wählen die Engine, in der ein Turnier **bereits liegt** — gelesen an den vorhandenen Dokumenten, nicht am Format. Ein laufendes Turnier wechselt also nicht den Speicher. Das Überführen des Bestands bleibt ein eigener, angekündigter Schritt (Block 5).

Im Formatkatalog bekommt `groups` dadurch einen Stage-Generator (vorher: gar keiner, der Weg über „Struktur aus Format" lief für Gruppen ins Leere). `swiss` bleibt bewusst ohne Schema — die Begründung steht jetzt in der Migrationsnotiz statt nur im Kopf.

## Prüfung

- `EXPECTED_GAPS` im Fähigkeiten-Inventar ist **leer**. Alle fünf Lücken aus Block 3 sind geschlossen; die geschlossenen bleiben als `CLOSED_GAPS` geprüft, damit ein Rückfall auffällt.
- Routenzahl unverändert bei **528** — es kam kein Endpunkt dazu, die vorhandenen können jetzt mehr.
- 643 Tests grün, Coverage 42,71 %
- Neu: 36 Fälle für Paarung, Freilose, Gruppenverteilung und Spieltage sowie 18 Fälle, die beide Endpunkte gegen eine Fake-Datenbank durchspielen — inklusive der Frage, ob das Geschriebene über das gemeinsame Lesemodell auch wieder herauskommt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
