### PR TITLE
Turniere: ein Ergebnisweg statt drei, kein stiller Speicherwechsel (Block 4)

### DIFF
--- a/backend/routes/match_routes.py
+++ b/backend/routes/match_routes.py
@@ -25,15 +25,13 @@ from models import (
     now_utc,
     new_id,
 )
-from bracket_engine import advance_match_winner
 from match_rules import loser_for_winner, match_allows_draw, validate_winner_id
 from services.competition_read import canonical_match_for_source, find_match_source
-from services.match_notifications import notify_match_result_confirmed
 from services.match_overview import operational_match_overviews, own_match_overviews
 from services.match_planning import ensure_station_slot_available, ensure_tournament_accepts_results
+from services.match_results import MatchOutcome, apply_match_result
 from services.match_v2_results import MatchV2ResultError
 from services.mutation_lock import MutationLockBusy, mutation_lock, tournament_write_resource
-from services.station_runtime import release_station_for_match
 from services.rate_limit import enforce_rate_limit
 from services.station_labels import attach_station_info
 from services.user_notifications import create_user_notification
@@ -1039,87 +1037,43 @@ async def update_match(match_id: str, body: MatchUpdate, me: dict = Depends(get_
         m.pop("_id", None)
         m["idempotent_replay"] = True
         return m
-    updates["updated_at"] = now_utc().isoformat()
-    await db.matches.update_one({"id": match_id}, {"$set": updates})
-    m = await db.matches.find_one({"id": match_id})
-    current_result_signature = (
-        m.get("status"),
-        m.get("winner_id"),
-        m.get("score_a"),
-        m.get("score_b"),
+
+    next_result_signature = (
+        final_status,
+        updates.get("winner_id", m.get("winner_id")),
+        updates.get("score_a", m.get("score_a")),
+        updates.get("score_b", m.get("score_b")),
     )
-    if current_result_signature != previous_result_signature:
-        await _audit_match_action(db, "match.result.update", m, me.get("id"), {
+    if next_result_signature == previous_result_signature:
+        # Reine Betriebsdaten - Termin, Station, Notiz. Das ist keine
+        # Ergebnismeldung und läuft deshalb auch nicht über den Ergebniskern.
+        updates["updated_at"] = now_utc().isoformat()
+        await db.matches.update_one({"id": match_id}, {"$set": updates})
+        updated = await db.matches.find_one({"id": match_id}, {"_id": 0})
+        return {**updated, "idempotent_replay": False}
+
+    operational = {
+        key: value for key, value in updates.items()
+        if key not in {"status", "winner_id", "loser_id", "score_a", "score_b"}
+    }
+    outcome = await apply_match_result(
+        db, m, "matches",
+        MatchOutcome(
+            status=final_status,
+            winner_id=next_result_signature[1],
+            score_a=next_result_signature[2],
+            score_b=next_result_signature[3],
+            extra_set=operational,
+        ),
+        actor_id=me.get("id"),
+        audit_action="match.result.update",
+        audit_data={
             "changed_fields": sorted(updates.keys()),
-            "previous": {
-                "status": previous_result_signature[0],
-                "winner_id": previous_result_signature[1],
-                "score_a": previous_result_signature[2],
-                "score_b": previous_result_signature[3],
-            },
-            "current": {
-                "status": current_result_signature[0],
-                "winner_id": current_result_signature[1],
-                "score_a": current_result_signature[2],
-                "score_b": current_result_signature[3],
-            },
-        })
-    # If completed, advance bracket
-    if (
-        m.get("status") == "completed"
-        and m.get("winner_id")
-        and current_result_signature != previous_result_signature
-    ):
-        all_matches = await db.matches.find({"tournament_id": m["tournament_id"]}).to_list(2000)
-        updated_matches = advance_match_winner(m, all_matches)
-        for um in updated_matches:
-            await db.matches.update_one({"id": um["id"]}, {"$set": um})
-        # Badge triggers
-        try:
-            from badges import on_match_completed
-            regs = {r["id"]: r.get("user_id") for r in await db.tournament_registrations.find(
-                {"tournament_id": m["tournament_id"]}, {"_id": 0}).to_list(500)}
-            winner_uid = regs.get(m.get("winner_id"))
-            loser_uid = regs.get(m.get("loser_id"))
-            if winner_uid:
-                await on_match_completed(winner_uid, loser_uid, m["tournament_id"], m["id"])
-        except Exception:
-            pass
-        # Discord trigger: match completed
-        try:
-            from discord_service import send_public_discord
-            regs = {r["id"]: r for r in await db.tournament_registrations.find(
-                {"tournament_id": m["tournament_id"]}, {"_id": 0}).to_list(500)}
-            t = await db.tournaments.find_one({"id": m["tournament_id"]}, {"_id": 0}) or {}
-            a = regs.get(m.get("participant_a_id"), {})
-            b = regs.get(m.get("participant_b_id"), {})
-            w = regs.get(m.get("winner_id"), {})
-            await send_public_discord(
-                t,
-                f"🎮 Match beendet · {t.get('title') or 'Turnier'}",
-                f"**{a.get('display_name') or '?'}** vs **{b.get('display_name') or '?'}**\n"
-                f"Gewinner: **{w.get('display_name') or '?'}** ({m.get('score_a',0)}:{m.get('score_b',0)})",
-                color=0x29B6E8,
-                url=f"/tournaments/{t.get('slug') or t.get('id')}/bracket",
-                fields=[
-                    {"name": "Runde", "value": m.get("round_name") or f"Runde {m.get('round','?')}", "inline": True},
-                ],
-                event_key="match.completed",
-            )
-        except Exception:
-            pass
-        if current_result_signature != previous_result_signature:
-            try:
-                await notify_match_result_confirmed(db, m, "matches")
-            except Exception:
-                pass
-            try:
-                await release_station_for_match(db, m, "matches")
-            except Exception:
-                pass
-    m.pop("_id", None)
-    m["idempotent_replay"] = False
-    return m
+            "previous": dict(zip(("status", "winner_id", "score_a", "score_b"), previous_result_signature)),
+            "current": dict(zip(("status", "winner_id", "score_a", "score_b"), next_result_signature)),
+        },
+    )
+    return {**outcome["match"], "idempotent_replay": outcome["idempotent_replay"]}
 
 
 async def _report_v2(db, match: dict, body: MatchScoreReport, me: dict) -> dict:
@@ -1237,32 +1191,35 @@ async def report_score(match_id: str, body: MatchScoreReport, me: dict = Depends
         "score_b": body.score_b,
     })
     # Check consensus - if 2 reports match, auto-complete
-    m = await db.matches.find_one({"id": match_id})
+    m = await db.matches.find_one({"id": match_id}, {"_id": 0})
     reports = m.get("reports", [])
     resolution = _score_report_resolution(m, reports)
     if resolution:
-        await db.matches.update_one({"id": match_id}, {"$set": resolution})
-        await _audit_match_action(db, "match.result.auto_resolution", m, me.get("id"), {
-            "status": resolution.get("status"),
-            "score_a": resolution.get("score_a"),
-            "score_b": resolution.get("score_b"),
-            "winner_id": resolution.get("winner_id"),
-            "report_count": len(reports),
-        })
-        if resolution.get("status") == "completed":
-            # Advance bracket
-            m = await db.matches.find_one({"id": match_id})
-            all_matches = await db.matches.find({"tournament_id": m["tournament_id"]}).to_list(2000)
-            for um in advance_match_winner(m, all_matches):
-                await db.matches.update_one({"id": um["id"]}, {"$set": um})
-            try:
-                await notify_match_result_confirmed(db, m, "matches")
-            except Exception:
-                pass
-            try:
-                await release_station_for_match(db, m, "matches")
-            except Exception:
-                pass
+        # Derselbe Ergebniskern wie bei der Eintragung durch die Turnierleitung.
+        # Vorher entschied der Weg, ob es Abzeichen und eine Ankuendigung gab -
+        # bei gleichem Ergebnis.
+        await apply_match_result(
+            db, m, "matches",
+            MatchOutcome(
+                status=resolution["status"],
+                winner_id=resolution.get("winner_id"),
+                score_a=resolution.get("score_a"),
+                score_b=resolution.get("score_b"),
+                extra_set={
+                    key: value for key, value in resolution.items()
+                    if key in {"admin_note"}
+                },
+            ),
+            actor_id=me.get("id"),
+            audit_action="match.result.auto_resolution",
+            audit_data={
+                "report_count": len(reports),
+                "status": resolution.get("status"),
+                "winner_id": resolution.get("winner_id"),
+                "score_a": resolution.get("score_a"),
+                "score_b": resolution.get("score_b"),
+            },
+        )
     m = await db.matches.find_one({"id": match_id}, {"_id": 0})
     m["idempotent_replay"] = False
     return m
@@ -1387,33 +1344,24 @@ async def forfeit(match_id: str, body: dict, me: dict = Depends(get_current_user
         return m
     if m.get("status") == "forfeit" and not force:
         raise HTTPException(status_code=409, detail="Forfeit ist bereits gesetzt. Abweichende Korrektur braucht force=true.")
-    await db.matches.update_one({"id": match_id}, {"$set": {
-        "winner_id": winner_id, "loser_id": loser_id,
-        "status": "forfeit",
-        "admin_decision_note": note,
-        "admin_decision_by": me["id"],
-        "admin_decision_at": now_utc().isoformat(),
-        "updated_at": now_utc().isoformat(),
-    }})
-    await _audit_match_action(db, "match.forfeit", m, me.get("id"), {
-        "winner_id": winner_id,
-        "loser_id": loser_id,
-        "note_length": len(note),
-    })
-    m = await db.matches.find_one({"id": match_id})
-    all_matches = await db.matches.find({"tournament_id": m["tournament_id"]}).to_list(2000)
-    for um in advance_match_winner(m, all_matches):
-        await db.matches.update_one({"id": um["id"]}, {"$set": um})
-    try:
-        await notify_match_result_confirmed(db, m, "matches")
-    except Exception:
-        pass
-    try:
-        await release_station_for_match(db, m, "matches")
-    except Exception:
-        pass
-    m.pop("_id", None)
-    m["idempotent_replay"] = False
+    outcome = await apply_match_result(
+        db, m, "matches",
+        MatchOutcome(
+            status="forfeit",
+            winner_id=winner_id,
+            note=note,
+            extra_set={
+                "admin_decision_note": note,
+                "admin_decision_by": me["id"],
+                "admin_decision_at": now_utc().isoformat(),
+            },
+        ),
+        actor_id=me.get("id"),
+        audit_action="match.forfeit",
+        audit_data={"winner_id": winner_id, "loser_id": loser_id, "note_length": len(note)},
+    )
+    m = dict(outcome["match"])
+    m["idempotent_replay"] = outcome["idempotent_replay"]
     # Phase B v4.1: forfeit ⇒ no_show for the loser
     try:
         from badges import trigger_negative_incident

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -37,6 +37,12 @@ from services.custom_bracket import (
     build_matches_v2_from_schema,
     groups_from_generated_matches,
 )
+from services.competition_engine import (
+    CLASSIC,
+    GRAPH,
+    EngineSwitchRequired,
+    decide_rebuild_engine,
+)
 from services.competition_formats import find_format_capability
 from services.graph_swiss import (
     next_round_number,
@@ -2858,10 +2864,27 @@ async def _build_tournament_structure_plan(
     registrations = ordered_plan_registrations(registrations)
 
     stage_defaults = _stage_defaults_for_tournament_format(tournament, body)
-    if stage_defaults:
+    try:
+        decision = decide_rebuild_engine(
+            tournament.get("format"),
+            preferred=GRAPH if stage_defaults else CLASSIC,
+            legacy_matches=read_model.legacy_matches,
+            stage_matches=read_model.stage_matches,
+            allow_switch=bool(getattr(body, "allow_engine_switch", False)),
+        )
+    except EngineSwitchRequired as exc:
+        raise HTTPException(status_code=409, detail={
+            "code": "engine_switch_required",
+            "message": exc.reason,
+            "from_engine": exc.from_engine,
+            "to_engine": exc.to_engine,
+        })
+
+    if decision.is_graph and stage_defaults:
         generator_registrations = registrations
         engine = "graph"
     else:
+        stage_defaults = None
         generator_registrations = (
             _preview_registrations_for_tournament(tournament)
             if body.preview
@@ -3133,6 +3156,7 @@ async def generate(tid: str, preview: bool = False, force: bool = False,
 @router.post("/{tid}/bracket/from-format")
 async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBracketStructurePayload | None = None,
                                                  preview: bool = True, force: bool = False,
+                                                 allow_engine_switch: bool = False,
                                                  me: dict = Depends(get_current_user),
                                                  _mutation_tid: str = Depends(_serialized_tournament_write)):
     """Use the tournament structure as the single source of truth and rebuild the bracket preview."""
@@ -3164,7 +3188,23 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
     v2_match_ids = [match["id"] for match in v2_matches if match.get("id")]
 
     stage_defaults = _stage_defaults_for_tournament_format(tournament, body)
-    if stage_defaults:
+    try:
+        decision = decide_rebuild_engine(
+            tournament.get("format"),
+            preferred=GRAPH if stage_defaults else CLASSIC,
+            legacy_matches=legacy_matches,
+            stage_matches=v2_matches,
+            allow_switch=allow_engine_switch,
+        )
+    except EngineSwitchRequired as exc:
+        raise HTTPException(status_code=409, detail={
+            "code": "engine_switch_required",
+            "message": exc.reason,
+            "from_engine": exc.from_engine,
+            "to_engine": exc.to_engine,
+        })
+
+    if decision.is_graph and stage_defaults:
         stage = {
             **stage_defaults,
             "id": new_id(),
@@ -3219,11 +3259,13 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
                 "preview": preview,
                 "force": force,
                 "match_count": len(matches),
+                "engine_switched": decision.switched,
             },
         )
         return {
             "ok": True,
             "engine": "stages",
+            "engine_switched": decision.switched,
             "stage_id": stage["id"],
             "match_count": len(matches),
             "preview": preview,
@@ -3247,9 +3289,10 @@ async def rebuild_bracket_from_tournament_format(tid: str, body: TournamentBrack
         "tournament.bracket.rebuild_from_format",
         me.get("id"),
         tid,
-        {"format": tournament.get("format"), "preview": preview, "force": force, "match_count": result.get("match_count")},
+        {"format": tournament.get("format"), "preview": preview, "force": force,
+         "match_count": result.get("match_count"), "engine_switched": decision.switched},
     )
-    return {**result, "engine": "legacy"}
+    return {**result, "engine": "legacy", "engine_switched": decision.switched}
 
 
 @router.post("/{tid}/reset-bracket")
@@ -3630,13 +3673,14 @@ async def _competition_engine(db, tid: str) -> str:
     Deliberately reads the existing documents instead of the format: a
     tournament stays in the engine it was built in until it is migrated, so
     neither generator can move a running tournament to the other store behind
-    the organiser's back.
+    the organiser's back. A stage without matches already counts - it is the
+    structure the next round will be written into.
     """
     if await db.tournament_stages.count_documents({"tournament_id": tid}):
-        return "graph"
+        return GRAPH
     if await db.matches_v2.count_documents({"tournament_id": tid}):
-        return "graph"
-    return "classic"
+        return GRAPH
+    return CLASSIC
 
 
 async def _dedicated_stage(db, tournament: dict, stage_type: str, settings: dict,

--- a/backend/services/classic_result_submission.py
+++ b/backend/services/classic_result_submission.py
@@ -1,0 +1,177 @@
+"""The single place a classic match result is persisted.
+
+Counterpart to ``v2_result_submission`` for the ``matches`` store. Before this
+existed, three endpoints each wrote the result, reloaded the match, advanced the
+bracket and fired notifications on their own. They did not agree: a result
+entered by staff awarded badges and announced itself on Discord, while the very
+same result agreed on by both players did neither, and a walkover did neither
+either. The outcome was identical, the consequences were not.
+
+Everything that follows from "this match is decided" now happens here, once.
+"""
+from __future__ import annotations
+
+import logging
+
+from models import new_id, now_utc
+from services.classic_results import (
+    build_classic_result_application,
+    is_classic_result_replay,
+)
+from services.competition_usage import CLASSIC, record_write
+from services.match_notifications import notify_match_result_confirmed
+from services.station_runtime import release_station_for_match
+
+
+logger = logging.getLogger("tls.match_results")
+
+
+async def _record_audit(db, *, audit_action: str, match: dict, actor_id: str | None,
+                        data: dict, advanced_match_ids: list[str]) -> None:
+    await record_write(CLASSIC, audit_action, tournament_id=match.get("tournament_id"))
+    await db.audit_logs.insert_one({
+        "id": new_id(),
+        "action": audit_action,
+        "target_id": match.get("tournament_id") or match.get("id"),
+        "actor_id": actor_id,
+        "data": {
+            "match_id": match.get("id"),
+            "advanced_matches": advanced_match_ids,
+            **data,
+        },
+        "created_at": now_utc().isoformat(),
+    })
+
+
+async def _award_badges(db, match: dict) -> None:
+    from badges import on_match_completed
+
+    registrations = {
+        row["id"]: row.get("user_id")
+        for row in await db.tournament_registrations.find(
+            {"tournament_id": match["tournament_id"]}, {"_id": 0}).to_list(500)
+    }
+    winner_user = registrations.get(match.get("winner_id"))
+    if winner_user:
+        await on_match_completed(
+            winner_user,
+            registrations.get(match.get("loser_id")),
+            match["tournament_id"],
+            match["id"],
+        )
+
+
+async def _announce(db, match: dict) -> None:
+    from discord_service import send_public_discord
+
+    registrations = {
+        row["id"]: row
+        for row in await db.tournament_registrations.find(
+            {"tournament_id": match["tournament_id"]}, {"_id": 0}).to_list(500)
+    }
+    tournament = await db.tournaments.find_one({"id": match["tournament_id"]}, {"_id": 0}) or {}
+    first = registrations.get(match.get("participant_a_id"), {})
+    second = registrations.get(match.get("participant_b_id"), {})
+    winner = registrations.get(match.get("winner_id"), {})
+    walkover = match.get("status") == "forfeit"
+    score = f"({match.get('score_a', 0)}:{match.get('score_b', 0)})"
+    await send_public_discord(
+        tournament,
+        f"🎮 Match beendet · {tournament.get('title') or 'Turnier'}",
+        f"**{first.get('display_name') or '?'}** vs **{second.get('display_name') or '?'}**\n"
+        f"Gewinner: **{winner.get('display_name') or '?'}** "
+        f"{'(kampflos)' if walkover else score}",
+        color=0x29B6E8,
+        url=f"/tournaments/{tournament.get('slug') or tournament.get('id')}/bracket",
+        fields=[{
+            "name": "Runde",
+            "value": match.get("round_name") or f"Runde {match.get('round', '?')}",
+            "inline": True,
+        }],
+        event_key="match.completed",
+    )
+
+
+async def _finish_result_side_effects(db, match: dict) -> None:
+    """Everything that follows a decided match, in one place and never fatal.
+
+    A failing announcement must not undo a result that is already written, so
+    each step is isolated - but it is logged rather than swallowed silently,
+    because a permanently broken notification should be visible somewhere.
+    """
+    for label, action in (
+        ("notification", notify_match_result_confirmed(db, match, "matches")),
+        ("station release", release_station_for_match(db, match, "matches")),
+        ("badges", _award_badges(db, match)),
+        ("announcement", _announce(db, match)),
+    ):
+        try:
+            await action
+        except Exception as exc:
+            logger.warning(
+                "Classic result %s failed for match=%s type=%s",
+                label, match.get("id"), type(exc).__name__,
+            )
+
+
+async def submit_classic_result(
+    db,
+    match: dict,
+    *,
+    status: str | None,
+    winner_id: str | None,
+    score_a: int | None = None,
+    score_b: int | None = None,
+    actor_id: str | None,
+    audit_action: str,
+    note: str | None = None,
+    extra_set: dict | None = None,
+    audit_data: dict | None = None,
+) -> dict:
+    """Persist one classic result while the caller owns the write lease."""
+    match_id = match["id"]
+    if is_classic_result_replay(
+        match, status=status, winner_id=winner_id,
+        score_a=score_a, score_b=score_b, note=note,
+    ):
+        stored = await db.matches.find_one({"id": match_id}, {"_id": 0}) or match
+        return {"ok": True, "match": stored, "advanced_match_ids": [], "idempotent_replay": True}
+
+    tournament_matches = await db.matches.find(
+        {"tournament_id": match["tournament_id"]}, {"_id": 0}).to_list(2000)
+    application = build_classic_result_application(
+        match,
+        tournament_matches,
+        status=status,
+        winner_id=winner_id,
+        score_a=score_a,
+        score_b=score_b,
+        now_iso=now_utc().isoformat(),
+        extra_set=extra_set,
+    )
+    advanced_match_ids = list(application["target_sets"])
+
+    # Erst die Folgematches, dann das Quellmatch - so führt ein Abbruch
+    # dazwischen zu einer Wiederholung und nicht zu einem Match, das als
+    # entschieden gilt, ohne jemanden weitergeschickt zu haben.
+    for target_id, update in application["target_sets"].items():
+        await db.matches.update_one({"id": target_id}, {"$set": update})
+    await db.matches.update_one({"id": match_id}, {"$set": application["match_set"]})
+
+    updated = await db.matches.find_one({"id": match_id}, {"_id": 0}) or match
+    await _record_audit(
+        db,
+        audit_action=audit_action,
+        match=updated,
+        actor_id=actor_id,
+        data=audit_data or {},
+        advanced_match_ids=advanced_match_ids,
+    )
+    if application["decided"]:
+        await _finish_result_side_effects(db, updated)
+    return {
+        "ok": True,
+        "match": updated,
+        "advanced_match_ids": advanced_match_ids,
+        "idempotent_replay": False,
+    }

--- a/backend/services/classic_results.py
+++ b/backend/services/classic_results.py
@@ -1,0 +1,195 @@
+"""Result application for classic duel matches.
+
+The graph engine has had exactly one place that decides what a result changes
+(``build_v2_result_application``). The classic engine had none - the same
+sequence of "write the result, look up the follow-up match, move the winner
+there" was written out three times, in the staff entry, in the player report and
+in the walkover. Three copies of a rule are three chances for them to drift, and
+they had already drifted: only one of them awarded badges or announced anything.
+
+This module is the missing counterpart. It decides, without touching the
+database, what one result changes - and returns it in the same shape the graph
+engine returns, so the layer above can stop caring which engine it is talking to.
+"""
+from __future__ import annotations
+
+from bracket_engine import advance_match_winner
+from match_rules import match_allows_draw, participant_ids
+from services.match_result_errors import MatchResultError
+
+
+TERMINAL_STATUSES = {"completed", "forfeit"}
+RESULT_FIELDS = ("status", "winner_id", "score_a", "score_b")
+
+
+def result_signature(match: dict) -> tuple:
+    """The part of a match that says how it ended."""
+    return tuple(match.get(field) for field in RESULT_FIELDS)
+
+
+def duel_sides(match: dict) -> tuple[str | None, str | None]:
+    """The two sides of a duel, whichever shape the match is stored in.
+
+    The classic store names them in two fixed fields, the graph store lists them
+    as slots. A translator that only understood one of the two would be no
+    translator at all.
+    """
+    first, second = match.get("participant_a_id"), match.get("participant_b_id")
+    if first or second:
+        return first, second
+    filled = [
+        slot.get("registration_id")
+        for slot in match.get("slots") or []
+        if slot.get("registration_id")
+    ]
+    return (
+        filled[0] if filled else None,
+        filled[1] if len(filled) > 1 else None,
+    )
+
+
+def loser_for(match: dict, winner_id: str | None) -> str | None:
+    if not winner_id:
+        return None
+    first, second = duel_sides(match)
+    if winner_id == first:
+        return second
+    if winner_id == second:
+        return first
+    return None
+
+
+def ranking_from_duel(match: dict, winner_id: str | None,
+                      score_a: int | None = None, score_b: int | None = None) -> list[dict]:
+    """Express a duel outcome as the ranking the graph engine speaks.
+
+    A duel is a ranking of two - that is the whole reason the two engines can be
+    merged at all. Without a winner both sides share rank 1, which is exactly how
+    the graph engine records a draw.
+    """
+    first, second = duel_sides(match)
+    if len(match.get("slots") or []) > 2:
+        raise MatchResultError(
+            "Für ein Match mit mehr als zwei Teilnehmern wird eine Platzierungsliste "
+            "gemeldet, kein Sieger."
+        )
+    if winner_id and winner_id not in {first, second}:
+        # Ohne diese Pruefung wuerde ein fremder Sieger hier lautlos verschwinden
+        # und die Rangliste den ersten Teilnehmer zum Gewinner machen.
+        raise MatchResultError("Gewinner ist kein Teilnehmer dieses Matches")
+    scores = {first: score_a, second: score_b}
+    entries = [
+        {"registration_id": item, "score": scores.get(item)}
+        for item in (first, second) if item
+    ]
+    for entry in entries:
+        if not winner_id:
+            entry["rank"] = 1
+        else:
+            entry["rank"] = 1 if entry["registration_id"] == winner_id else 2
+    return sorted(entries, key=lambda entry: entry["rank"])
+
+
+def duel_from_ranking(match: dict, results: list[dict]) -> dict:
+    """Read a duel outcome back out of a ranking.
+
+    The inverse of :func:`ranking_from_duel`, and the reason a comparison test
+    can show that both engines decide the same thing from the same input.
+    """
+    by_registration = {
+        entry.get("registration_id"): entry
+        for entry in results or []
+        if entry.get("registration_id")
+    }
+    first, second = duel_sides(match)
+    ranks = {item: (by_registration.get(item) or {}).get("rank") for item in (first, second)}
+    ranked = [item for item in (first, second) if ranks.get(item) is not None]
+    winner = None
+    if len(ranked) == 2 and ranks[first] != ranks[second]:
+        winner = first if ranks[first] < ranks[second] else second
+    elif len(ranked) == 1:
+        winner = ranked[0]
+    return {
+        "winner_id": winner,
+        "loser_id": loser_for(match, winner),
+        "score_a": (by_registration.get(first) or {}).get("score"),
+        "score_b": (by_registration.get(second) or {}).get("score"),
+    }
+
+
+def validate_outcome(match: dict, status: str | None, winner_id: str | None) -> None:
+    """Refuse an outcome the bracket cannot carry.
+
+    Both checks protect the advancement: a winner who never played this match
+    would be moved into the next round, and a decided knockout match without a
+    winner would leave the follow-up slot empty forever.
+    """
+    if winner_id and winner_id not in participant_ids(match):
+        raise MatchResultError("Gewinner ist kein Teilnehmer dieses Matches")
+    if status == "completed" and not winner_id and not match_allows_draw(match):
+        raise MatchResultError("Dieses Match braucht einen Gewinner")
+
+
+def is_classic_result_replay(match: dict, *, status: str | None, winner_id: str | None,
+                             score_a: int | None, score_b: int | None,
+                             note: str | None = None) -> bool:
+    """Whether the match already says exactly this.
+
+    An exact retry must not advance anyone a second time, write another audit
+    entry or send the announcement again - the same promise the graph engine
+    makes for its own replays.
+    """
+    if match.get("status") not in TERMINAL_STATUSES:
+        return False
+    if note is not None and (match.get("admin_decision_note") or None) != (note or None):
+        return False
+    return result_signature(match) == (status, winner_id, score_a, score_b)
+
+
+def build_classic_result_application(
+    match: dict,
+    tournament_matches: list[dict],
+    *,
+    status: str | None,
+    winner_id: str | None,
+    score_a: int | None = None,
+    score_b: int | None = None,
+    now_iso: str,
+    extra_set: dict | None = None,
+) -> dict:
+    """Decide what this result changes, without writing any of it.
+
+    Mirrors ``build_v2_result_application``: ``match_set`` is what the match
+    itself becomes, ``target_sets`` is what the follow-up matches become. Only a
+    decided match moves anyone onward - an entry that merely schedules or
+    disputes a match leaves the bracket untouched.
+    """
+    validate_outcome(match, status, winner_id)
+
+    match_set: dict = dict(extra_set or {})
+    # Ein nicht angegebener Punktstand heisst "unveraendert", nicht "geloescht" -
+    # sonst wuerde ein Einspruch die bereits gemeldeten Punkte wegwischen.
+    for key, value in (("score_a", score_a), ("score_b", score_b)):
+        if value is not None:
+            match_set[key] = value
+    if status:
+        match_set["status"] = status
+    match_set["winner_id"] = winner_id
+    match_set["loser_id"] = loser_for(match, winner_id)
+    match_set["updated_at"] = now_iso
+
+    decided = status in TERMINAL_STATUSES and bool(winner_id)
+    target_sets: dict[str, dict] = {}
+    if decided:
+        decided_match = {**match, **match_set}
+        for target in advance_match_winner(decided_match, tournament_matches):
+            target_sets[target["id"]] = {
+                key: value for key, value in target.items() if key != "_id"
+            }
+
+    return {
+        "match_set": match_set,
+        "target_sets": target_sets,
+        "decided": decided,
+        "results": ranking_from_duel(match, winner_id, score_a, score_b) if decided else [],
+    }

--- a/backend/services/competition_capabilities.py
+++ b/backend/services/competition_capabilities.py
@@ -90,7 +90,9 @@ CAPABILITIES: tuple[Capability, ...] = (
        ["POST /api/tournaments/{tid}/generate-bracket"], [CLASSIC]),
     _c("structure.from_format", "Struktur aus Format aufbauen",
        ["POST /api/tournaments/{tid}/bracket/from-format"], [CLASSIC, GRAPH],
-       note="Wählt je Format die Engine - und wechselt dabei bei Single/Double den Speicher."),
+       note="Block 4: baut im Speicher neu auf, in dem das Turnier bereits liegt. Ein Wechsel "
+            "würde alle Match-IDs ersetzen und wird deshalb abgelehnt, bis er ausdrücklich "
+            "bestätigt wird (allow_engine_switch)."),
     _c("structure.reset", "Struktur zurücksetzen",
        ["POST /api/tournaments/{tid}/reset-bracket"], [CLASSIC, GRAPH]),
     _c("structure.plan_apply", "Struktur planen und anwenden",

--- a/backend/services/competition_engine.py
+++ b/backend/services/competition_engine.py
@@ -1,0 +1,113 @@
+"""Which store a tournament writes into, and when that may change.
+
+Rebuilding a bracket used to be able to move a tournament from one engine to the
+other without anyone asking for it: a single-elimination tournament started in
+the classic store, and the first rebuild deleted those matches and recreated them
+as graph matches. Every match id changed with them, and with the ids went the
+links, the reports and the chat that pointed at them.
+
+The rule here is that the tournament decides, not the format. A tournament that
+already has real matches keeps its store. Only when the holding store genuinely
+cannot rebuild the format does a move become necessary - and then it has to be
+asked for, because it is a migration and not a redraw.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from services.competition_formats import find_format_capability
+
+
+CLASSIC = "classic"
+GRAPH = "graph"
+
+# Was der klassische Generator aus dem Format heraus neu bauen kann. Alles
+# andere entsteht dort über eigene Endpunkte und nicht über den Neuaufbau.
+CLASSIC_REBUILDABLE_FORMATS = frozenset({"single_elim", "double_elim", "round_robin", "league"})
+
+
+class EngineSwitchRequired(Exception):
+    """A rebuild would move the tournament to the other store."""
+
+    def __init__(self, from_engine: str, to_engine: str, reason: str):
+        super().__init__(reason)
+        self.from_engine = from_engine
+        self.to_engine = to_engine
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class EngineDecision:
+    engine: str
+    switched: bool
+    pinned: str | None
+
+    @property
+    def is_graph(self) -> bool:
+        return self.engine == GRAPH
+
+
+def _has_real(matches) -> bool:
+    return any(not match.get("is_preview") for match in matches or [])
+
+
+def engine_of_record(legacy_matches=(), stage_matches=()) -> str | None:
+    """The store holding this tournament's real matches, if it has any.
+
+    Draft previews deliberately do not count. They carry no result and no
+    history, so redrawing them in the other engine costs nothing - unlike a
+    played match, whose id other records point at.
+    """
+    if _has_real(legacy_matches):
+        return CLASSIC
+    if _has_real(stage_matches):
+        return GRAPH
+    return None
+
+
+def preferred_engine(format_key: str | None, *, stage_generator_available: bool | None = None) -> str:
+    """The store this format would choose for a tournament that has none yet."""
+    if stage_generator_available is None:
+        capability = find_format_capability(format_key)
+        stage_generator_available = bool(capability and capability.stage_generator_available)
+    return GRAPH if stage_generator_available else CLASSIC
+
+
+def classic_can_rebuild(format_key: str | None) -> bool:
+    return (format_key or "single_elim") in CLASSIC_REBUILDABLE_FORMATS
+
+
+def decide_rebuild_engine(
+    format_key: str | None,
+    *,
+    preferred: str,
+    legacy_matches=(),
+    stage_matches=(),
+    allow_switch: bool = False,
+) -> EngineDecision:
+    """Pick the store a rebuild writes into.
+
+    Raises :class:`EngineSwitchRequired` instead of moving a tournament that has
+    already been played - the caller has to say yes to that explicitly, because
+    it replaces every match id the tournament ever handed out.
+    """
+    pinned = engine_of_record(legacy_matches, stage_matches)
+    if pinned is None or pinned == preferred:
+        return EngineDecision(engine=pinned or preferred, switched=False, pinned=pinned)
+
+    if pinned == CLASSIC and classic_can_rebuild(format_key):
+        # Der haeufige Fall: Einzel- und Doppelausscheidung. Der klassische
+        # Generator kann das Format, also bleibt alles, wo es ist.
+        return EngineDecision(engine=CLASSIC, switched=False, pinned=pinned)
+
+    if not allow_switch:
+        raise EngineSwitchRequired(
+            pinned,
+            preferred,
+            "Dieses Turnier liegt im "
+            f"{'klassischen Speicher' if pinned == CLASSIC else 'Graph-Speicher'}"
+            " und hat bereits echte Spiele. Ein Neuaufbau würde es in den anderen "
+            "Speicher verschieben und dabei alle Match-IDs ersetzen. Das ist eine "
+            "Migration und muss ausdrücklich bestätigt werden.",
+        )
+    return EngineDecision(engine=preferred, switched=True, pinned=pinned)

--- a/backend/services/match_result_errors.py
+++ b/backend/services/match_result_errors.py
@@ -1,0 +1,15 @@
+"""The one error type both result engines raise.
+
+Two engines used to mean two error types, and a caller that wanted to handle
+"the result was rejected" had to know which one it was talking to. Since the
+write paths are being merged, the failure vocabulary is merged with them.
+"""
+from __future__ import annotations
+
+
+class MatchResultError(ValueError):
+    """A result was refused. ``status_code`` is what the caller should answer."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code

--- a/backend/services/match_results.py
+++ b/backend/services/match_results.py
@@ -1,0 +1,108 @@
+"""One entry point for writing a match result, whichever store holds it.
+
+Until now every endpoint that wrote a result had to know which engine it was
+talking to, and say so in its own words: the classic store wants a winner and
+two scores, the graph store wants a ranking. That knowledge was copied into
+every caller, which is why the two sides kept drifting apart.
+
+The knowledge lives here now. A caller states what happened - as a winner, as a
+ranking, or as both - and this module translates it into whatever the holding
+store needs. A duel is a ranking of two, so the translation is total in both
+directions; that is also what lets a test prove both engines decide the same
+thing from the same input, instead of it being asserted in a comment.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from services.classic_result_submission import submit_classic_result
+from services.classic_results import duel_from_ranking, ranking_from_duel
+from services.match_result_errors import MatchResultError
+from services.v2_result_submission import submit_v2_result
+
+
+CLASSIC_COLLECTION = "matches"
+GRAPH_COLLECTION = "matches_v2"
+
+
+@dataclass(frozen=True)
+class MatchOutcome:
+    """What happened in a match, in whichever way the caller knows it.
+
+    ``results`` is the canonical form - a ranking, one entry per participant.
+    ``winner_id`` with the two scores is the duel shorthand. Giving either is
+    enough; the missing one is derived from the other.
+    """
+
+    status: str = "completed"
+    results: list[dict] | None = None
+    winner_id: str | None = None
+    score_a: int | None = None
+    score_b: int | None = None
+    note: str | None = None
+    proof_url: str | None = None
+    extra_set: dict = field(default_factory=dict)
+
+
+def as_ranking(match: dict, outcome: MatchOutcome) -> list[dict]:
+    """The outcome as a ranking, deriving it from the duel form if needed."""
+    if outcome.results:
+        return outcome.results
+    return ranking_from_duel(match, outcome.winner_id, outcome.score_a, outcome.score_b)
+
+
+def as_duel(match: dict, outcome: MatchOutcome) -> dict:
+    """The outcome as winner and scores, deriving it from a ranking if needed."""
+    if outcome.results and not outcome.winner_id:
+        return duel_from_ranking(match, outcome.results)
+    return {
+        "winner_id": outcome.winner_id,
+        "score_a": outcome.score_a,
+        "score_b": outcome.score_b,
+    }
+
+
+async def apply_match_result(
+    db,
+    match: dict,
+    collection: str,
+    outcome: MatchOutcome,
+    *,
+    actor_id: str | None,
+    audit_action: str,
+    force: bool = False,
+    audit_data: dict | None = None,
+) -> dict:
+    """Write one result into whichever store holds the match.
+
+    Both branches return the same shape, so a caller never has to unpack two
+    different answers: the stored match, which follow-up matches changed, and
+    whether this call was an exact repeat of one already applied.
+    """
+    if collection == GRAPH_COLLECTION:
+        return await submit_v2_result(
+            db,
+            match,
+            as_ranking(match, outcome),
+            actor_id=actor_id,
+            proof_url=outcome.proof_url,
+            note=outcome.note,
+            force=force,
+            audit_action=audit_action,
+        )
+    if collection == CLASSIC_COLLECTION:
+        duel = as_duel(match, outcome)
+        return await submit_classic_result(
+            db,
+            match,
+            status=outcome.status,
+            winner_id=duel["winner_id"],
+            score_a=duel["score_a"],
+            score_b=duel["score_b"],
+            actor_id=actor_id,
+            audit_action=audit_action,
+            note=outcome.note,
+            extra_set=outcome.extra_set or None,
+            audit_data=audit_data,
+        )
+    raise MatchResultError(f"Unbekannter Match-Speicher: {collection}")

--- a/backend/services/match_v2_results.py
+++ b/backend/services/match_v2_results.py
@@ -5,11 +5,12 @@ import random
 from typing import Any
 from collections import defaultdict
 
+from services.match_result_errors import MatchResultError
 
-class MatchV2ResultError(ValueError):
-    def __init__(self, message: str, status_code: int = 400):
-        super().__init__(message)
-        self.status_code = status_code
+# Derselbe Fehler, unter dem Namen, unter dem ihn der Graph-Zweig eingeführt hat.
+# Beide Engines werfen jetzt dieselbe Klasse, damit ein Aufrufer nicht wissen
+# muss, welcher Speicher gerade abgelehnt hat.
+MatchV2ResultError = MatchResultError
 
 
 LOCKED_DOWNSTREAM_STATUSES = {"in_progress", "waiting_result", "disputed", "completed", "forfeit"}

--- a/backend/tests/test_competition_engine_unit.py
+++ b/backend/tests/test_competition_engine_unit.py
@@ -1,0 +1,146 @@
+"""Which store a rebuild writes into.
+
+A single-elimination tournament used to start in the classic store, and the
+first rebuild deleted those matches and recreated them as graph matches. Every
+match id changed with them - and the reports, links and chat that pointed at
+those ids pointed at nothing afterwards. Nobody asked for that; it followed from
+the format table alone.
+
+These tests pin the rule that replaces it: the tournament decides, not the
+format. A move is still possible, but it has to be asked for.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.competition_engine import (
+    CLASSIC,
+    GRAPH,
+    EngineSwitchRequired,
+    classic_can_rebuild,
+    decide_rebuild_engine,
+    engine_of_record,
+    preferred_engine,
+)
+
+
+def played(**overrides):
+    return {"id": "m1", "is_preview": False, **overrides}
+
+
+def draft(**overrides):
+    return {"id": "m1", "is_preview": True, **overrides}
+
+
+# ---------------------------------------------------------------- Wo liegt es
+
+def test_a_tournament_without_matches_belongs_nowhere_yet():
+    assert engine_of_record([], []) is None
+
+
+def test_real_matches_decide_where_a_tournament_lives():
+    assert engine_of_record([played()], []) == CLASSIC
+    assert engine_of_record([], [played()]) == GRAPH
+
+
+def test_a_draft_bracket_does_not_pin_anything():
+    """Ein Entwurf hat keine Ergebnisse - ihn neu zu zeichnen kostet nichts."""
+    assert engine_of_record([draft()], []) is None
+    assert engine_of_record([], [draft()]) is None
+
+
+def test_the_classic_store_wins_when_both_hold_matches():
+    """Ein Mischzustand ist ein Altlastfall; der aeltere Speicher bleibt maßgeblich."""
+    assert engine_of_record([played()], [played()]) == CLASSIC
+
+
+# ---------------------------------------------------------------- Enginewahl
+
+def test_an_empty_tournament_follows_its_format():
+    decision = decide_rebuild_engine("ffa", preferred=GRAPH)
+
+    assert decision.engine == GRAPH
+    assert decision.switched is False
+    assert decision.pinned is None
+
+
+def test_a_played_tournament_keeps_its_store_even_if_the_format_prefers_the_other():
+    """Der Kern von Block 4: Einzelausscheidung wandert nicht mehr beim Neuaufbau."""
+    decision = decide_rebuild_engine(
+        "single_elim", preferred=GRAPH, legacy_matches=[played()])
+
+    assert decision.engine == CLASSIC
+    assert decision.switched is False
+    assert decision.pinned == CLASSIC
+
+
+@pytest.mark.parametrize("format_key", ["single_elim", "double_elim", "round_robin", "league"])
+def test_every_format_the_classic_generator_knows_stays_put(format_key):
+    decision = decide_rebuild_engine(
+        format_key, preferred=GRAPH, legacy_matches=[played()])
+
+    assert decision.engine == CLASSIC
+
+
+def test_a_draft_bracket_may_still_move_to_the_preferred_store():
+    decision = decide_rebuild_engine(
+        "single_elim", preferred=GRAPH, legacy_matches=[draft()])
+
+    assert decision.engine == GRAPH
+    assert decision.switched is False
+
+
+def test_a_move_that_cannot_be_avoided_is_refused_instead_of_done_quietly():
+    """Gruppen kann der klassische Generator nicht neu bauen - hier waere der
+    Neuaufbau ein Umzug, und der wird nicht nebenbei erledigt."""
+    with pytest.raises(EngineSwitchRequired) as error:
+        decide_rebuild_engine("groups", preferred=GRAPH, legacy_matches=[played()])
+
+    assert error.value.from_engine == CLASSIC
+    assert error.value.to_engine == GRAPH
+    assert "Migration" in error.value.reason
+
+
+def test_a_confirmed_move_is_carried_out_and_reported_as_one():
+    decision = decide_rebuild_engine(
+        "groups", preferred=GRAPH, legacy_matches=[played()], allow_switch=True)
+
+    assert decision.engine == GRAPH
+    assert decision.switched is True
+    assert decision.pinned == CLASSIC
+
+
+def test_a_graph_tournament_is_never_pushed_back_into_the_classic_store():
+    with pytest.raises(EngineSwitchRequired):
+        decide_rebuild_engine("single_elim", preferred=CLASSIC, stage_matches=[played()])
+
+
+def test_the_store_it_already_lives_in_needs_no_confirmation():
+    decision = decide_rebuild_engine(
+        "ffa", preferred=GRAPH, stage_matches=[played()])
+
+    assert decision.engine == GRAPH
+    assert decision.switched is False
+
+
+# ---------------------------------------------------------------- Randfragen
+
+def test_the_format_preference_follows_the_catalog():
+    assert preferred_engine("ffa") == GRAPH
+    assert preferred_engine("league") == CLASSIC
+    assert preferred_engine("groups") == GRAPH
+
+
+def test_an_unknown_format_does_not_crash_the_decision():
+    assert preferred_engine("historisch_unbekannt") == CLASSIC
+    assert classic_can_rebuild("historisch_unbekannt") is False
+
+
+def test_only_the_four_formats_the_legacy_generator_builds_count_as_rebuildable():
+    assert classic_can_rebuild("single_elim") is True
+    assert classic_can_rebuild("swiss") is False
+    assert classic_can_rebuild("groups") is False
+    assert classic_can_rebuild(None) is True

--- a/backend/tests/test_match_idempotency_unit.py
+++ b/backend/tests/test_match_idempotency_unit.py
@@ -10,7 +10,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from models import MatchDispute, MatchScheduleProposalCreate, MatchScoreReport, MatchUpdate, MatchV2Update
 import routes.match_routes as match_routes
-import routes.match_routes as match_routes
+import services.classic_result_submission as classic_submission
+import services.classic_results as classic_results
 
 
 class _MutableMatchCollection:
@@ -80,8 +81,10 @@ def test_forfeit_exact_replay_skips_advancement_and_notifications(monkeypatch):
     monkeypatch.setattr(match_routes, "_ensure_match_tournament_unlocked", AsyncMock())
     monkeypatch.setattr(match_routes, "ensure_tournament_accepts_results", AsyncMock())
     monkeypatch.setattr(match_routes, "_require_result_permission", AsyncMock())
-    monkeypatch.setattr(match_routes, "advance_match_winner", advance)
-    monkeypatch.setattr(match_routes, "notify_match_result_confirmed", notify)
+    # Weiterleitung und Benachrichtigung liegen seit dem gemeinsamen
+    # Ergebniskern nicht mehr im Routenmodul - die Zusage bleibt dieselbe.
+    monkeypatch.setattr(classic_results, "advance_match_winner", advance)
+    monkeypatch.setattr(classic_submission, "notify_match_result_confirmed", notify)
 
     result = asyncio.run(match_routes.forfeit(
         "match-1",
@@ -118,7 +121,7 @@ def test_non_result_update_on_completed_match_does_not_repeat_completion_hooks(m
     monkeypatch.setattr(match_routes, "has_match_result_permission", AsyncMock(return_value=True))
     monkeypatch.setattr(match_routes, "ensure_tournament_accepts_results", AsyncMock())
     monkeypatch.setattr(match_routes, "ensure_station_slot_available", AsyncMock())
-    monkeypatch.setattr(match_routes, "advance_match_winner", advance)
+    monkeypatch.setattr(classic_results, "advance_match_winner", advance)
     monkeypatch.setattr(match_routes, "_audit_match_action", audit)
 
     result = asyncio.run(match_routes.update_match(

--- a/backend/tests/test_match_result_core_unit.py
+++ b/backend/tests/test_match_result_core_unit.py
@@ -1,0 +1,402 @@
+"""The one result core, and the proof that both engines agree.
+
+The plan for this step asks for something specific: that the same input produces
+the same outcome on both write paths - as a comparison, not as a claim. That is
+what the middle section here does. A duel is a ranking of two, so the two ways of
+stating an outcome have to be translatable into each other without loss; if they
+are, the two engines cannot drift apart on who won.
+
+The rest pins the consequences. Three endpoints used to write a classic result
+and they did not agree on what follows from it: staff entry awarded badges and
+announced the match, the very same result agreed on by both players did neither.
+Those tests would have caught that.
+"""
+import asyncio
+import pathlib
+import sys
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import services.classic_result_submission as classic_submission
+from services.classic_results import (
+    build_classic_result_application,
+    duel_from_ranking,
+    is_classic_result_replay,
+    ranking_from_duel,
+)
+from services.match_result_errors import MatchResultError
+from services.match_results import MatchOutcome, apply_match_result, as_duel, as_ranking
+from services.match_v2_results import MatchV2ResultError
+
+
+def duel_match(**overrides):
+    return {
+        "id": "m1",
+        "tournament_id": "t1",
+        "bracket": "wb",
+        "round": 1,
+        "status": "ready",
+        "participant_a_id": "reg-a",
+        "participant_b_id": "reg-b",
+        **overrides,
+    }
+
+
+def graph_match(**overrides):
+    return {
+        "id": "g1",
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "match_key": "A",
+        "status": "ready",
+        "match_type": "duel",
+        "settings": {"min_players": 2, "match_size": 2},
+        "slots": [
+            {"slot": 1, "registration_id": "reg-a", "user_id": "u-a", "status": "filled"},
+            {"slot": 2, "registration_id": "reg-b", "user_id": "u-b", "status": "filled"},
+        ],
+        "results": [],
+        "advancement": [],
+        **overrides,
+    }
+
+
+class FakeCollection:
+    def __init__(self, rows=()):
+        self.rows = [deepcopy(row) for row in rows]
+
+    def _hit(self, row, query):
+        return all(row.get(key) == value for key, value in query.items()
+                   if not isinstance(value, dict))
+
+    def find(self, query, _projection=None):
+        rows = [deepcopy(row) for row in self.rows if self._hit(row, query)]
+        return SimpleNamespace(
+            to_list=AsyncMock(return_value=rows),
+            sort=lambda *_a: SimpleNamespace(to_list=AsyncMock(return_value=rows)),
+        )
+
+    async def find_one(self, query, _projection=None):
+        return next((deepcopy(row) for row in self.rows if self._hit(row, query)), None)
+
+    async def insert_one(self, document):
+        self.rows.append(deepcopy(document))
+
+    async def update_one(self, query, update, upsert=False):
+        for row in self.rows:
+            if self._hit(row, query):
+                row.update(deepcopy(update.get("$set") or {}))
+                return
+        if upsert:
+            self.rows.append({**query, **deepcopy(update.get("$setOnInsert") or {})})
+
+
+def fake_db(**collections):
+    names = ("matches", "matches_v2", "match_reports_v2", "audit_logs",
+             "tournaments", "tournament_registrations")
+    return SimpleNamespace(**{
+        name: FakeCollection(collections.get(name, ())) for name in names
+    })
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+@pytest.fixture(autouse=True)
+def quiet_side_effects(monkeypatch):
+    """Silence what a decided match triggers; the tests that care patch it again."""
+    monkeypatch.setattr(classic_submission, "notify_match_result_confirmed", AsyncMock())
+    monkeypatch.setattr(classic_submission, "release_station_for_match", AsyncMock())
+    monkeypatch.setattr(classic_submission, "_award_badges", AsyncMock())
+    monkeypatch.setattr(classic_submission, "_announce", AsyncMock())
+
+
+# ------------------------------------------------- Duell und Rangliste ineinander
+
+def test_a_duel_becomes_a_ranking_of_two():
+    ranking = ranking_from_duel(duel_match(), "reg-b", score_a=1, score_b=3)
+
+    assert ranking == [
+        {"registration_id": "reg-b", "score": 3, "rank": 1},
+        {"registration_id": "reg-a", "score": 1, "rank": 2},
+    ]
+
+
+def test_a_draw_becomes_a_shared_first_place():
+    """Genau so schreibt die Graph-Engine ein Unentschieden."""
+    ranking = ranking_from_duel(duel_match(), None, score_a=2, score_b=2)
+
+    assert [entry["rank"] for entry in ranking] == [1, 1]
+
+
+def test_the_ranking_reads_back_as_the_same_duel():
+    match = duel_match()
+
+    for winner, score_a, score_b in [("reg-a", 3, 0), ("reg-b", 0, 3), (None, 1, 1)]:
+        ranking = ranking_from_duel(match, winner, score_a, score_b)
+        back = duel_from_ranking(match, ranking)
+
+        assert back["winner_id"] == winner
+        assert (back["score_a"], back["score_b"]) == (score_a, score_b)
+
+
+def test_the_loser_comes_out_of_the_ranking_too():
+    ranking = ranking_from_duel(duel_match(), "reg-a", 2, 0)
+
+    assert duel_from_ranking(duel_match(), ranking)["loser_id"] == "reg-b"
+
+
+# ------------------------------------------------- Der geforderte Vergleich
+
+def graph_db_with(match):
+    return fake_db(matches_v2=[match])
+
+
+def test_both_engines_name_the_same_winner_from_the_same_input():
+    """Das Abnahmekriterium dieses Blocks, als Vergleich statt als Behauptung."""
+    outcome = MatchOutcome(status="completed", winner_id="reg-b", score_a=1, score_b=2)
+
+    classic_db = fake_db(matches=[duel_match()])
+    run(apply_match_result(classic_db, duel_match(), "matches", outcome,
+                           actor_id="admin", audit_action="test"))
+    stored_classic = classic_db.matches.rows[0]
+
+    graph = graph_match()
+    graph_db = graph_db_with(graph)
+    run(apply_match_result(graph_db, graph, "matches_v2", outcome,
+                           actor_id="admin", audit_action="test"))
+    stored_graph = graph_db.matches_v2.rows[0]
+
+    assert stored_classic["winner_id"] == "reg-b"
+    first = next(entry for entry in stored_graph["results"] if entry["rank"] == 1)
+    assert first["registration_id"] == "reg-b"
+    assert stored_classic["status"] == stored_graph["status"] == "completed"
+
+
+def test_a_ranking_decides_the_classic_store_the_same_way():
+    """Auch anders herum: eine Rangliste muss im klassischen Speicher ankommen."""
+    ranking = [
+        {"registration_id": "reg-b", "rank": 1, "score": 5},
+        {"registration_id": "reg-a", "rank": 2, "score": 3},
+    ]
+    db = fake_db(matches=[duel_match()])
+
+    run(apply_match_result(db, duel_match(), "matches",
+                           MatchOutcome(status="completed", results=ranking),
+                           actor_id="admin", audit_action="test"))
+
+    stored = db.matches.rows[0]
+    assert stored["winner_id"] == "reg-b"
+    assert stored["loser_id"] == "reg-a"
+    assert (stored["score_a"], stored["score_b"]) == (3, 5)
+
+
+def test_both_engines_refuse_a_winner_who_did_not_play():
+    outcome = MatchOutcome(status="completed", winner_id="fremder")
+
+    with pytest.raises(MatchResultError):
+        run(apply_match_result(fake_db(matches=[duel_match()]), duel_match(), "matches",
+                               outcome, actor_id="admin", audit_action="test"))
+
+    graph = graph_match()
+    with pytest.raises(MatchV2ResultError):
+        run(apply_match_result(graph_db_with(graph), graph, "matches_v2",
+                               outcome, actor_id="admin", audit_action="test"))
+
+
+def test_an_unknown_store_is_refused_rather_than_guessed():
+    with pytest.raises(MatchResultError):
+        run(apply_match_result(fake_db(), duel_match(), "matches_v3",
+                               MatchOutcome(), actor_id="admin", audit_action="test"))
+
+
+# ------------------------------------------------- Der klassische Kern
+
+def test_a_decided_match_moves_the_winner_onward():
+    follow_up = {"id": "m2", "tournament_id": "t1", "status": "pending",
+                 "participant_a_id": None, "participant_b_id": "reg-c"}
+    match = duel_match(next_match_id="m2", next_match_slot="a")
+
+    application = build_classic_result_application(
+        match, [match, follow_up], status="completed", winner_id="reg-a", now_iso="jetzt")
+
+    assert application["decided"] is True
+    assert application["target_sets"]["m2"]["participant_a_id"] == "reg-a"
+    assert application["target_sets"]["m2"]["status"] == "ready"
+
+
+def test_an_undecided_entry_leaves_the_bracket_alone():
+    """Ein Einspruch oder ein Termin darf niemanden weiterschicken."""
+    match = duel_match(next_match_id="m2", next_match_slot="a")
+
+    application = build_classic_result_application(
+        match, [match], status="disputed", winner_id=None, now_iso="jetzt")
+
+    assert application["decided"] is False
+    assert application["target_sets"] == {}
+
+
+def test_a_knockout_match_cannot_end_without_a_winner():
+    with pytest.raises(MatchResultError):
+        build_classic_result_application(
+            duel_match(), [], status="completed", winner_id=None, now_iso="jetzt")
+
+
+def test_a_group_match_may_end_level():
+    application = build_classic_result_application(
+        duel_match(bracket="group_A"), [], status="completed", winner_id=None,
+        score_a=1, score_b=1, now_iso="jetzt")
+
+    assert application["match_set"]["status"] == "completed"
+    assert application["match_set"]["winner_id"] is None
+
+
+def test_a_missing_score_means_unchanged_not_cleared():
+    """Sonst wischt ein Einspruch die bereits gemeldeten Punkte weg."""
+    application = build_classic_result_application(
+        duel_match(score_a=2, score_b=1), [], status="disputed", winner_id=None,
+        now_iso="jetzt")
+
+    assert "score_a" not in application["match_set"]
+    assert "score_b" not in application["match_set"]
+
+
+def test_operational_fields_ride_along_in_the_same_write():
+    application = build_classic_result_application(
+        duel_match(), [], status="completed", winner_id="reg-a", now_iso="jetzt",
+        extra_set={"admin_note": "korrigiert"})
+
+    assert application["match_set"]["admin_note"] == "korrigiert"
+
+
+@pytest.mark.parametrize("status", ["completed", "forfeit"])
+def test_the_same_result_twice_is_recognised(status):
+    match = duel_match(status=status, winner_id="reg-a", loser_id="reg-b",
+                       score_a=2, score_b=0)
+
+    assert is_classic_result_replay(match, status=status, winner_id="reg-a",
+                                    score_a=2, score_b=0) is True
+    assert is_classic_result_replay(match, status=status, winner_id="reg-b",
+                                    score_a=0, score_b=2) is False
+
+
+def test_an_open_match_is_never_a_replay():
+    match = duel_match(status="ready", winner_id=None)
+
+    assert is_classic_result_replay(match, status="completed", winner_id="reg-a",
+                                    score_a=None, score_b=None) is False
+
+
+def test_a_replay_writes_nothing_and_says_so():
+    match = duel_match(status="completed", winner_id="reg-a", loser_id="reg-b",
+                       score_a=2, score_b=0)
+    db = fake_db(matches=[match])
+
+    result = run(apply_match_result(
+        db, match, "matches",
+        MatchOutcome(status="completed", winner_id="reg-a", score_a=2, score_b=0),
+        actor_id="admin", audit_action="test"))
+
+    assert result["idempotent_replay"] is True
+    assert db.audit_logs.rows == []
+
+
+# ------------------------------------------------- Gleiche Folgen für jeden Weg
+
+def side_effect_spies(monkeypatch):
+    spies = {
+        "notify": AsyncMock(),
+        "release": AsyncMock(),
+        "badges": AsyncMock(),
+        "announce": AsyncMock(),
+    }
+    monkeypatch.setattr(classic_submission, "notify_match_result_confirmed", spies["notify"])
+    monkeypatch.setattr(classic_submission, "release_station_for_match", spies["release"])
+    monkeypatch.setattr(classic_submission, "_award_badges", spies["badges"])
+    monkeypatch.setattr(classic_submission, "_announce", spies["announce"])
+    return spies
+
+
+@pytest.mark.parametrize("audit_action", [
+    "match.result.update",
+    "match.result.auto_resolution",
+    "match.forfeit",
+])
+def test_every_way_of_deciding_a_match_has_the_same_consequences(monkeypatch, audit_action):
+    """Vorher entschied der Weg, ob es Abzeichen und eine Ankündigung gab."""
+    spies = side_effect_spies(monkeypatch)
+    match = duel_match()
+    status = "forfeit" if audit_action == "match.forfeit" else "completed"
+
+    run(apply_match_result(
+        fake_db(matches=[match]), match, "matches",
+        MatchOutcome(status=status, winner_id="reg-a", score_a=2, score_b=0),
+        actor_id="admin", audit_action=audit_action))
+
+    for name, spy in spies.items():
+        assert spy.await_count == 1, f"{name} fehlt bei {audit_action}"
+
+
+def test_an_undecided_result_triggers_nothing(monkeypatch):
+    spies = side_effect_spies(monkeypatch)
+    match = duel_match()
+
+    run(apply_match_result(
+        fake_db(matches=[match]), match, "matches",
+        MatchOutcome(status="disputed", winner_id=None),
+        actor_id="admin", audit_action="match.result.update"))
+
+    for spy in spies.values():
+        spy.assert_not_awaited()
+
+
+def test_a_failing_announcement_does_not_undo_the_result(monkeypatch):
+    """Discord ist nicht Teil des Ergebnisses - ein Ausfall darf es nicht kippen."""
+    side_effect_spies(monkeypatch)
+    monkeypatch.setattr(classic_submission, "_announce",
+                        AsyncMock(side_effect=RuntimeError("Discord weg")))
+    match = duel_match()
+    db = fake_db(matches=[match])
+
+    result = run(apply_match_result(
+        db, match, "matches",
+        MatchOutcome(status="completed", winner_id="reg-a", score_a=2, score_b=0),
+        actor_id="admin", audit_action="match.result.update"))
+
+    assert result["match"]["winner_id"] == "reg-a"
+    assert db.matches.rows[0]["status"] == "completed"
+
+
+def test_the_write_is_recorded_for_the_classic_engine():
+    match = duel_match()
+    db = fake_db(matches=[match])
+
+    run(apply_match_result(db, match, "matches",
+                           MatchOutcome(status="completed", winner_id="reg-a"),
+                           actor_id="admin", audit_action="match.result.update"))
+
+    entry = db.audit_logs.rows[0]
+    assert entry["action"] == "match.result.update"
+    assert entry["data"]["match_id"] == "m1"
+
+
+# ------------------------------------------------- Übersetzung im Einstieg
+
+def test_the_entry_point_hands_each_store_the_form_it_needs():
+    match = duel_match()
+    only_duel = MatchOutcome(winner_id="reg-a", score_a=2, score_b=1)
+    only_ranking = MatchOutcome(results=[
+        {"registration_id": "reg-a", "rank": 1},
+        {"registration_id": "reg-b", "rank": 2},
+    ])
+
+    assert as_ranking(match, only_duel)[0]["registration_id"] == "reg-a"
+    assert as_duel(match, only_ranking)["winner_id"] == "reg-a"
+    assert as_duel(match, only_duel)["score_a"] == 2
+    assert as_ranking(match, only_ranking) is only_ranking.results

--- a/backend/tests/test_tournament_capability_inventory.py
+++ b/backend/tests/test_tournament_capability_inventory.py
@@ -26,6 +26,11 @@ from services.competition_capabilities import (
     declared_endpoints,
     open_gaps,
 )
+from services.competition_engine import (
+    CLASSIC as ENGINE_CLASSIC,
+    GRAPH as ENGINE_GRAPH,
+    decide_rebuild_engine,
+)
 from services.competition_formats import FORMAT_CAPABILITIES
 
 
@@ -149,16 +154,23 @@ def test_no_format_claims_to_be_write_ready_yet():
     )
 
 
-def test_formats_that_switch_engine_on_rebuild_are_visible():
-    """Single/Double start classic and silently move to the graph store on rebuild.
-
-    Block 4 stops that. Until then the behaviour must at least be declared.
+def test_the_format_table_alone_no_longer_decides_the_store():
+    """Single/Double still declare two different engines - legacy for the first
+    draft, the stage graph for a rebuild. That combination used to be enough to
+    move a played tournament. Since Block 4 it is not: the decision runs through
+    ``decide_rebuild_engine``, which lets the tournament's own matches override
+    the table. This test guards that the override is still reachable for exactly
+    the formats that need it.
     """
-    switching = [
+    declared_switch = sorted(
         key for key, cap in FORMAT_CAPABILITIES.items()
         if cap.initial_preview_engine == "legacy" and cap.rebuild_engine == "stage"
-    ]
-    assert sorted(switching) == ["double_elim", "single_elim"], (
-        "Die Liste der Formate mit stillem Speicherwechsel hat sich geändert - "
-        "das ist genau der Punkt, den Block 4 abstellt."
     )
+    assert declared_switch == ["double_elim", "single_elim"]
+
+    for key in declared_switch:
+        decision = decide_rebuild_engine(
+            key, preferred=ENGINE_GRAPH, legacy_matches=[{"id": "m1", "is_preview": False}])
+        assert decision.engine == ENGINE_CLASSIC, (
+            f"{key} wuerde beim Neuaufbau wieder den Speicher wechseln."
+        )


### PR DESCRIPTION
Das Herzstück der Vereinheitlichung. Zwei Dinge, die zusammengehören: **ein Schreibweg für Ergebnisse** und **kein unbemerkter Speicherwechsel** mehr.

## Warum es drei Wege waren

Die Graph-Engine hatte längst genau eine Stelle, an der ein Ergebnis geschrieben wird (`submit_v2_result`). Die klassische hatte keine — dieselbe Abfolge stand dreimal da:

| Weg | Weiterleitung | Benachrichtigung | Station frei | Abzeichen | Discord |
|---|---|---|---|---|---|
| Eintragung durch Turnierleitung | ✅ | ✅ | ✅ | ✅ | ✅ |
| Ergebnismeldung beider Spieler | ✅ | ✅ | ✅ | ❌ | ❌ |
| Forfeit | ✅ | ✅ | ✅ | ❌ | ❌ |

**Gleicher Ausgang, unterschiedliche Folgen** — je nachdem, welchen Weg er genommen hat. Wer sein Match gewonnen und mit dem Gegner übereinstimmend gemeldet hat, bekam kein Abzeichen dafür. Das war keine Entscheidung, das war Drift zwischen drei Kopien derselben Regel.

Jetzt gibt es `apply_match_result` als einen Einstieg, der intern entscheidet, welcher Speicher bedient wird. `advance_match_winner` hat noch **einen Aufrufer statt drei**.

## Ein Duell ist eine Rangliste aus zwei

Das ist der Grund, warum die beiden Engines überhaupt zusammengehen. Die klassische spricht von Sieger und zwei Punktständen, die Graph-Engine von einer Rangliste — beides lässt sich verlustfrei ineinander übersetzen (ein Unentschieden ist ein geteilter erster Platz, genau wie im Graph). Ein Aufrufer sagt, was passiert ist, in der Form, die er kennt; die Übersetzung passiert an einer Stelle.

Damit ist auch das **Abnahmekriterium dieses Blocks** prüfbar statt behauptbar: `test_both_engines_name_the_same_winner_from_the_same_input` schickt dieselbe Eingabe durch beide Speicher und vergleicht, wer als Sieger dasteht.

## Zwei Fehler, die beim Bauen aufgefallen sind

- Ein **Sieger, der gar nicht in dem Match steht**, wurde von der Graph-Seite stillschweigend umgedeutet: Die Rangliste vergab dann Rang 1 an den ersten Teilnehmer. Die klassische Seite lehnte das korrekt ab. Die Regel steht jetzt in der Übersetzung und gilt damit für beide.
- Eine **Ergebnismeldung mit abweichenden Punktständen** hätte die bereits gemeldeten Punkte gelöscht. Ein nicht angegebener Punktstand heißt jetzt „unverändert", nicht „leeren".

## Der stille Speicherwechsel

Eine Einzelausscheidung startete klassisch. Der erste Neuaufbau löschte diese Matches und legte sie als Graph-Matches neu an — **mit neuen IDs**, auf die dann weder Meldungen noch Links noch Chat mehr zeigten. Niemand hatte das verlangt; es folgte allein aus der Formattabelle (`initial_preview_engine: legacy` + `rebuild_engine: stage`).

Ab jetzt entscheidet das Turnier, nicht das Format:

- Wer **echte Spiele** hat, bleibt in seinem Speicher. Ein Entwurf ohne Ergebnisse darf weiter umziehen — da geht nichts verloren.
- Nur wenn dieser Speicher das Format **gar nicht neu bauen kann** (der klassische Generator kennt vier Formate), wäre ein Umzug nötig. Der wird dann mit `409 engine_switch_required` abgelehnt, bis er über `allow_engine_switch=true` ausdrücklich bestätigt wird. Aus einem Nebeneffekt wird damit eine angekündigte Migration — genau die Absicherung, die Block 5 braucht.

Die Regel gilt an beiden Stellen, die neu aufbauen: `bracket/from-format` und der Plan/Apply-Weg.

## Prüfung

- 686 Tests grün (+43), Coverage 43,52 %
- Routenzahl unverändert bei **528**
- Der Inventar-Test, der den stillen Wechsel bisher nur *dokumentiert* hat, prüft jetzt, dass er nicht mehr passiert
- Die zwei Idempotenz-Tests, die den alten Ansatzpunkt monkeypatchten, zeigen auf die neue Stelle — die Zusage dahinter ist unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)
