### PR TITLE
Turnier-Migration: Trockenlauf, der nur liest (Vorbereitung Block 5)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -38,6 +38,7 @@ Das ersetzt keine manuelle Prüfung externer Links oder der fachlichen Abnahme.
 
 - [COMPETITION_ENGINE](COMPETITION_ENGINE.md): eigenständiger künftiger Umbau mit Abnahmekriterien.
 - [TOURNAMENT_CUSTOM_BRACKETS](TOURNAMENT_CUSTOM_BRACKETS.md): vorhandene Strukturen und Bedienung.
+- [TOURNAMENT_MIGRATION_DRYRUN](TOURNAMENT_MIGRATION_DRYRUN.md): Bestandsaufnahme vor der Zusammenführung — liest nur, schreibt nichts.
 - [IMPROVEMENT_REPORT](IMPROVEMENT_REPORT.md): Umsetzungshistorie der Plattformhärtung.
 - [TOURNAMENT_ROADMAP](TOURNAMENT_ROADMAP.md) und [APP_BETA_PHASE_PLAN](APP_BETA_PHASE_PLAN.md):
   historische Planstände; neue Aufgaben entstehen ausschließlich im Restplan.

--- a/TOURNAMENT_MIGRATION_DRYRUN.md
+++ b/TOURNAMENT_MIGRATION_DRYRUN.md
@@ -1,0 +1,91 @@
+# Turnier-Migration: Trockenlauf
+
+Bevor die gespeicherten Turniere auf eine Engine zusammengeführt werden, wird
+gemessen statt vermutet. Dieses Werkzeug liest den Bestand, beschreibt ihn und
+legt eine Vergleichsbasis an — es schreibt nichts.
+
+## Warum das vor der Migration kommt
+
+Eine Migration schreibt neue Match-Dokumente. Die IDs ändern sich dabei, also
+kann man nicht über IDs vergleichen. Verglichen wird deshalb der **Inhalt**: wer
+hat in welcher Runde gegen wen gespielt, wer hat gewonnen, was sagt die Tabelle,
+wer steht auf welchem Platz. Das ist zugleich genau das, was ein Mitglied sehen
+würde — wenn das gleich bleibt, hat sich für niemanden etwas geändert.
+
+## Ausführen
+
+Auf dem Server, der die Daten hält, mit denselben `MONGO_URL` und `DB_NAME` wie
+das Backend:
+
+```bash
+python scripts/tournament-migration-dryrun.py --out vorher.json
+```
+
+Das Skript kann nicht schreiben. Die Datenbankhülle lässt Schreibmethoden gar
+nicht erst durch — ein Schreibversuch bricht mit einem Fehler ab, statt
+ausgeführt zu werden. Das ist eine Eigenschaft des Codes, nicht ein Versprechen
+im Kommentar, und wird mitgetestet.
+
+Nützliche Schalter:
+
+| Schalter | Wofür |
+| --- | --- |
+| `--tournament <id\|slug>` | Nur ein einzelnes Turnier ansehen |
+| `--limit N` | Nur die ersten N Turniere (für einen schnellen Blick) |
+| `--out datei.json` | Bericht als JSON ablegen |
+| `--compare vorher.json` | Gegen eine frühere Aufnahme vergleichen |
+
+## Was im Bericht steht
+
+**Mängel** sind Defekte in einzelnen Turnieren, die jemand vor der Migration
+anfassen muss:
+
+| Code | Bedeutung |
+| --- | --- |
+| `mixed_source` | Echte Spiele liegen in beiden Speichern |
+| `open_matches` | Spiele sind offen oder angefochten |
+| `decided_without_winner` | K.-o.-Spiel abgeschlossen, aber ohne eindeutigen Sieger |
+| `result_without_participants` | Entschiedenes Spiel ohne Teilnehmer (Altlast) |
+| `graph_issues` | Die Strukturprüfung meldet einen kaputten Turnierbaum |
+| `external_format` | Format läuft nicht über die Turnier-Engines (Zeitfahren, Grand Prix) |
+
+**Hinweise** sind getrennt aufgeführt, weil sie fast jedes klassische Turnier
+betreffen und **eine** Entscheidung brauchen statt fünfzig Einzelkorrekturen:
+
+| Code | Bedeutung |
+| --- | --- |
+| `explicit_placements_would_be_replaced` | Das Turnier hat feste Platzierungen (`final_position`), die nach der Migration aus der Tabelle abgeleitet würden |
+| `placements_would_appear` | Das Turnier hat heute keine Platzierungen und bekäme nach der Migration welche |
+
+### Zum Platzierungs-Hinweis
+
+Das ist der wichtigste Fund des Trockenlaufs, und er ist beim Bauen des
+Werkzeugs aufgefallen: Die beiden Engines beantworten die Frage „wer ist Erster"
+unterschiedlich.
+
+- **Klassisch:** aus dem historischen Feld `final_position` — und gar nicht, wenn
+  das Feld leer ist. Geschrieben wird es nirgends mehr, nur noch gelesen.
+- **Graph:** immer aus der Tabelle abgeleitet.
+
+Platzierungen hängen an **Preisen, der Turnier-Historie im Mitgliederprofil, den
+Sieger- und Podest-Abzeichen und den Saisonpunkten**. Eine Migration, die die
+Quelle stillschweigend umstellt, würde alle vier für längst beendete Turniere neu
+beantworten. Deshalb steht die Entscheidung darüber vor der Migration und nicht
+danach.
+
+## Nach der Migration
+
+Denselben Lauf noch einmal, gegen die Vorher-Aufnahme:
+
+```bash
+python scripts/tournament-migration-dryrun.py --out nachher.json --compare vorher.json
+```
+
+Der Exit-Code ist `0`, wenn jedes Turnier denselben Fingerabdruck hat, und `1`,
+wenn eines abweicht — dann wird pro Turnier aufgeführt, was sich unterscheidet.
+
+## Datenschutz
+
+Der Bericht enthält Turniertitel, Slugs und Anmelde-IDs. **Keine Mitgliedsnamen,
+keine E-Mail-Adressen** — das wird mitgetestet. Er ist damit teilbar, ohne
+Mitgliederdaten weiterzugeben.

--- a/backend/services/migration_dryrun.py
+++ b/backend/services/migration_dryrun.py
@@ -1,0 +1,369 @@
+"""Measuring a tournament so a migration can be proven not to have changed it.
+
+Before the stored tournaments move to one engine, two questions need answers
+that are numbers rather than opinions: what is actually in there, and would
+anything a member can see come out differently afterwards.
+
+The second question decides how the measurement has to work. A migration writes
+new match documents, so **match ids do not survive it** - a fingerprint built on
+ids would report every tournament as changed and prove nothing. What survives is
+the content: who played whom in which round, who won, what the table says and who
+placed where. Those are also exactly the things a member would notice, which is
+why they are the right thing to compare.
+
+Everything here reads; nothing writes. The projections come from the canonical
+read contract, which is engine-independent by design - with one exception that
+building this turned up: placements are still answered differently by the two
+engines, and since they feed prizes, profile history, badges and season points,
+that is reported as a notice before anything moves rather than discovered after.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+from services.competition_engine import CLASSIC, GRAPH, engine_of_record
+from services.competition_formats import find_format_capability
+from services.competition_graph_validation import validate_competition_graph
+from services.competition_standings import placements_for_structure, standings_for_structure
+
+
+TERMINAL = {"completed", "forfeit"}
+OPEN_STATUSES = {"disputed", "waiting_result", "in_progress"}
+KNOCKOUT_FORMATS = {"single_elim", "double_elim"}
+
+
+def _participants(match: dict) -> list[str]:
+    return sorted(
+        slot.get("registration_id")
+        for slot in match.get("slots") or []
+        if slot.get("registration_id")
+    )
+
+
+def _winner(match: dict) -> str | None:
+    winners = [
+        result.get("registration_id")
+        for result in match.get("results") or []
+        if result.get("outcome") == "winner"
+    ]
+    return winners[0] if len(winners) == 1 else None
+
+
+def match_identity(match: dict) -> str:
+    """Name a match by what happened in it, not by its id.
+
+    A migration writes new documents with new ids. Identifying a match by round
+    and participants is what makes a before/after comparison possible at all.
+    """
+    return "{}|{}|{}".format(
+        match.get("round") or 0,
+        match.get("section") or "",
+        ",".join(_participants(match)),
+    )
+
+
+def standings_order(rows: list) -> list[str]:
+    """The table as a plain ranked list of registration ids.
+
+    Group tournaments return one table per group; they are flattened in group
+    order so the comparison stays a simple list either way.
+    """
+    order: list[str] = []
+    for row in rows or []:
+        if isinstance(row, dict) and "standings" in row:
+            order.extend(
+                entry.get("registration_id")
+                for entry in row.get("standings") or []
+                if entry.get("registration_id")
+            )
+        elif isinstance(row, dict) and row.get("registration_id"):
+            order.append(row["registration_id"])
+    return order
+
+
+def tournament_fingerprint(
+    tournament: dict,
+    snapshot: dict,
+    registrations: list[dict],
+    *,
+    groups: list[dict] = (),
+) -> dict:
+    """What a member can see about this tournament, as comparable values."""
+    matches = snapshot.get("matches") or []
+    decided = [match for match in matches if match.get("status") in TERMINAL]
+    results = {}
+    for match in decided:
+        identity = match_identity(match)
+        # Ein wiederholter Schlüssel wäre selbst schon ein Befund: zwei Matches
+        # mit derselben Runde und denselben Teilnehmern.
+        results.setdefault(identity, []).append(_winner(match))
+
+    standings = standings_for_structure(tournament, snapshot, registrations, groups=list(groups))
+    placements = placements_for_structure(snapshot, registrations)
+
+    return {
+        "participants": sorted(
+            registration["id"] for registration in registrations if registration.get("id")
+        ),
+        "match_count": len(matches),
+        "decided_count": len(decided),
+        "results": {key: sorted(filter(None, value)) for key, value in sorted(results.items())},
+        "standings": standings_order(standings),
+        "placements": {str(rank): entry.get("registration_id")
+                       for rank, entry in sorted(placements.items())},
+    }
+
+
+def fingerprint_digest(fingerprint: dict) -> str:
+    payload = json.dumps(fingerprint, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def placement_risk(snapshot: dict, registrations: list[dict]) -> dict | None:
+    """Whether this tournament's placements would be answered differently afterwards.
+
+    Placements are the one projection that is *not* engine-independent today.
+    For a classic tournament they come from the historical ``final_position``
+    field, and from nothing at all when that field is empty. For a graph
+    tournament they are always derived from the standings.
+
+    That matters far beyond the bracket: placements feed prize awards, the
+    tournament history on member profiles, the winner/podium badges and the
+    season points. A migration that quietly switches the source would rewrite
+    all four for tournaments that are long finished.
+    """
+    matches = snapshot.get("matches") or []
+    legacy = [match for match in matches if match.get("source", {}).get("engine") == "legacy"]
+    if not legacy:
+        return None
+
+    explicit = [match for match in legacy if match.get("final_position")]
+    decided = [match for match in legacy if match.get("status") in TERMINAL]
+    if explicit:
+        return {
+            "code": "explicit_placements_would_be_replaced",
+            "detail": f"{len(explicit)} Spiele tragen eine feste Platzierung (final_position).",
+            "action": "Diese Platzierungen vor der Migration festschreiben - sonst werden sie "
+                      "danach aus der Tabelle abgeleitet und können abweichen. Betrifft Preise, "
+                      "Profil-Historie, Abzeichen und Saisonpunkte.",
+        }
+    if decided and not placements_for_structure(snapshot, registrations):
+        return {
+            "code": "placements_would_appear",
+            "detail": "Das Turnier hat heute keine Platzierungen.",
+            "action": "Nach der Migration würde es welche aus der Tabelle bekommen. Prüfen, ob "
+                      "das für Preise und Saisonpunkte gewollt ist.",
+        }
+    return None
+
+
+def migration_notices(snapshot: dict, registrations: list[dict] = ()) -> list[dict]:
+    """Things that will change on migration but are systemic, not broken.
+
+    Kept apart from the blockers on purpose. A blocker is a defect in one
+    tournament that somebody has to go and fix; a notice applies to nearly every
+    classic tournament and needs one decision, taken once. Mixing the two would
+    bury three real defects under fifty routine lines.
+    """
+    notices = []
+    risk = placement_risk(snapshot, list(registrations))
+    if risk:
+        notices.append(risk)
+    return notices
+
+
+def migration_blockers(tournament: dict, snapshot: dict, registrations: list[dict] = ()) -> list[dict]:
+    """Reasons this tournament cannot move yet, each with what to do about it.
+
+    Deliberately reported per tournament instead of aborting the whole run: the
+    point of a dry run is to see the full picture once, not to stop at the first
+    surprise.
+    """
+    blockers: list[dict] = []
+    matches = snapshot.get("matches") or []
+    format_key = tournament.get("format")
+    capability = find_format_capability(format_key)
+
+    if snapshot.get("mixed_source"):
+        blockers.append({
+            "code": "mixed_source",
+            "detail": "Das Turnier hat echte Spiele in beiden Speichern.",
+            "action": "Vor der Migration klären, welcher Speicher gilt.",
+        })
+
+    if capability and capability.current_write_model == "external":
+        blockers.append({
+            "code": "external_format",
+            "detail": f"Format {format_key} wird nicht über die Turnier-Engines geführt.",
+            "action": "Bleibt außerhalb der Migration.",
+        })
+
+    open_matches = [match for match in matches if match.get("status") in OPEN_STATUSES]
+    if open_matches:
+        blockers.append({
+            "code": "open_matches",
+            "detail": f"{len(open_matches)} Spiele sind offen oder angefochten.",
+            "action": "Erst entscheiden lassen, dann migrieren.",
+        })
+
+    if format_key in KNOCKOUT_FORMATS:
+        drawn = [
+            match for match in matches
+            if match.get("status") == "completed" and not _winner(match)
+        ]
+        if drawn:
+            blockers.append({
+                "code": "decided_without_winner",
+                "detail": f"{len(drawn)} abgeschlossene K.-o.-Spiele haben keinen eindeutigen Sieger.",
+                "action": "Sieger nachtragen - der Turnierbaum kann sie sonst nicht weiterleiten.",
+            })
+
+    orphaned = [
+        match for match in matches
+        if match.get("status") in TERMINAL and not _participants(match)
+    ]
+    if orphaned:
+        blockers.append({
+            "code": "result_without_participants",
+            "detail": f"{len(orphaned)} entschiedene Spiele haben keine Teilnehmer mehr.",
+            "action": "Vermutlich Altlast - vor der Migration prüfen.",
+        })
+
+    issues = validate_competition_graph(snapshot).get("issues") or []
+    if issues:
+        counted: dict[str, int] = {}
+        for issue in issues:
+            counted[issue.get("type") or "unknown"] = counted.get(issue.get("type") or "unknown", 0) + 1
+        blockers.append({
+            "code": "graph_issues",
+            "detail": "Strukturprüfung meldet: " + ", ".join(
+                f"{name} ({count}x)" for name, count in sorted(counted.items())),
+            "action": "Struktur reparieren oder neu aufbauen.",
+        })
+
+    return blockers
+
+
+def tournament_report(
+    tournament: dict,
+    snapshot: dict,
+    registrations: list[dict],
+    *,
+    groups: list[dict] = (),
+) -> dict:
+    """One tournament's row in the dry-run report. Contains no member names."""
+    legacy = [m for m in snapshot.get("matches") or []
+              if m.get("source", {}).get("engine") == "legacy"]
+    stage = [m for m in snapshot.get("matches") or []
+             if m.get("source", {}).get("engine") == "stage"]
+    engine = engine_of_record(legacy, stage)
+    capability = find_format_capability(tournament.get("format"))
+    fingerprint = tournament_fingerprint(tournament, snapshot, registrations, groups=groups)
+    blockers = migration_blockers(tournament, snapshot, registrations)
+
+    return {
+        "id": tournament.get("id"),
+        "slug": tournament.get("slug"),
+        "title": tournament.get("title"),
+        "format": tournament.get("format"),
+        "status": tournament.get("status"),
+        "engine": engine,
+        "needs_migration": engine == CLASSIC,
+        "target_engine": GRAPH if capability and capability.stage_generator_available else None,
+        "participant_count": len(fingerprint["participants"]),
+        "match_count": fingerprint["match_count"],
+        "decided_count": fingerprint["decided_count"],
+        "digest": fingerprint_digest(fingerprint),
+        "fingerprint": fingerprint,
+        "blockers": blockers,
+        "notices": migration_notices(snapshot, registrations),
+        "ready": not blockers and engine is not None,
+    }
+
+
+def compare_reports(before: dict, after: dict) -> dict:
+    """Diff two dry-run baselines, tournament by tournament."""
+    before_by_id = {row["id"]: row for row in before.get("tournaments") or []}
+    after_by_id = {row["id"]: row for row in after.get("tournaments") or []}
+
+    changed: list[dict] = []
+    for tournament_id, previous in before_by_id.items():
+        current = after_by_id.get(tournament_id)
+        if current is None:
+            changed.append({"id": tournament_id, "title": previous.get("title"),
+                            "problem": "fehlt jetzt", "differences": []})
+            continue
+        if previous["digest"] == current["digest"]:
+            continue
+        changed.append({
+            "id": tournament_id,
+            "title": previous.get("title"),
+            "problem": "Fingerabdruck weicht ab",
+            "differences": fingerprint_differences(previous["fingerprint"], current["fingerprint"]),
+        })
+
+    return {
+        "compared": len(before_by_id),
+        "unchanged": len(before_by_id) - len(changed),
+        "changed": changed,
+        "new": sorted(set(after_by_id) - set(before_by_id)),
+        "equivalent": not changed,
+    }
+
+
+def fingerprint_differences(previous: dict, current: dict) -> list[str]:
+    """Say what moved, in words a person can act on."""
+    differences: list[str] = []
+    for field, label in (
+        ("participants", "Teilnehmer"),
+        ("standings", "Tabellenreihenfolge"),
+        ("match_count", "Anzahl Spiele"),
+        ("decided_count", "Anzahl entschiedener Spiele"),
+    ):
+        if previous.get(field) != current.get(field):
+            differences.append(f"{label}: vorher {_short(previous.get(field))}, jetzt {_short(current.get(field))}")
+
+    previous_results = previous.get("results") or {}
+    current_results = current.get("results") or {}
+    for key in sorted(set(previous_results) | set(current_results)):
+        if previous_results.get(key) != current_results.get(key):
+            differences.append(
+                f"Spiel [{key}]: Sieger vorher {previous_results.get(key)}, jetzt {current_results.get(key)}")
+
+    previous_places = previous.get("placements") or {}
+    current_places = current.get("placements") or {}
+    for rank in sorted(set(previous_places) | set(current_places), key=lambda value: int(value)):
+        if previous_places.get(rank) != current_places.get(rank):
+            differences.append(
+                f"Platz {rank}: vorher {previous_places.get(rank)}, jetzt {current_places.get(rank)}")
+    return differences
+
+
+def _short(value) -> str:
+    if isinstance(value, list):
+        return f"{len(value)} Einträge"
+    return str(value)
+
+
+def summarize(rows: list[dict]) -> dict:
+    """The headline numbers of one dry run."""
+    by_engine: dict[str, int] = {}
+    blockers: dict[str, int] = {}
+    notices: dict[str, int] = {}
+    for row in rows:
+        key = row.get("engine") or "leer"
+        by_engine[key] = by_engine.get(key, 0) + 1
+        for blocker in row.get("blockers") or []:
+            blockers[blocker["code"]] = blockers.get(blocker["code"], 0) + 1
+        for notice in row.get("notices") or []:
+            notices[notice["code"]] = notices.get(notice["code"], 0) + 1
+    return {
+        "tournaments": len(rows),
+        "by_engine": dict(sorted(by_engine.items())),
+        "needs_migration": sum(1 for row in rows if row.get("needs_migration")),
+        "ready": sum(1 for row in rows if row.get("ready")),
+        "blocked": sum(1 for row in rows if row.get("blockers")),
+        "blockers": dict(sorted(blockers.items())),
+        "notices": dict(sorted(notices.items())),
+    }

--- a/backend/tests/test_migration_dryrun_unit.py
+++ b/backend/tests/test_migration_dryrun_unit.py
@@ -1,0 +1,514 @@
+"""The measurement that has to survive a migration.
+
+The dry run exists to answer one question with numbers: would anything a member
+can see come out differently after the tournaments move to one engine. That only
+works if the measurement itself is engine-independent - so the central test here
+builds the same tournament twice, once in each store, and requires the same
+values to come out. If it ever fails, the fingerprint is measuring the storage
+instead of the tournament, and the whole dry run would be worthless.
+
+One field deliberately does not pass that test: placements. They genuinely are
+answered differently by the two engines today, which is a finding rather than a
+bug in the measurement - and the reason the tool reports it before anything moves.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.competition_snapshot import build_structure_snapshot
+from services.migration_dryrun import (
+    compare_reports,
+    fingerprint_differences,
+    fingerprint_digest,
+    match_identity,
+    migration_blockers,
+    migration_notices,
+    standings_order,
+    summarize,
+    tournament_fingerprint,
+    tournament_report,
+)
+
+
+REGISTRATIONS = [
+    {"id": "reg-a", "user_id": "u-a", "display_name": "Anna"},
+    {"id": "reg-b", "user_id": "u-b", "display_name": "Bert"},
+    {"id": "reg-c", "user_id": "u-c", "display_name": "Cem"},
+    {"id": "reg-d", "user_id": "u-d", "display_name": "Dana"},
+]
+
+TOURNAMENT = {"id": "t1", "slug": "sommer-cup", "title": "Sommer Cup",
+              "format": "single_elim", "status": "completed"}
+
+
+def legacy_match(match_id, round_number, first, second, winner, *, status="completed", **extra):
+    return {
+        "id": match_id,
+        "tournament_id": "t1",
+        "bracket": "wb",
+        "round": round_number,
+        "match_index": 0,
+        "status": status,
+        "participant_a_id": first,
+        "participant_b_id": second,
+        "winner_id": winner,
+        "loser_id": (second if winner == first else first) if winner else None,
+        "score_a": 2 if winner == first else 0,
+        "score_b": 2 if winner == second else 0,
+        **extra,
+    }
+
+
+def stage_match(match_id, round_number, first, second, winner, *, status="completed", **extra):
+    ranked = [winner, second if winner == first else first] if winner else [first, second]
+    return {
+        "id": match_id,
+        "tournament_id": "t1",
+        "stage_id": "s1",
+        "stage_number": 1,
+        "match_key": match_id,
+        "section": "wb",
+        "round": round_number,
+        "order": 1,
+        "status": status,
+        "match_type": "duel",
+        "settings": {"min_players": 2, "match_size": 2},
+        "slots": [
+            {"slot": 1, "registration_id": first, "status": "filled"},
+            {"slot": 2, "registration_id": second, "status": "filled"},
+        ],
+        "results": [
+            {"registration_id": item, "rank": index + 1,
+             "score": 2 if index == 0 else 0}
+            for index, item in enumerate(ranked)
+        ] if winner else [],
+        "advancement": [],
+        **extra,
+    }
+
+
+def legacy_snapshot(matches):
+    return build_structure_snapshot("t1", legacy_matches=matches)
+
+
+def stage_snapshot(matches):
+    return build_structure_snapshot("t1", stage_matches=matches)
+
+
+# ------------------------------------------------ Die zentrale Zusage
+
+SAME_TOURNAMENT_CLASSIC = [
+    legacy_match("m1", 1, "reg-a", "reg-b", "reg-a"),
+    legacy_match("m2", 1, "reg-c", "reg-d", "reg-c"),
+    legacy_match("m3", 2, "reg-a", "reg-c", "reg-a"),
+]
+SAME_TOURNAMENT_GRAPH = [
+    stage_match("g1", 1, "reg-a", "reg-b", "reg-a"),
+    stage_match("g2", 1, "reg-c", "reg-d", "reg-c"),
+    stage_match("g3", 2, "reg-a", "reg-c", "reg-a"),
+]
+
+
+@pytest.mark.parametrize("field", ["participants", "match_count", "decided_count",
+                                   "results", "standings"])
+def test_the_same_tournament_measures_the_same_in_both_stores(field):
+    """Der Kern des Trockenlaufs: die Messung gilt dem Turnier, nicht dem Speicher.
+
+    Wenn das hier fällt, misst der Fingerabdruck den Speicher - und der ganze
+    Vergleich vorher/nachher wäre wertlos.
+    """
+    before = tournament_fingerprint(
+        TOURNAMENT, legacy_snapshot(SAME_TOURNAMENT_CLASSIC), REGISTRATIONS)
+    after = tournament_fingerprint(
+        TOURNAMENT, stage_snapshot(SAME_TOURNAMENT_GRAPH), REGISTRATIONS)
+
+    assert before[field] == after[field]
+
+
+def test_placements_are_the_one_thing_that_does_not_survive_a_move():
+    """Ein bewusst festgehaltener Befund, kein Versehen.
+
+    Klassische Turniere beziehen ihre Platzierungen aus dem historischen Feld
+    ``final_position`` - und haben gar keine, wenn es leer ist. Graph-Turniere
+    leiten sie immer aus der Tabelle ab. Das hängt an Preisen, Profil-Historie,
+    Abzeichen und Saisonpunkten, deshalb meldet der Trockenlauf es als Befund,
+    statt es beim Umzug einfach passieren zu lassen.
+    """
+    classic = legacy_snapshot(SAME_TOURNAMENT_CLASSIC)
+    graph = stage_snapshot(SAME_TOURNAMENT_GRAPH)
+
+    before = tournament_fingerprint(TOURNAMENT, classic, REGISTRATIONS)
+    after = tournament_fingerprint(TOURNAMENT, graph, REGISTRATIONS)
+
+    assert before["placements"] == {}
+    assert after["placements"], "Das Graph-System leitet Platzierungen aus der Tabelle ab"
+
+    codes = [notice["code"] for notice in migration_notices(classic, REGISTRATIONS)]
+    assert "placements_would_appear" in codes
+
+
+def test_a_tournament_with_recorded_placements_is_flagged_separately():
+    """Feste Platzierungen sind der gefährlichere Fall: sie gehen beim Umzug verloren."""
+    matches = [dict(match) for match in SAME_TOURNAMENT_CLASSIC]
+    matches[2]["final_position"] = 1
+
+    codes = [notice["code"] for notice
+             in migration_notices(legacy_snapshot(matches), REGISTRATIONS)]
+
+    assert "explicit_placements_would_be_replaced" in codes
+
+
+def test_a_tournament_already_in_the_graph_has_no_placement_risk():
+    assert migration_notices(stage_snapshot(SAME_TOURNAMENT_GRAPH), REGISTRATIONS) == []
+
+
+def test_the_placement_notice_is_not_counted_as_a_defect():
+    """Ein Hinweis, der fast jedes Turnier betrifft, würde drei echte Mängel zudecken."""
+    row = tournament_report(
+        TOURNAMENT, legacy_snapshot(SAME_TOURNAMENT_CLASSIC), REGISTRATIONS)
+
+    assert row["blockers"] == []
+    assert row["notices"]
+    assert row["ready"] is True
+
+
+def test_new_match_ids_alone_do_not_count_as_a_change():
+    """Eine Migration vergibt neue IDs - daran darf die Messung nicht hängen."""
+    first = legacy_snapshot([legacy_match("alt-1", 1, "reg-a", "reg-b", "reg-a")])
+    second = legacy_snapshot([legacy_match("neu-99", 1, "reg-a", "reg-b", "reg-a")])
+
+    assert (fingerprint_digest(tournament_fingerprint(TOURNAMENT, first, REGISTRATIONS))
+            == fingerprint_digest(tournament_fingerprint(TOURNAMENT, second, REGISTRATIONS)))
+
+
+def test_a_different_winner_is_caught():
+    before = tournament_fingerprint(
+        TOURNAMENT, legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")]), REGISTRATIONS)
+    after = tournament_fingerprint(
+        TOURNAMENT, legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-b")]), REGISTRATIONS)
+
+    differences = fingerprint_differences(before, after)
+
+    assert any("Sieger" in text for text in differences)
+    assert fingerprint_digest(before) != fingerprint_digest(after)
+
+
+def test_a_lost_match_is_caught():
+    before = tournament_fingerprint(TOURNAMENT, legacy_snapshot([
+        legacy_match("m1", 1, "reg-a", "reg-b", "reg-a"),
+        legacy_match("m2", 1, "reg-c", "reg-d", "reg-c"),
+    ]), REGISTRATIONS)
+    after = tournament_fingerprint(TOURNAMENT, legacy_snapshot([
+        legacy_match("m1", 1, "reg-a", "reg-b", "reg-a"),
+    ]), REGISTRATIONS)
+
+    assert any("Anzahl Spiele" in text for text in fingerprint_differences(before, after))
+
+
+def test_a_changed_table_order_is_caught():
+    before = {"standings": ["reg-a", "reg-b"], "results": {}, "placements": {}}
+    after = {"standings": ["reg-b", "reg-a"], "results": {}, "placements": {}}
+
+    assert any("Tabellenreihenfolge" in text for text in fingerprint_differences(before, after))
+
+
+def test_a_changed_placement_is_named_with_its_rank():
+    before = {"standings": [], "results": {}, "placements": {"1": "reg-a"}}
+    after = {"standings": [], "results": {}, "placements": {"1": "reg-b"}}
+
+    assert fingerprint_differences(before, after) == [
+        "Platz 1: vorher reg-a, jetzt reg-b"]
+
+
+# ------------------------------------------------ Wie ein Spiel benannt wird
+
+def test_a_match_is_named_by_round_and_participants():
+    identity = match_identity({
+        "round": 2, "section": "wb",
+        "slots": [{"registration_id": "reg-b"}, {"registration_id": "reg-a"}],
+    })
+
+    assert identity == "2|wb|reg-a,reg-b"
+
+
+def test_the_participant_order_does_not_matter():
+    first = match_identity({"round": 1, "slots": [
+        {"registration_id": "reg-a"}, {"registration_id": "reg-b"}]})
+    second = match_identity({"round": 1, "slots": [
+        {"registration_id": "reg-b"}, {"registration_id": "reg-a"}]})
+
+    assert first == second
+
+
+# ------------------------------------------------ Befunde
+
+def test_a_clean_tournament_has_nothing_to_report():
+    snapshot = legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")])
+
+    assert migration_blockers(TOURNAMENT, snapshot) == []
+
+
+def test_a_disputed_match_holds_the_tournament_back():
+    snapshot = legacy_snapshot([
+        legacy_match("m1", 1, "reg-a", "reg-b", None, status="disputed")])
+
+    codes = [blocker["code"] for blocker in migration_blockers(TOURNAMENT, snapshot)]
+
+    assert "open_matches" in codes
+
+
+def test_a_knockout_match_decided_without_a_winner_is_reported():
+    """Den kann der Turnierbaum nicht weiterleiten - das muss vorher auffallen."""
+    snapshot = legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", None)])
+
+    codes = [blocker["code"] for blocker in migration_blockers(TOURNAMENT, snapshot)]
+
+    assert "decided_without_winner" in codes
+
+
+def test_a_draw_in_a_group_stage_is_not_a_finding():
+    snapshot = legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", None)])
+
+    codes = [blocker["code"]
+             for blocker in migration_blockers({**TOURNAMENT, "format": "groups"}, snapshot)]
+
+    assert "decided_without_winner" not in codes
+
+
+def test_a_tournament_living_in_both_stores_is_reported():
+    snapshot = build_structure_snapshot(
+        "t1",
+        legacy_matches=[legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")],
+        stage_matches=[stage_match("g1", 1, "reg-c", "reg-d", "reg-c")],
+    )
+
+    codes = [blocker["code"] for blocker in migration_blockers(TOURNAMENT, snapshot)]
+
+    assert "mixed_source" in codes
+
+
+def test_a_format_that_lives_outside_the_engines_is_marked_as_such():
+    snapshot = legacy_snapshot([])
+
+    codes = [blocker["code"]
+             for blocker in migration_blockers({**TOURNAMENT, "format": "time_trial"}, snapshot)]
+
+    assert "external_format" in codes
+
+
+def test_a_decided_match_without_participants_is_reported():
+    orphan = legacy_match("m1", 1, None, None, None)
+    orphan["status"] = "completed"
+    snapshot = legacy_snapshot([orphan])
+
+    codes = [blocker["code"]
+             for blocker in migration_blockers({**TOURNAMENT, "format": "groups"}, snapshot)]
+
+    assert "result_without_participants" in codes
+
+
+# ------------------------------------------------ Bericht und Vergleich
+
+def test_a_report_names_the_store_and_whether_it_has_to_move():
+    snapshot = legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")])
+
+    row = tournament_report(TOURNAMENT, snapshot, REGISTRATIONS)
+
+    assert row["engine"] == "classic"
+    assert row["needs_migration"] is True
+    assert row["target_engine"] == "graph"
+    assert row["ready"] is True
+
+
+def test_a_tournament_already_in_the_graph_needs_no_migration():
+    snapshot = stage_snapshot([stage_match("g1", 1, "reg-a", "reg-b", "reg-a")])
+
+    row = tournament_report(TOURNAMENT, snapshot, REGISTRATIONS)
+
+    assert row["engine"] == "graph"
+    assert row["needs_migration"] is False
+
+
+def test_the_report_carries_no_member_names():
+    """Der Bericht soll teilbar sein, ohne Mitgliederdaten weiterzugeben."""
+    snapshot = legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")])
+
+    row = tournament_report(TOURNAMENT, snapshot, REGISTRATIONS)
+
+    import json
+    text = json.dumps(row, ensure_ascii=False)
+    for name in ("Anna", "Bert", "Cem", "Dana"):
+        assert name not in text
+
+
+def test_an_unchanged_run_compares_as_equivalent():
+    snapshot = legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")])
+    report = {"tournaments": [tournament_report(TOURNAMENT, snapshot, REGISTRATIONS)]}
+
+    result = compare_reports(report, report)
+
+    assert result["equivalent"] is True
+    assert result["unchanged"] == 1
+
+
+def test_a_changed_run_names_the_tournament_and_the_difference():
+    before = {"tournaments": [tournament_report(
+        TOURNAMENT, legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")]),
+        REGISTRATIONS)]}
+    after = {"tournaments": [tournament_report(
+        TOURNAMENT, legacy_snapshot([legacy_match("m1", 1, "reg-a", "reg-b", "reg-b")]),
+        REGISTRATIONS)]}
+
+    result = compare_reports(before, after)
+
+    assert result["equivalent"] is False
+    assert result["changed"][0]["title"] == "Sommer Cup"
+    assert result["changed"][0]["differences"]
+
+
+def test_a_tournament_that_vanished_is_reported_as_missing():
+    before = {"tournaments": [tournament_report(
+        TOURNAMENT, legacy_snapshot([]), REGISTRATIONS)]}
+
+    result = compare_reports(before, {"tournaments": []})
+
+    assert result["changed"][0]["problem"] == "fehlt jetzt"
+
+
+def test_the_summary_counts_stores_and_findings():
+    rows = [
+        tournament_report(TOURNAMENT, legacy_snapshot(
+            [legacy_match("m1", 1, "reg-a", "reg-b", "reg-a")]), REGISTRATIONS),
+        tournament_report(TOURNAMENT, legacy_snapshot(
+            [legacy_match("m2", 1, "reg-a", "reg-b", None, status="disputed")]), REGISTRATIONS),
+    ]
+
+    summary = summarize(rows)
+
+    assert summary["tournaments"] == 2
+    assert summary["by_engine"]["classic"] == 2
+    assert summary["blocked"] == 1
+    assert summary["blockers"]["open_matches"] == 1
+
+
+# ------------------------------------------------ Tabellenformen
+
+def test_a_group_table_is_flattened_in_group_order():
+    rows = [
+        {"group": {"group_key": "A"}, "standings": [
+            {"registration_id": "reg-a"}, {"registration_id": "reg-b"}]},
+        {"group": {"group_key": "B"}, "standings": [
+            {"registration_id": "reg-c"}]},
+    ]
+
+    assert standings_order(rows) == ["reg-a", "reg-b", "reg-c"]
+
+
+def test_a_flat_table_stays_flat():
+    assert standings_order([{"registration_id": "reg-a"}]) == ["reg-a"]
+
+
+@pytest.mark.parametrize("rows", [None, [], [{}]])
+def test_an_empty_table_does_not_crash(rows):
+    assert standings_order(rows) == []
+
+
+# ------------------------------------------------ Das Skript selbst
+
+def load_script():
+    import importlib.util
+    path = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "tournament-migration-dryrun.py"
+    spec = importlib.util.spec_from_file_location("dryrun_script", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ScriptCursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, *_args):
+        return self
+
+    async def to_list(self, limit):
+        return self.rows[:limit]
+
+
+class ScriptCollection:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+        self.writes = 0
+
+    def find(self, query, _projection=None):
+        def hit(row):
+            for key, value in query.items():
+                if key == "$or":
+                    if not any(row.get(k) == v for option in value for k, v in option.items()):
+                        return False
+                elif row.get(key) != value:
+                    return False
+            return True
+        return ScriptCursor([row for row in self.rows if hit(row)])
+
+    async def insert_one(self, document):
+        self.writes += 1
+
+
+class ScriptDb:
+    def __init__(self, **collections):
+        self._collections = {
+            name: ScriptCollection(collections.get(name, ()))
+            for name in ("tournaments", "matches", "matches_v2", "tournament_stages",
+                         "tournament_registrations", "tournament_groups")
+        }
+
+    def __getattr__(self, name):
+        return self._collections[name]
+
+
+def test_the_script_produces_a_report_for_a_stored_tournament():
+    """Bevor das jemand auf echten Daten laufen lässt, muss es hier durchlaufen."""
+    import asyncio
+    script = load_script()
+    db = script.ReadOnlyDb(ScriptDb(
+        tournaments=[TOURNAMENT],
+        matches=SAME_TOURNAMENT_CLASSIC,
+        tournament_registrations=REGISTRATIONS,
+    ))
+
+    rows = asyncio.run(script.collect(db, limit=None, only=None))
+
+    assert len(rows) == 1
+    assert rows[0]["engine"] == "classic"
+    assert rows[0]["needs_migration"] is True
+    assert rows[0]["decided_count"] == 3
+    assert rows[0]["notices"], "Der Platzierungs-Hinweis muss im Bericht auftauchen"
+
+
+def test_the_script_cannot_write_even_if_someone_adds_a_write_later():
+    """Der Schreibschutz ist eine Eigenschaft des Codes, kein Versprechen im Kommentar."""
+    import asyncio
+    script = load_script()
+    inner = ScriptDb(tournaments=[TOURNAMENT])
+    db = script.ReadOnlyDb(inner)
+
+    with pytest.raises(script.ReadOnlyViolation):
+        asyncio.run(db.tournaments.insert_one({"id": "x"}))
+    assert inner.tournaments.writes == 0
+
+
+def test_the_script_can_be_pointed_at_a_single_tournament():
+    import asyncio
+    script = load_script()
+    db = script.ReadOnlyDb(ScriptDb(
+        tournaments=[TOURNAMENT, {**TOURNAMENT, "id": "t2", "slug": "anderes"}],
+        tournament_registrations=REGISTRATIONS,
+    ))
+
+    rows = asyncio.run(script.collect(db, limit=None, only="sommer-cup"))
+
+    assert [row["id"] for row in rows] == ["t1"]

--- a/scripts/tournament-migration-dryrun.py
+++ b/scripts/tournament-migration-dryrun.py
@@ -1,0 +1,210 @@
+"""Read-only survey of the stored tournaments before they are migrated.
+
+Run this on the server that holds the data. It reads, measures and reports. It
+cannot write: the database handle is wrapped so that any write method raises
+instead of executing, which makes "nothing was changed" a property of the code
+rather than a promise in a comment.
+
+    # Bestandsaufnahme und Vergleichsbasis erzeugen
+    python scripts/tournament-migration-dryrun.py --out vorher.json
+
+    # ... nach der Migration ...
+    python scripts/tournament-migration-dryrun.py --out nachher.json \
+        --compare vorher.json
+
+The report contains tournament titles, slugs and opaque registration ids - no
+member names, no e-mail addresses. It is meant to be shareable.
+
+Environment: the same MONGO_URL and DB_NAME the backend uses.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[1] / "backend"
+sys.path.insert(0, str(BACKEND))
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET", "dryrun-secret-with-at-least-32-characters")
+os.environ.setdefault("FRONTEND_URL", "http://localhost:3000")
+os.environ.setdefault("CORS_ORIGINS", "http://localhost:3000")
+
+from services.competition_read import load_competition_read_model  # noqa: E402
+from services.migration_dryrun import (  # noqa: E402
+    compare_reports,
+    summarize,
+    tournament_report,
+)
+
+
+WRITE_METHODS = {
+    "insert_one", "insert_many", "update_one", "update_many", "replace_one",
+    "delete_one", "delete_many", "find_one_and_update", "find_one_and_replace",
+    "find_one_and_delete", "bulk_write", "drop", "rename", "create_index",
+    "drop_index", "drop_indexes", "aggregate_raw_batches",
+}
+
+
+class ReadOnlyViolation(RuntimeError):
+    pass
+
+
+class ReadOnlyCollection:
+    """A collection that can be read and cannot be written."""
+
+    def __init__(self, collection):
+        self._collection = collection
+
+    def __getattr__(self, name):
+        if name in WRITE_METHODS:
+            raise ReadOnlyViolation(
+                f"Der Trockenlauf darf nicht schreiben (versucht: {name}). "
+                "Das ist ein Fehler im Skript, nicht in deinen Daten."
+            )
+        return getattr(self._collection, name)
+
+
+class ReadOnlyDb:
+    def __init__(self, db):
+        self._db = db
+
+    def __getattr__(self, name):
+        return ReadOnlyCollection(getattr(self._db, name))
+
+    def __getitem__(self, name):
+        return ReadOnlyCollection(self._db[name])
+
+
+async def collect(db, *, limit: int | None, only: str | None) -> list[dict]:
+    query: dict = {}
+    if only:
+        query = {"$or": [{"id": only}, {"slug": only}]}
+    cursor = db.tournaments.find(query, {"_id": 0}).sort("created_at", 1)
+    tournaments = await cursor.to_list(limit or 5000)
+
+    rows: list[dict] = []
+    for index, tournament in enumerate(tournaments, start=1):
+        tid = tournament.get("id")
+        if not tid:
+            continue
+        read_model = await load_competition_read_model(db, tid)
+        snapshot = read_model.structure_snapshot()
+        registrations = await db.tournament_registrations.find(
+            {"tournament_id": tid}, {"_id": 0}).to_list(1000)
+        groups = []
+        if tournament.get("format") == "groups":
+            groups = await db.tournament_groups.find(
+                {"tournament_id": tid}, {"_id": 0}).to_list(50)
+        rows.append(tournament_report(tournament, snapshot, registrations, groups=groups))
+        print(f"  [{index}/{len(tournaments)}] {tournament.get('title') or tid}", file=sys.stderr)
+    return rows
+
+
+def print_report(rows: list[dict]) -> None:
+    summary = summarize(rows)
+    print("\n=== Bestand ===")
+    print(f"Turniere gesamt:        {summary['tournaments']}")
+    for engine, count in summary["by_engine"].items():
+        print(f"  im Speicher {engine:<8} {count}")
+    print(f"Migration nötig:        {summary['needs_migration']}")
+    print(f"Davon bereit:           {summary['ready']}")
+    print(f"Mit Mangel:             {summary['blocked']}")
+
+    blocked = [row for row in rows if row.get("blockers")]
+    if blocked:
+        print("\n=== Mängel: das muss vorher jemand anfassen ===")
+        for code, count in summary["blockers"].items():
+            print(f"  {code:<34} {count}x")
+        for row in blocked:
+            print(f"\n  {row.get('title') or row['id']}  [{row.get('format')} · {row.get('status')}]")
+            print(f"    Speicher: {row.get('engine')} · {row['match_count']} Spiele, "
+                  f"{row['decided_count']} entschieden")
+            for blocker in row["blockers"]:
+                print(f"    - {blocker['detail']}")
+                print(f"      → {blocker['action']}")
+    else:
+        print("\nKeine Mängel gefunden.")
+
+    if summary.get("notices"):
+        # Bewusst getrennt: das betrifft fast jedes klassische Turnier und
+        # braucht eine Entscheidung, keine fünfzig Einzelkorrekturen.
+        print("\n=== Hinweise: eine Entscheidung, nicht fünfzig Korrekturen ===")
+        seen: dict[str, dict] = {}
+        for row in rows:
+            for notice in row.get("notices") or []:
+                seen.setdefault(notice["code"], notice)
+        for code, count in summary["notices"].items():
+            notice = seen[code]
+            print(f"\n  {count} Turnier(e): {notice['detail']}")
+            print(f"    → {notice['action']}")
+
+
+def print_comparison(result: dict) -> None:
+    print("\n=== Vergleich mit der Vorher-Aufnahme ===")
+    print(f"Verglichen:   {result['compared']}")
+    print(f"Unverändert:  {result['unchanged']}")
+    if result["new"]:
+        print(f"Neu dazu:     {len(result['new'])} (nicht Teil des Vergleichs)")
+
+    if result["equivalent"]:
+        print("\nErgebnis: deckungsgleich. Kein Turnier hat Ergebnisse, Tabelle "
+              "oder Platzierungen verändert.")
+        return
+
+    print(f"\nErgebnis: {len(result['changed'])} Turnier(e) weichen ab.")
+    for row in result["changed"]:
+        print(f"\n  {row.get('title') or row['id']}: {row['problem']}")
+        for difference in row["differences"][:12]:
+            print(f"    - {difference}")
+        if len(row["differences"]) > 12:
+            print(f"    ... und {len(row['differences']) - 12} weitere")
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", help="Bericht als JSON hierhin schreiben")
+    parser.add_argument("--compare", help="Gegen eine frühere Aufnahme vergleichen")
+    parser.add_argument("--limit", type=int, help="Nur die ersten N Turniere")
+    parser.add_argument("--tournament", help="Nur dieses Turnier (ID oder Slug)")
+    args = parser.parse_args()
+
+    for name in ("MONGO_URL", "DB_NAME"):
+        if not os.environ.get(name):
+            print(f"{name} ist nicht gesetzt. Bitte dieselben Werte wie das Backend verwenden.",
+                  file=sys.stderr)
+            return 2
+
+    from database import get_db
+
+    db = ReadOnlyDb(get_db())
+    print("Lese Turniere (nur lesend) ...", file=sys.stderr)
+    rows = await collect(db, limit=args.limit, only=args.tournament)
+    if not rows:
+        print("Keine Turniere gefunden.", file=sys.stderr)
+        return 1
+
+    report = {"version": 1, "summary": summarize(rows), "tournaments": rows}
+    print_report(rows)
+
+    exit_code = 0
+    if args.compare:
+        previous = json.loads(Path(args.compare).read_text(encoding="utf-8"))
+        result = compare_reports(previous, report)
+        report["comparison"] = result
+        print_comparison(result)
+        exit_code = 0 if result["equivalent"] else 1
+
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\nBericht geschrieben: {args.out}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
Vor der Zusammenführung wird gemessen statt vermutet. Dieses Werkzeug liest den gespeicherten Bestand, beschreibt ihn und legt eine Vergleichsbasis an — es schreibt nichts.

## Es kann nicht schreiben

Die Datenbankhülle lässt Schreibmethoden gar nicht erst durch; ein Versuch bricht mit einem Fehler ab, statt ausgeführt zu werden. Das ist eine Eigenschaft des Codes, kein Versprechen im Kommentar, und wird mitgetestet.

## Warum nicht über Match-IDs verglichen wird

Eine Migration schreibt neue Dokumente — die IDs ändern sich dabei. Ein Fingerabdruck darauf würde jedes Turnier als verändert melden und nichts beweisen.

Verglichen wird deshalb der **Inhalt**: wer hat in welcher Runde gegen wen gespielt, wer hat gewonnen, was sagt die Tabelle, wer steht auf welchem Platz. Das ist zugleich genau das, was ein Mitglied sehen würde — bleibt es gleich, hat sich für niemanden etwas geändert.

Der zentrale Test baut dasselbe Turnier zweimal, einmal je Speicher, und verlangt dieselben Werte. Fällt er, misst der Fingerabdruck den Speicher statt das Turnier, und der ganze Vergleich wäre wertlos.

## Der Fund

Beim Bauen ist aufgefallen, dass die beiden Engines **„wer ist Erster" unterschiedlich beantworten**:

- **Klassisch:** aus dem historischen Feld `final_position` — und gar nicht, wenn das Feld leer ist. Geschrieben wird es nirgends mehr, nur noch gelesen.
- **Graph:** immer aus der Tabelle abgeleitet.

Platzierungen speisen **Preise, die Turnier-Historie im Mitgliederprofil, die Sieger- und Podest-Abzeichen und die Saisonpunkte** (`prize_service`, `profile_references`, `registration_tournament_achievement_progress`, `placement_rows_for_structure`). Eine Migration, die die Quelle stillschweigend umstellt, würde alle vier für längst beendete Turniere neu beantworten — vermutlich erst bemerkt, wenn sich jemand über seine veränderte Profil-Historie wundert.

Das ist keine Kleinigkeit, die man beim Umzug nebenbei entscheidet. Deshalb meldet der Trockenlauf es, bevor etwas bewegt wird.

## Mängel und Hinweise sind getrennt

Ein **Mangel** ist ein Defekt in einem Turnier, den jemand anfassen muss — offene Spiele, K.-o.-Partie ohne Sieger, Turnier in beiden Speichern, kaputte Struktur.

Ein **Hinweis** betrifft fast jedes klassische Turnier und braucht **eine** Entscheidung statt fünfzig Einzelkorrekturen — der Platzierungsfall oben.

Würde man beides in einen Topf werfen, verschwänden drei echte Mängel unter fünfzig Routinezeilen.

## Bedienung

```bash
python scripts/tournament-migration-dryrun.py --out vorher.json
# ... nach der Migration ...
python scripts/tournament-migration-dryrun.py --out nachher.json --compare vorher.json
```

Exit-Code `0`, wenn jedes Turnier denselben Fingerabdruck hat, sonst `1` mit Auflistung, was abweicht. Details in [TOURNAMENT_MIGRATION_DRYRUN.md](TOURNAMENT_MIGRATION_DRYRUN.md).

## Datenschutz

Der Bericht enthält Turniertitel, Slugs und Anmelde-IDs — **keine Mitgliedsnamen, keine Adressen**. Auch das wird geprüft, damit er teilbar bleibt.

## Prüfung

- 724 Tests grün (+38), Coverage 44,06 %
- Das Skript wird gegen eine Fake-Datenbank durchgespielt, bevor es jemand auf echte Daten loslässt
- Der Schreibschutz wird explizit getestet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
