### PR TITLE
Trockenlauf: Wrapper für den Container und Zählung beider Speicher

### DIFF
--- a/TOURNAMENT_MIGRATION_DRYRUN.md
+++ b/TOURNAMENT_MIGRATION_DRYRUN.md
@@ -86,6 +86,23 @@ Quelle stillschweigend umstellt, würde alle vier für längst beendete Turniere
 beantworten. Deshalb steht die Entscheidung darüber vor der Migration und nicht
 danach.
 
+## Speicher insgesamt
+
+Am Ende zählt der Bericht beide Speicher komplett durch — Entwürfe und
+verwaiste Spiele eingeschlossen. Die Turnierliste beantwortet „muss etwas
+umziehen"; diese Zählung beantwortet die andere Frage: **liegt im klassischen
+Speicher überhaupt noch etwas**, das seiner Stilllegung im Weg steht.
+
+| Zustand | Bedeutung |
+| --- | --- |
+| `empty` | Der klassische Speicher ist leer |
+| `drafts_only` | Nur Entwürfe, keine gespielten Partien — die halten niemanden auf |
+| `in_use` | Es liegen echte Partien darin |
+
+Verwaiste Spiele — solche, deren Turnier es nicht mehr gibt — verhindern die
+Stilllegung ebenfalls, auch wenn sonst nichts gespielt wurde. Ungeklärtes
+schaltet man nicht einfach ab.
+
 ## Nach der Migration
 
 Denselben Lauf noch einmal, gegen die Vorher-Aufnahme:

--- a/TOURNAMENT_MIGRATION_DRYRUN.md
+++ b/TOURNAMENT_MIGRATION_DRYRUN.md
@@ -14,25 +14,38 @@ würde — wenn das gleich bleibt, hat sich für niemanden etwas geändert.
 
 ## Ausführen
 
-Auf dem Server, der die Daten hält, mit denselben `MONGO_URL` und `DB_NAME` wie
-das Backend:
+Im Verzeichnis der `docker-compose.yml` auf dem Server:
 
 ```bash
-python scripts/tournament-migration-dryrun.py --out vorher.json
+bash scripts/tournament-dryrun.sh                # Bericht in die Konsole
+bash scripts/tournament-dryrun.sh vorher.json    # zusätzlich als JSON ablegen
 ```
+
+**Warum ein Wrapper und nicht direkt `python3`:** MongoDB hat bewusst keinen
+veröffentlichten Port und ist nur im Docker-Netz erreichbar. Auf dem Host gibt es
+also weder eine Verbindung noch die Python-Abhängigkeiten des Backends. Der
+Wrapper startet den Lauf deshalb im Backend-Container, der beides schon hat.
 
 Das Skript kann nicht schreiben. Die Datenbankhülle lässt Schreibmethoden gar
 nicht erst durch — ein Schreibversuch bricht mit einem Fehler ab, statt
 ausgeführt zu werden. Das ist eine Eigenschaft des Codes, nicht ein Versprechen
 im Kommentar, und wird mitgetestet.
 
-Nützliche Schalter:
+### Direkter Aufruf
+
+Wer das Skript selbst startet (etwa lokal gegen eine Kopie), braucht `MONGO_URL`
+und `DB_NAME` in der Umgebung:
+
+```bash
+python3 scripts/tournament-migration-dryrun.py --out vorher.json
+```
 
 | Schalter | Wofür |
 | --- | --- |
 | `--tournament <id\|slug>` | Nur ein einzelnes Turnier ansehen |
 | `--limit N` | Nur die ersten N Turniere (für einen schnellen Blick) |
 | `--out datei.json` | Bericht als JSON ablegen |
+| `--json` | JSON nach stdout, Bericht nach stderr — für Umleitung in eine Datei |
 | `--compare vorher.json` | Gegen eine frühere Aufnahme vergleichen |
 
 ## Was im Bericht steht
@@ -78,7 +91,7 @@ danach.
 Denselben Lauf noch einmal, gegen die Vorher-Aufnahme:
 
 ```bash
-python scripts/tournament-migration-dryrun.py --out nachher.json --compare vorher.json
+bash scripts/tournament-dryrun.sh nachher.json vorher.json
 ```
 
 Der Exit-Code ist `0`, wenn jedes Turnier denselben Fingerabdruck hat, und `1`,

--- a/backend/services/migration_dryrun.py
+++ b/backend/services/migration_dryrun.py
@@ -346,6 +346,41 @@ def _short(value) -> str:
     return str(value)
 
 
+def census_verdict(census: dict) -> dict:
+    """Read a store census: is the classic store still holding anything?
+
+    The per-tournament survey only counts matches that belong to a tournament
+    that still exists and has really been played. This looks at the raw
+    collections instead, because the question for retiring the old store is a
+    different one: is there *anything* left in it - drafts and orphans included.
+    """
+    classic_total = int(census.get("matches") or 0)
+    orphans = int(census.get("orphaned_matches") or 0)
+    drafts = int(census.get("preview_matches") or 0)
+    real = max(0, classic_total - drafts)
+
+    if classic_total == 0:
+        state = "empty"
+        summary = "Der klassische Speicher ist leer."
+    elif real == 0:
+        state = "drafts_only"
+        summary = f"Im klassischen Speicher liegen nur {drafts} Entwürfe, keine gespielten Partien."
+    else:
+        state = "in_use"
+        summary = f"Im klassischen Speicher liegen {real} echte Partien."
+
+    return {
+        "state": state,
+        "summary": summary,
+        "classic_total": classic_total,
+        "classic_real": real,
+        "classic_drafts": drafts,
+        "orphaned_matches": orphans,
+        "graph_total": int(census.get("matches_v2") or 0),
+        "retirable": state in {"empty", "drafts_only"} and orphans == 0,
+    }
+
+
 def summarize(rows: list[dict]) -> dict:
     """The headline numbers of one dry run."""
     by_engine: dict[str, int] = {}

--- a/backend/tests/test_migration_dryrun_unit.py
+++ b/backend/tests/test_migration_dryrun_unit.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from services.competition_snapshot import build_structure_snapshot
 from services.migration_dryrun import (
+    census_verdict,
     compare_reports,
     fingerprint_differences,
     fingerprint_digest,
@@ -552,3 +553,88 @@ def test_json_mode_keeps_the_readable_report_out_of_stdout(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "Bestand" in captured.err
+
+
+# ------------------------------------------------ Speicher-Zählung
+
+def test_an_empty_classic_store_can_be_retired():
+    verdict = census_verdict({"matches": 0, "matches_v2": 120, "preview_matches": 0,
+                              "orphaned_matches": 0})
+
+    assert verdict["state"] == "empty"
+    assert verdict["retirable"] is True
+    assert "leer" in verdict["summary"]
+
+
+def test_drafts_alone_do_not_keep_the_old_store_alive():
+    """Ein Entwurf hat keine Ergebnisse - der hält niemanden auf."""
+    verdict = census_verdict({"matches": 12, "preview_matches": 12, "matches_v2": 40,
+                              "orphaned_matches": 0})
+
+    assert verdict["state"] == "drafts_only"
+    assert verdict["classic_real"] == 0
+    assert verdict["retirable"] is True
+
+
+def test_real_matches_keep_the_old_store_in_use():
+    verdict = census_verdict({"matches": 30, "preview_matches": 4, "matches_v2": 10,
+                              "orphaned_matches": 0})
+
+    assert verdict["state"] == "in_use"
+    assert verdict["classic_real"] == 26
+    assert verdict["retirable"] is False
+
+
+def test_orphans_block_retirement_even_when_nothing_is_played():
+    """Spiele ohne Turnier sind ungeklärt - die schaltet man nicht einfach ab."""
+    verdict = census_verdict({"matches": 5, "preview_matches": 5, "matches_v2": 10,
+                              "orphaned_matches": 5})
+
+    assert verdict["retirable"] is False
+
+
+def test_the_census_counts_both_stores_and_finds_orphans():
+    import asyncio
+    script = load_script()
+
+    class CensusCollection(ScriptCollection):
+        async def count_documents(self, query):
+            def hit(row):
+                for key, value in query.items():
+                    if isinstance(value, dict) and "$in" in value:
+                        if row.get(key) not in value["$in"]:
+                            return False
+                    elif row.get(key) != value:
+                        return False
+                return True
+            return sum(1 for row in self.rows if hit(row))
+
+        async def distinct(self, field):
+            return sorted({row.get(field) for row in self.rows if row.get(field)})
+
+    class CensusDb(ScriptDb):
+        def __init__(self, **collections):
+            super().__init__(**collections)
+            for name, rows in collections.items():
+                self._collections[name] = CensusCollection(rows)
+            for name in ("tournaments", "matches", "matches_v2", "tournament_stages"):
+                self._collections.setdefault(name, CensusCollection())
+                if not isinstance(self._collections[name], CensusCollection):
+                    self._collections[name] = CensusCollection(self._collections[name].rows)
+
+    db = script.ReadOnlyDb(CensusDb(
+        tournaments=[TOURNAMENT],
+        matches=[
+            {"id": "m1", "tournament_id": "t1", "is_preview": True},
+            {"id": "m2", "tournament_id": "geloescht", "is_preview": False},
+        ],
+        matches_v2=[{"id": "g1", "tournament_id": "t1"}],
+    ))
+
+    census = asyncio.run(script.store_census(db))
+
+    assert census["matches"] == 2
+    assert census["preview_matches"] == 1
+    assert census["matches_v2"] == 1
+    assert census["orphaned_matches"] == 1
+    assert census["orphaned_tournament_ids"] == ["geloescht"]

--- a/backend/tests/test_migration_dryrun_unit.py
+++ b/backend/tests/test_migration_dryrun_unit.py
@@ -512,3 +512,43 @@ def test_the_script_can_be_pointed_at_a_single_tournament():
     rows = asyncio.run(script.collect(db, limit=None, only="sommer-cup"))
 
     assert [row["id"] for row in rows] == ["t1"]
+
+
+def test_the_backend_package_is_found_in_a_checkout_and_in_the_image():
+    """Im Image liegt das Backend direkt unter /app, im Checkout in backend/.
+
+    Ein Werkzeug, das nur im Checkout startet, wird auf dem Server nicht benutzt.
+    """
+    script = load_script()
+    root = script._backend_root()
+
+    assert (root / "database.py").is_file()
+    assert root.name in {"backend", "app"}
+
+
+def test_a_missing_connection_points_at_the_wrapper(monkeypatch, capsys):
+    """Die Fehlermeldung muss sagen, was stattdessen zu tun ist."""
+    import asyncio
+    script = load_script()
+    monkeypatch.delenv("MONGO_URL", raising=False)
+    monkeypatch.setattr(sys, "argv", ["dryrun"])
+
+    code = asyncio.run(script.main())
+
+    assert code == 2
+    message = capsys.readouterr().err
+    assert "tournament-dryrun.sh" in message
+    assert "Docker" in message
+
+
+def test_json_mode_keeps_the_readable_report_out_of_stdout(monkeypatch, capsys):
+    """Sonst landet der Fließtext mit im JSON und die Datei ist unbrauchbar."""
+    script = load_script()
+    rows = [tournament_report(TOURNAMENT, legacy_snapshot(SAME_TOURNAMENT_CLASSIC), REGISTRATIONS)]
+
+    monkeypatch.setattr(script, "REPORT_STREAM", sys.stderr)
+    script.print_report(rows)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Bestand" in captured.err

--- a/scripts/tournament-dryrun.sh
+++ b/scripts/tournament-dryrun.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Read-only tournament survey, run inside the backend container.
+#
+# MongoDB is deliberately not reachable from the host - it has no published
+# port and lives only on the Compose network. So the survey runs where the
+# backend runs, with the same connection settings the backend already has.
+#
+#   bash scripts/tournament-dryrun.sh                 # Bericht in die Konsole
+#   bash scripts/tournament-dryrun.sh vorher.json     # zusätzlich als JSON
+#   bash scripts/tournament-dryrun.sh nachher.json vorher.json   # und vergleichen
+#
+# Nothing is written to the database; the script it starts cannot write.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail() { printf "\033[1;31m==> %s\033[0m\n" "$*" >&2; exit 1; }
+info() { printf "\033[1;36m==> %s\033[0m\n" "$*" >&2; }
+ok() { printf "\033[1;32m==> %s\033[0m\n" "$*" >&2; }
+
+OUT_FILE="${1:-}"
+COMPARE_FILE="${2:-}"
+
+command -v docker >/dev/null || fail "docker wurde nicht gefunden."
+docker compose ps backend >/dev/null 2>&1 || fail \
+  "Der Backend-Dienst ist über docker compose nicht erreichbar. Im Verzeichnis der docker-compose.yml ausführen."
+
+ARGS=(--json)
+MOUNTS=(-v "${ROOT}/scripts:/app/scripts:ro")
+
+if [ -n "$COMPARE_FILE" ]; then
+  [ -f "$COMPARE_FILE" ] || fail "Vergleichsdatei nicht gefunden: ${COMPARE_FILE}"
+  COMPARE_ABS="$(cd "$(dirname "$COMPARE_FILE")" && pwd)/$(basename "$COMPARE_FILE")"
+  MOUNTS+=(-v "${COMPARE_ABS}:/app/vergleich.json:ro")
+  ARGS+=(--compare /app/vergleich.json)
+  info "Vergleiche gegen ${COMPARE_FILE}"
+fi
+
+info "Starte Trockenlauf im Backend-Container (nur lesend) ..."
+
+# --no-deps: MongoDB laeuft bereits; der Lauf soll nichts neu starten.
+# Der Bericht kommt ueber stderr, das JSON ueber stdout - deshalb laesst sich
+# beides trennen, ohne im Container ein beschreibbares Verzeichnis zu brauchen.
+set +e
+if [ -n "$OUT_FILE" ]; then
+  docker compose run --rm --no-deps -T \
+    "${MOUNTS[@]}" \
+    -e PYTHONPATH=/app \
+    backend python /app/scripts/tournament-migration-dryrun.py "${ARGS[@]}" > "$OUT_FILE"
+  STATUS=$?
+else
+  docker compose run --rm --no-deps -T \
+    "${MOUNTS[@]}" \
+    -e PYTHONPATH=/app \
+    backend python /app/scripts/tournament-migration-dryrun.py "${ARGS[@]}" > /dev/null
+  STATUS=$?
+fi
+set -e
+
+if [ -n "$OUT_FILE" ] && [ -s "$OUT_FILE" ]; then
+  ok "Bericht gespeichert: ${OUT_FILE}"
+elif [ -n "$OUT_FILE" ]; then
+  rm -f "$OUT_FILE"
+  fail "Es wurde kein Bericht erzeugt - siehe Meldungen oben."
+fi
+
+if [ -n "$COMPARE_FILE" ] && [ "$STATUS" -ne 0 ]; then
+  fail "Der Vergleich hat Abweichungen gefunden (siehe oben)."
+fi
+exit "$STATUS"

--- a/scripts/tournament-migration-dryrun.py
+++ b/scripts/tournament-migration-dryrun.py
@@ -50,6 +50,7 @@ os.environ.setdefault("CORS_ORIGINS", "http://localhost:3000")
 
 from services.competition_read import load_competition_read_model  # noqa: E402
 from services.migration_dryrun import (  # noqa: E402
+    census_verdict,
     compare_reports,
     summarize,
     tournament_report,
@@ -126,6 +127,45 @@ REPORT_STREAM = sys.stdout
 
 def say(text: str = "") -> None:
     print(text, file=REPORT_STREAM)
+
+
+async def store_census(db) -> dict:
+    """Count what each store holds at all - drafts and orphans included.
+
+    The per-tournament survey answers "does anything have to move". This answers
+    the other question, the one that decides whether the old store can be shut
+    off: is there anything left in it that nobody is looking at any more.
+    """
+    tournament_ids = set(await db.tournaments.distinct("id"))
+    referenced = set(await db.matches.distinct("tournament_id"))
+    orphaned_ids = [item for item in referenced - tournament_ids if item]
+
+    orphaned = 0
+    if orphaned_ids:
+        orphaned = await db.matches.count_documents({"tournament_id": {"$in": orphaned_ids}})
+
+    return {
+        "matches": await db.matches.count_documents({}),
+        "preview_matches": await db.matches.count_documents({"is_preview": True}),
+        "matches_v2": await db.matches_v2.count_documents({}),
+        "stages": await db.tournament_stages.count_documents({}),
+        "orphaned_matches": orphaned,
+        "orphaned_tournament_ids": sorted(orphaned_ids)[:20],
+    }
+
+
+def print_census(verdict: dict) -> None:
+    say("\n=== Speicher insgesamt ===")
+    say(f"Klassisch (matches):    {verdict['classic_total']} "
+        f"({verdict['classic_real']} echt, {verdict['classic_drafts']} Entwürfe)")
+    say(f"Graph (matches_v2):     {verdict['graph_total']}")
+    if verdict["orphaned_matches"]:
+        say(f"Verwaist:               {verdict['orphaned_matches']} "
+            "(gehören zu keinem Turnier mehr)")
+    say(f"\n{verdict['summary']}")
+    if verdict["retirable"]:
+        say("→ Der klassische Speicher hält nichts mehr. Er kann stillgelegt werden, "
+            "sobald keine neuen Turniere mehr dort starten.")
 
 
 def print_report(rows: list[dict]) -> None:
@@ -221,8 +261,10 @@ async def main() -> int:
         print("Keine Turniere gefunden.", file=sys.stderr)
         return 1
 
-    report = {"version": 1, "summary": summarize(rows), "tournaments": rows}
+    census = census_verdict(await store_census(db))
+    report = {"version": 2, "summary": summarize(rows), "census": census, "tournaments": rows}
     print_report(rows)
+    print_census(census)
 
     exit_code = 0
     if args.compare:

--- a/scripts/tournament-migration-dryrun.py
+++ b/scripts/tournament-migration-dryrun.py
@@ -26,8 +26,22 @@ import os
 import sys
 from pathlib import Path
 
-BACKEND = Path(__file__).resolve().parents[1] / "backend"
-sys.path.insert(0, str(BACKEND))
+def _backend_root() -> Path:
+    """Find the backend package, in the repo as well as inside the container.
+
+    In a checkout it sits next to this script's parent. In the deployed image the
+    backend *is* the working directory, because the image is built from the
+    backend folder alone. Detecting both means one command works in both places.
+    """
+    here = Path(__file__).resolve()
+    candidates = [here.parents[1] / "backend", here.parents[1], Path("/app")]
+    for candidate in candidates:
+        if (candidate / "database.py").is_file():
+            return candidate
+    return candidates[0]
+
+
+sys.path.insert(0, str(_backend_root()))
 
 os.environ.setdefault("APP_ENV", "development")
 os.environ.setdefault("JWT_SECRET", "dryrun-secret-with-at-least-32-characters")
@@ -105,77 +119,96 @@ async def collect(db, *, limit: int | None, only: str | None) -> list[dict]:
     return rows
 
 
+# Der lesbare Bericht geht nach stdout - ausser bei --json, dann macht er dort
+# Platz für die maschinenlesbare Ausgabe und wandert nach stderr.
+REPORT_STREAM = sys.stdout
+
+
+def say(text: str = "") -> None:
+    print(text, file=REPORT_STREAM)
+
+
 def print_report(rows: list[dict]) -> None:
     summary = summarize(rows)
-    print("\n=== Bestand ===")
-    print(f"Turniere gesamt:        {summary['tournaments']}")
+    say("\n=== Bestand ===")
+    say(f"Turniere gesamt:        {summary['tournaments']}")
     for engine, count in summary["by_engine"].items():
-        print(f"  im Speicher {engine:<8} {count}")
-    print(f"Migration nötig:        {summary['needs_migration']}")
-    print(f"Davon bereit:           {summary['ready']}")
-    print(f"Mit Mangel:             {summary['blocked']}")
+        say(f"  im Speicher {engine:<8} {count}")
+    say(f"Migration nötig:        {summary['needs_migration']}")
+    say(f"Davon bereit:           {summary['ready']}")
+    say(f"Mit Mangel:             {summary['blocked']}")
 
     blocked = [row for row in rows if row.get("blockers")]
     if blocked:
-        print("\n=== Mängel: das muss vorher jemand anfassen ===")
+        say("\n=== Mängel: das muss vorher jemand anfassen ===")
         for code, count in summary["blockers"].items():
-            print(f"  {code:<34} {count}x")
+            say(f"  {code:<34} {count}x")
         for row in blocked:
-            print(f"\n  {row.get('title') or row['id']}  [{row.get('format')} · {row.get('status')}]")
-            print(f"    Speicher: {row.get('engine')} · {row['match_count']} Spiele, "
-                  f"{row['decided_count']} entschieden")
+            say(f"\n  {row.get('title') or row['id']}  [{row.get('format')} · {row.get('status')}]")
+            say(f"    Speicher: {row.get('engine')} · {row['match_count']} Spiele, "
+                f"{row['decided_count']} entschieden")
             for blocker in row["blockers"]:
-                print(f"    - {blocker['detail']}")
-                print(f"      → {blocker['action']}")
+              say(f"    - {blocker['detail']}")
+              say(f"      → {blocker['action']}")
     else:
-        print("\nKeine Mängel gefunden.")
+        say("\nKeine Mängel gefunden.")
 
     if summary.get("notices"):
         # Bewusst getrennt: das betrifft fast jedes klassische Turnier und
         # braucht eine Entscheidung, keine fünfzig Einzelkorrekturen.
-        print("\n=== Hinweise: eine Entscheidung, nicht fünfzig Korrekturen ===")
+        say("\n=== Hinweise: eine Entscheidung, nicht fünfzig Korrekturen ===")
         seen: dict[str, dict] = {}
         for row in rows:
             for notice in row.get("notices") or []:
-                seen.setdefault(notice["code"], notice)
+              seen.setdefault(notice["code"], notice)
         for code, count in summary["notices"].items():
             notice = seen[code]
-            print(f"\n  {count} Turnier(e): {notice['detail']}")
-            print(f"    → {notice['action']}")
+            say(f"\n  {count} Turnier(e): {notice['detail']}")
+            say(f"    → {notice['action']}")
 
 
 def print_comparison(result: dict) -> None:
-    print("\n=== Vergleich mit der Vorher-Aufnahme ===")
-    print(f"Verglichen:   {result['compared']}")
-    print(f"Unverändert:  {result['unchanged']}")
+    say("\n=== Vergleich mit der Vorher-Aufnahme ===")
+    say(f"Verglichen:   {result['compared']}")
+    say(f"Unverändert:  {result['unchanged']}")
     if result["new"]:
-        print(f"Neu dazu:     {len(result['new'])} (nicht Teil des Vergleichs)")
+        say(f"Neu dazu:     {len(result['new'])} (nicht Teil des Vergleichs)")
 
     if result["equivalent"]:
-        print("\nErgebnis: deckungsgleich. Kein Turnier hat Ergebnisse, Tabelle "
-              "oder Platzierungen verändert.")
+        say("\nErgebnis: deckungsgleich. Kein Turnier hat Ergebnisse, Tabelle "
+            "oder Platzierungen verändert.")
         return
 
-    print(f"\nErgebnis: {len(result['changed'])} Turnier(e) weichen ab.")
+    say(f"\nErgebnis: {len(result['changed'])} Turnier(e) weichen ab.")
     for row in result["changed"]:
-        print(f"\n  {row.get('title') or row['id']}: {row['problem']}")
+        say(f"\n  {row.get('title') or row['id']}: {row['problem']}")
         for difference in row["differences"][:12]:
-            print(f"    - {difference}")
+            say(f"    - {difference}")
         if len(row["differences"]) > 12:
-            print(f"    ... und {len(row['differences']) - 12} weitere")
+            say(f"    ... und {len(row['differences']) - 12} weitere")
 
 
 async def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", help="Bericht als JSON hierhin schreiben")
+    parser.add_argument("--json", action="store_true",
+                        help="JSON nach stdout, Bericht nach stderr - zum Umleiten in eine Datei")
     parser.add_argument("--compare", help="Gegen eine frühere Aufnahme vergleichen")
     parser.add_argument("--limit", type=int, help="Nur die ersten N Turniere")
     parser.add_argument("--tournament", help="Nur dieses Turnier (ID oder Slug)")
     args = parser.parse_args()
 
+    if args.json:
+        # Im Container gibt es kein beschreibbares Verzeichnis. Über stdout kommt
+        # der Bericht auch ohne eingehängtes Volume heraus.
+        globals()["REPORT_STREAM"] = sys.stderr
+
     for name in ("MONGO_URL", "DB_NAME"):
         if not os.environ.get(name):
-            print(f"{name} ist nicht gesetzt. Bitte dieselben Werte wie das Backend verwenden.",
+            print(f"{name} ist nicht gesetzt.\n"
+                  "Das Backend läuft in Docker; MongoDB ist absichtlich nur im Docker-Netz "
+                  "erreichbar. Nutze bitte scripts/tournament-dryrun.sh - das startet den "
+                  "Lauf im Backend-Container mit den richtigen Werten.",
                   file=sys.stderr)
             return 2
 
@@ -202,7 +235,9 @@ async def main() -> int:
     if args.out:
         Path(args.out).write_text(
             json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
-        print(f"\nBericht geschrieben: {args.out}")
+        say(f"\nBericht geschrieben: {args.out}")
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
     return exit_code
 
 


### PR DESCRIPTION
Nachtrag zu #170 — beides beim ersten echten Lauf auf dem Server aufgefallen. Der Fix zu #170 kam zu spät und ist dort nicht mitgemergt worden, deshalb ist er hier mit dabei.

## Der Container

Das Backend läuft in Docker, und MongoDB hat **bewusst keinen veröffentlichten Port** — es ist nur im Compose-Netz erreichbar. Auf dem Host gibt es also weder eine Verbindung noch die Python-Abhängigkeiten des Backends. Die Anleitung „`python scripts/...` auf dem Server ausführen" konnte dort gar nicht funktionieren; sie endete mit `MONGO_URL ist nicht gesetzt`.

Ein Wrapper startet den Lauf jetzt dort, wo das Backend läuft:

```bash
bash scripts/tournament-dryrun.sh                # Bericht in die Konsole
bash scripts/tournament-dryrun.sh vorher.json    # zusätzlich als JSON
bash scripts/tournament-dryrun.sh nachher.json vorher.json   # und vergleichen
```

Damit das aufgeht, drei Anpassungen:

- Das Skript findet das Backend-Paket in **beiden Layouts** — im Checkout unter `backend/`, im Image direkt unter `/app`, weil das Image nur aus dem Backend-Ordner gebaut wird. Ein Werkzeug, das nur im Checkout startet, wird auf dem Server nicht benutzt.
- `--json` schickt das JSON nach stdout und den lesbaren Bericht nach stderr. Der Container ist `read_only`; so kommt der Bericht heraus, ohne dass ein beschreibbares Verzeichnis eingehängt werden muss.
- Die Fehlermeldung bei fehlender Verbindung sagt jetzt, **was stattdessen zu tun ist**, statt nur festzustellen, dass etwas fehlt.

## Die Zählung beider Speicher

Der erste echte Lauf hat ergeben: **kein einziges Turnier muss migriert werden.** Vier Turniere, drei im Graph-Speicher, eines ohne Spiele, keine Mängel.

Damit wird sofort die nächste Frage wichtig, die der Bericht bisher nicht beantwortet hat: liegt im klassischen Speicher überhaupt noch etwas? Die Turnierliste zählt nur gespielte Partien lebender Turniere. Die neue Zählung sieht in die Sammlungen selbst:

| Zustand | Bedeutung |
| --- | --- |
| `empty` | Der klassische Speicher ist leer |
| `drafts_only` | Nur Entwürfe, keine gespielten Partien — die halten niemanden auf |
| `in_use` | Es liegen echte Partien darin |

Verwaiste Spiele — solche, deren Turnier es nicht mehr gibt — verhindern die Stilllegung ebenfalls, auch wenn sonst nichts gespielt wurde. Ungeklärtes schaltet man nicht ab.

## Prüfung

- 732 Tests grün (+8), alle Gates sauber
- Die Zählung wird gegen eine Fake-Datenbank durchgespielt, inklusive Verwaisten-Erkennung
- `bash -n` über alle Skripte

🤖 Generated with [Claude Code](https://claude.com/claude-code)
