### PR TITLE
Turniere: Beschriftungen, Spieltage und brauchbare Vorgaben

### DIFF
--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -250,6 +250,21 @@ def _can_create_initial_legacy_preview(tournament: dict) -> bool:
     return 0 < _estimate_legacy_preview_matches(tournament) <= MAX_INITIAL_PREVIEW_MATCHES
 
 
+GROUP_TARGET_SIZE = 4
+
+
+def _default_group_count(tournament: dict) -> int:
+    """How many groups a group stage starts with, from the field size.
+
+    A fixed default of four turned eight participants into four pairs - four
+    "groups" of two, where every group is decided by a single match. Aiming for
+    groups of about four keeps a group stage what it is: a few matches inside
+    each group before anyone advances.
+    """
+    size = max(2, int(tournament.get("max_participants") or 0) or 2)
+    return max(1, min(size // GROUP_TARGET_SIZE, size // 2))
+
+
 def _can_create_initial_stage_preview(tournament: dict) -> bool:
     capability = find_format_capability(tournament.get("format"))
     if not capability or capability.initial_preview_engine != "stage":
@@ -553,7 +568,7 @@ def _stage_defaults_for_tournament_format(tournament: dict, body: TournamentBrac
     settings.setdefault("min_players", 2)
     if stage_type == "round_robin_groups":
         # Eine Gruppe ist ein Round Robin, mehrere sind eine Gruppenphase.
-        settings.setdefault("group_count", 4 if fmt == "groups" else 1)
+        settings.setdefault("group_count", _default_group_count(tournament) if fmt == "groups" else 1)
     settings.setdefault("qualifiers_per_match", 2 if match_type == "ffa" else 1)
     settings.setdefault("duration_minutes", int(tournament.get("match_duration_minutes") or 30))
     settings.setdefault("score_type", "points")

--- a/backend/services/custom_bracket.py
+++ b/backend/services/custom_bracket.py
@@ -24,7 +24,7 @@ from typing import Any
 ASSIGNMENT_RE = re.compile(r"^(?P<key>[A-Za-z0-9_.-]+)\s*=\s*\[(?P<slots>.*)\]\s*$")
 SECTION_RE = re.compile(r"^\[(?P<section>[A-Za-z0-9_. -]+)\]\s*$")
 SOURCE_RE = re.compile(r"^(?P<flow>[WLR]):(?P<match>[A-Za-z0-9_.-]+):(?P<rank>[1-9][0-9]*)$")
-ROUND_RE = re.compile(r"\b(?:round|runde)\s+([0-9]+)\b", re.IGNORECASE)
+ROUND_RE = re.compile(r"\b(?:round|runde|spieltag)\s+([0-9]+)\b", re.IGNORECASE)
 
 
 class BracketSchemaError(ValueError):
@@ -410,13 +410,16 @@ def _auto_groups_schema(slot_count: int, group_count: int) -> str:
     any result - so it fits the declarative schema without a dynamic generator.
     """
     groups = distribute_into_groups(slot_count, group_count)
+    # Eine einzige Gruppe ist keine Gruppenphase, sondern ein Round Robin. Sie
+    # bekommt deshalb keinen Gruppennamen - sonst stünde über jedem Spielplan
+    # ein "Gruppe A", das sich von keiner Gruppe B unterscheidet.
+    single = len(groups) == 1
     lines: list[str] = []
     key_index = 0
     for number, seeds in enumerate(groups, start=1):
-        label = group_label(number)
-        lines.append(f"[{group_section(number)}]")
+        lines.append(f"[{'round_robin' if single else group_section(number)}]")
         for matchday, pairs in enumerate(_round_robin_rounds(seeds), start=1):
-            lines.append(f"# Gruppe {label} - Runde {matchday}")
+            lines.append(f"# Spieltag {matchday}")
             for left, right in pairs:
                 key = _match_key(key_index)
                 key_index += 1
@@ -440,7 +443,7 @@ def _auto_league_schema(slot_count: int) -> str:
     lines = ["[LIGA]"]
     key_index = 0
     for matchday, pairs in enumerate(first_leg + return_leg, start=1):
-        lines.append(f"# Runde {matchday}")
+        lines.append(f"# Spieltag {matchday}")
         for home, away in pairs:
             key = _match_key(key_index)
             key_index += 1

--- a/frontend/src/lib/tournamentLabels.js
+++ b/frontend/src/lib/tournamentLabels.js
@@ -146,7 +146,13 @@ export const BRACKET_SECTION_LABELS = {
   grand_final: "Großes Finale",
   bronze: "Spiel um Platz 3",
   round_robin: "Spieltage",
+  LIGA: "Spieltage",
+  swiss: "Schweizer Runden",
 };
+
+// Gruppen heißen im Turnierbaum group_A, group_B … - so findet die
+// Gruppentabelle ihre Spiele. Angezeigt wird das nicht.
+const GROUP_SECTION_RE = /^group_([A-Za-z0-9]+)$/;
 
 export const DEVICE_TYPE_LABELS = {
   switch: "Switch",
@@ -202,7 +208,10 @@ export function formatRegistrationStatus(value) {
 }
 
 export function formatBracketSection(value) {
-  return BRACKET_SECTION_LABELS[value] || value || "Turnierbaum";
+  if (BRACKET_SECTION_LABELS[value]) return BRACKET_SECTION_LABELS[value];
+  const group = GROUP_SECTION_RE.exec(String(value || ""));
+  if (group) return `Gruppe ${group[1].toUpperCase()}`;
+  return value || "Turnierbaum";
 }
 
 export function formatDeviceType(value) {

--- a/frontend/src/lib/tournamentLabels.js
+++ b/frontend/src/lib/tournamentLabels.js
@@ -1,6 +1,6 @@
 export const TOURNAMENT_FORMAT_LABELS = {
-  single_elim: "Einzelausscheidung",
-  double_elim: "Doppelausscheidung",
+  single_elim: "Single Elimination",
+  double_elim: "Double Elimination",
   round_robin: "Jeder gegen jeden",
   swiss: "Schweizer System",
   groups: "Gruppenphase",
@@ -29,14 +29,14 @@ export const TOURNAMENT_FORMAT_OPTIONS = [
 ];
 
 export const STAGE_TYPE_LABELS = {
-  single_elimination: "Einzelausscheidung",
-  double_elimination: "Doppelausscheidung",
+  single_elimination: "Single Elimination",
+  double_elimination: "Double Elimination",
   custom_bracket: "Freier Turnierbaum",
   round_robin_groups: "Jeder-gegen-jeden-Gruppen",
   swiss: "Schweizer System",
   league: "Liga",
   simple: "Einzelrunde",
-  ffa_single_elimination: "Mehrspieler-Einzelausscheidung",
+  ffa_single_elimination: "FFA Single Elimination",
   ffa_custom_bracket: "Mehrspieler freier Turnierbaum",
   ffa_league: "Mehrspieler-Liga",
 };
@@ -136,14 +136,14 @@ export const STAFF_SCOPE_OPTIONS = [
 ];
 
 export const BRACKET_SECTION_LABELS = {
-  WB: "Siegerbaum",
-  LB: "Hoffnungsbaum",
-  GF: "Großes Finale",
+  WB: "Winner Bracket",
+  LB: "Loser Bracket",
+  GF: "Grand Final",
   MAIN: "Hauptfeld",
   FINAL: "Finale",
-  winner: "Siegerbaum",
-  loser: "Hoffnungsbaum",
-  grand_final: "Großes Finale",
+  winner: "Winner Bracket",
+  loser: "Loser Bracket",
+  grand_final: "Grand Final",
   bronze: "Spiel um Platz 3",
   round_robin: "Spieltage",
   LIGA: "Spieltage",
@@ -226,9 +226,8 @@ export function formatRoundName(value, number) {
   if (!value) return number ? `Runde ${number}` : "Runde";
   return String(value)
     .replace(/^Round\b/i, "Runde")
-    .replace(/^Winner Final$/i, "Sieger-Finale")
-    .replace(/^Loser Final$/i, "Hoffnungs-Finale")
-    .replace(/^Grand Final$/i, "Großes Finale")
+    .replace(/^Winner Final$/i, "Winner Final")
+    .replace(/^Loser Final$/i, "Loser Final")
     .replace(/^Bronze Match$/i, "Spiel um Platz 3");
 }
 

--- a/frontend/src/lib/tournamentLabels.test.js
+++ b/frontend/src/lib/tournamentLabels.test.js
@@ -3,10 +3,17 @@ import { describe, expect, it } from "vitest";
 import { formatBracketSection } from "./tournamentLabels";
 
 describe("formatBracketSection", () => {
-  it("benennt die klassischen Baumteile auf Deutsch", () => {
-    expect(formatBracketSection("WB")).toBe("Siegerbaum");
-    expect(formatBracketSection("LB")).toBe("Hoffnungsbaum");
-    expect(formatBracketSection("GF")).toBe("Großes Finale");
+  it("nutzt die eingefuehrten eSports-Begriffe statt Uebersetzungen", () => {
+    expect(formatBracketSection("WB")).toBe("Winner Bracket");
+    expect(formatBracketSection("LB")).toBe("Loser Bracket");
+    expect(formatBracketSection("GF")).toBe("Grand Final");
+    expect(formatBracketSection("winner")).toBe("Winner Bracket");
+    expect(formatBracketSection("loser")).toBe("Loser Bracket");
+  });
+
+  it("beschriftet Round Robin als Spieltage statt als Gruppe", () => {
+    expect(formatBracketSection("round_robin")).toBe("Spieltage");
+    expect(formatBracketSection("LIGA")).toBe("Spieltage");
   });
 
   it("übersetzt die Gruppenabschnitte, statt group_A anzuzeigen", () => {

--- a/frontend/src/lib/tournamentLabels.test.js
+++ b/frontend/src/lib/tournamentLabels.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { formatBracketSection } from "./tournamentLabels";
+
+describe("formatBracketSection", () => {
+  it("benennt die klassischen Baumteile auf Deutsch", () => {
+    expect(formatBracketSection("WB")).toBe("Siegerbaum");
+    expect(formatBracketSection("LB")).toBe("Hoffnungsbaum");
+    expect(formatBracketSection("GF")).toBe("Großes Finale");
+  });
+
+  it("übersetzt die Gruppenabschnitte, statt group_A anzuzeigen", () => {
+    // group_A ist der Name, unter dem die Gruppentabelle ihre Spiele findet -
+    // sehen soll ihn niemand.
+    expect(formatBracketSection("group_A")).toBe("Gruppe A");
+    expect(formatBracketSection("group_b")).toBe("Gruppe B");
+    expect(formatBracketSection("group_12")).toBe("Gruppe 12");
+  });
+
+  it("benennt Liga und Schweizer System", () => {
+    expect(formatBracketSection("LIGA")).toBe("Spieltage");
+    expect(formatBracketSection("swiss")).toBe("Schweizer Runden");
+  });
+
+  it("zeigt Unbekanntes unverändert statt es zu verschlucken", () => {
+    expect(formatBracketSection("EIGENER_ABSCHNITT")).toBe("EIGENER_ABSCHNITT");
+    expect(formatBracketSection("")).toBe("Turnierbaum");
+    expect(formatBracketSection(null)).toBe("Turnierbaum");
+  });
+
+  it("verwechselt ähnliche Namen nicht mit Gruppen", () => {
+    expect(formatBracketSection("group")).toBe("group");
+    expect(formatBracketSection("group_")).toBe("group_");
+  });
+});

--- a/frontend/src/pages/admin/AdminTournamentEditPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.jsx
@@ -19,6 +19,8 @@ import { gameOptionLabel } from "@/lib/gameLabels";
 import { RULE_PRESETS, ruleModeSummary, rulePresetKey, rulePresetWarnings } from "@/lib/tournamentRulePresets";
 import {
   REGISTRATION_STATUS_OPTIONS,
+  STAGE_TYPE_OPTIONS,
+  TOURNAMENT_FORMAT_OPTIONS,
   STAFF_ROLE_OPTIONS,
   STAFF_SCOPE_OPTIONS,
   STAGE_STATUS_OPTIONS,
@@ -45,21 +47,6 @@ const TOURNAMENT_STATUS_OPTIONS = [
 ];
 const OPERATIONAL_STATUS_VALUES = new Set(["check_in", "live", "paused", "completed"]);
 
-const TOURNAMENT_FORMAT_OPTIONS = [
-  ["single_elim", "Einzelausscheidung"],
-  ["double_elim", "Doppelausscheidung"],
-  ["round_robin", "Jeder gegen jeden"],
-  ["swiss", "Schweizer System"],
-  ["groups", "Gruppen"],
-  ["ffa", "Mehrspieler frei"],
-  ["battle_royale", "Überlebensmodus"],
-  ["league", "Liga"],
-  ["time_trial", "Zeitfahren"],
-  ["grand_prix", "Rennserie"],
-  ["custom_bracket", "Freier Turnierbaum"],
-  ["ffa_custom_bracket", "Mehrspieler freier Turnierbaum"],
-];
-
 const TEAM_MODE_OPTIONS = [["solo", "Einzelspieler"], ["team", "Team"]];
 const SEEDING_OPTIONS = [["random", "Zufall"], ["manual", "Manuell"], ["ranking", "Ranking"]];
 const VISIBILITY_OPTIONS = [["public", "Öffentlich"], ["community", "Community"], ["members", "Vereinsmitglieder"], ["internal", "Intern"]];
@@ -77,18 +64,6 @@ const TOURNAMENT_SEASON_WEIGHT_OPTIONS = [
   ["0", "Keine Jahreswertung (x0.00)"],
 ];
 
-const STAGE_TYPES = [
-  ["single_elimination", "Einzelausscheidung"],
-  ["double_elimination", "Doppelausscheidung"],
-  ["custom_bracket", "Freier Turnierbaum"],
-  ["round_robin_groups", "Jeder-gegen-jeden-Gruppen"],
-  ["swiss", "Schweizer System"],
-  ["league", "Liga"],
-  ["simple", "Einzelrunde"],
-  ["ffa_single_elimination", "Mehrspieler-Einzelausscheidung"],
-  ["ffa_custom_bracket", "Mehrspieler freier Turnierbaum"],
-  ["ffa_league", "Mehrspieler-Liga"],
-];
 const DEFAULT_FFA_SCHEMA = `[WB]
 # Runde 1
 A=[1,2,3,4]
@@ -101,7 +76,12 @@ C=[W:A:1,W:A:2,W:B:1,W:B:2]
 # Runde 1
 LA=[L:A:1,L:A:2,L:B:1,L:B:2]`;
 const CUSTOM_STAGE_TYPES = new Set(["custom_bracket", "ffa_custom_bracket"]);
-const AUTO_STAGE_TYPES = new Set(["single_elimination", "double_elimination", "custom_bracket", "ffa_custom_bracket"]);
+// Strukturen, die das Backend aus dem Format bauen kann. Schweizer Runden
+// fehlen hier bewusst: die entstehen einzeln über "Schweizer Runde".
+const AUTO_STAGE_TYPES = new Set([
+  "single_elimination", "double_elimination", "custom_bracket", "ffa_custom_bracket",
+  "round_robin_groups", "league", "simple",
+]);
 const FFA_STAGE_TYPES = new Set(["simple", "ffa_single_elimination", "ffa_custom_bracket", "ffa_league"]);
 const BRONZE_FORMATS = new Set(["single_elim"]);
 const MATCH_SECTION_ORDER = ["WB", "winner", "MAIN", "main", "LB", "loser", "BRONZE", "bronze", "GF", "grand_final", "FINAL", "final", "round_robin"];
@@ -875,7 +855,7 @@ export default function AdminTournamentEditPage() {
       {activeTab === "bracket" && bracket && (
         <div className="bg-[#0A0A0A] rounded-sm p-4 border border-white/10">
           {(bracket.matches?.length || 0) + (bracket.matches_v2?.length || 0) === 0 ? (
-            <div className="text-center py-16 text-white/40 font-display tracking-widest">TURNIERBAUM NICHT GENERIERT</div>
+            <EmptyBracketNotice tournament={t} />
           ) : (
             <BracketTree data={bracket} />
           )}
@@ -1129,7 +1109,7 @@ function TournamentStagesPanel({ tournamentId, stages, matches, registrations, s
           {createOpen && (
             <form onSubmit={createStage} className="border-t border-white/10 p-5 grid md:grid-cols-3 gap-3">
               <Fld label="Name" value={form.name} onChange={(v)=>set("name", v)} testId="stage-new-name" />
-              <SelectField label="Struktur-Typ" value={form.stage_type} onChange={setStageType} options={STAGE_TYPES} />
+              <SelectField label="Struktur-Typ" value={form.stage_type} onChange={setStageType} options={STAGE_TYPE_OPTIONS} />
               <div className="block">
                 <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">Spieltyp</div>
                 <div className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-white/70">{formatMatchType(form.match_type)}</div>
@@ -1338,7 +1318,7 @@ function StageCard({ tournamentId, stage, matches, regById, stations = [], tourn
             <div className="grid sm:grid-cols-2 gap-3">
               <Fld label="Name" value={form.name} onChange={(v)=>set("name", v)} testId={`stage-name-${stage.id}`} />
               <SelectField label="Status" value={form.status} onChange={(v)=>set("status", v)} options={STAGE_STATUS_OPTIONS} />
-              <SelectField label="Struktur-Typ" value={form.stage_type} onChange={setStageType} options={STAGE_TYPES} />
+              <SelectField label="Struktur-Typ" value={form.stage_type} onChange={setStageType} options={STAGE_TYPE_OPTIONS} />
               <div className="block">
                 <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">Spieltyp</div>
                 <div className="w-full bg-[#0A0A0A] border border-white/10 px-3 py-2 rounded-sm text-white/70">{formatMatchType(form.match_type)}</div>
@@ -1996,6 +1976,58 @@ function SelectField({ label, value, onChange, options }) {
         {options.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
       </select>
     </label>
+  );
+}
+
+// Ein leerer Turnierbaum hat je nach Format einen ganz anderen Grund. "Nicht
+// generiert" ließ offen, ob etwas fehlt, kaputt ist oder so sein soll.
+const MAX_PREVIEW_MATCHES = 512;
+
+function emptyBracketReason(tournament) {
+  const format = tournament?.format;
+  const size = Number(tournament?.max_participants) || 0;
+
+  if (format === "swiss") {
+    return {
+      title: "Noch keine Runde erzeugt",
+      detail: "Beim Schweizer System gibt es keine Vorschau: wer gegen wen spielt, "
+        + "ergibt sich erst aus den Ergebnissen der Vorrunde.",
+      action: "Teilnehmer bestätigen, dann „Schweizer Runde“ drücken.",
+    };
+  }
+  if (format === "time_trial" || format === "grand_prix") {
+    return {
+      title: "Kein Turnierbaum vorgesehen",
+      detail: "Dieses Format wird über Rundenzeiten gewertet, nicht über Spielpaarungen.",
+      action: null,
+    };
+  }
+  const pairings = format === "league" ? size * (size - 1)
+    : format === "round_robin" ? (size * (size - 1)) / 2
+      : 0;
+  if (pairings > MAX_PREVIEW_MATCHES) {
+    return {
+      title: "Zu viele Begegnungen für eine Vorschau",
+      detail: `Jeder gegen jeden ergibt bei ${size} Teilnehmern ${pairings} Spiele. `
+        + `Ab ${MAX_PREVIEW_MATCHES} Spielen wird kein Entwurf mehr gezeichnet.`,
+      action: "Teilnehmerzahl senken oder in Gruppen aufteilen.",
+    };
+  }
+  return {
+    title: "Turnierbaum noch nicht erzeugt",
+    detail: "Für dieses Turnier liegt noch keine Struktur vor.",
+    action: "Unter „Struktur“ erzeugen oder Teilnehmer bestätigen.",
+  };
+}
+
+function EmptyBracketNotice({ tournament }) {
+  const { title, detail, action } = emptyBracketReason(tournament);
+  return (
+    <div className="text-center py-14 px-6 space-y-2">
+      <div className="text-white/60 font-display tracking-widest uppercase">{title}</div>
+      <p className="text-white/40 text-sm max-w-lg mx-auto">{detail}</p>
+      {action && <p className="text-[#29B6E8]/70 text-sm">{action}</p>}
+    </div>
   );
 }
 


### PR DESCRIPTION
Alles aus deinem Praxistest der neuen Formate. **A1, A2 und A3 waren rechnerisch korrekt** — 12 Spiele über 6 Spieltage mit getauschter Rückrunde, 20 Spiele bei fünf Teilnehmern, 6 Spiele beim Round Robin. Was nicht stimmte, war die Darstellung und zwei Vorgaben.

Vorweg: Der Fix für `group_A` war schon fertig, wurde aber in #172 **nicht mitgemergt** — mein Fehler, ich hatte ihn nach dem Merge nachgeschoben. Er ist hier wieder dabei.

## Begriffe

Winner Bracket und Loser Bracket statt Siegerbaum und Hoffnungsbaum, Grand Final statt Großes Finale, Single und Double Elimination statt Einzel- und Doppelausscheidung. Der übrige Text bleibt deutsch — es geht nur um die Fachbegriffe.

Noch nicht angefasst, weil nicht angefragt: Round Robin (aktuell „Jeder gegen jeden"), Group Stage (aktuell „Gruppenphase"), Swiss (aktuell „Schweizer System"). Sag Bescheid, ob die auch umziehen sollen.

## Spieltage statt Runden

Bei jeder gegen jeden ist „Runde 3" irreführend — es scheidet niemand aus. Liga und Gruppen zählen jetzt **Spieltage**. Der Schema-Parser erkennt das Wort zusätzlich, damit die Beschriftung die Rundenzuordnung nicht verliert.

## Round Robin sah aus wie eine Gruppenphase

Weil es technisch genau das ist: eine Gruppenphase mit einer Gruppe. Über dem Spielplan stand `group_A` — eine „Gruppe A", die sich von keiner Gruppe B unterscheidet. Eine einzelne Gruppe bekommt jetzt keinen Gruppennamen.

## Die Gruppenvorgabe war unbrauchbar

Dein B1-Test: **8 Teilnehmer ergaben 4 Zweiergruppen** mit je einem einzigen Spiel. Das ist keine Gruppenphase. Die Vorgabe zielt jetzt auf Vierergruppen:

| Teilnehmer | vorher | jetzt |
| --- | --- | --- |
| 8 | 4 Gruppen à 2 | **2 Gruppen à 4** |
| 16 | 4 Gruppen à 4 | 4 Gruppen à 4 |
| 6 | 3 Gruppen à 2 | **1 Gruppe** |

## Der leere Turnierbaum sagt jetzt warum

Deine Frage bei A4 („aber auch kein Matchplan, wie weiß man da wie was man spielt?") und bei B2 war berechtigt: `TURNIERBAUM NICHT GENERIERT` ließ offen, ob etwas fehlt, kaputt ist oder so sein soll. Drei verschiedene Fälle, eine Meldung.

- **Schweizer System:** „Beim Schweizer System gibt es keine Vorschau: wer gegen wen spielt, ergibt sich erst aus den Ergebnissen der Vorrunde." → Teilnehmer bestätigen, dann Runde erzeugen. **Dein B2 war also kein Fehler**, sondern die Schutzregel bei 0 bestätigten Teilnehmern.
- **Zu große Liga:** nennt die Rechnung („bei 64 Teilnehmern 4032 Spiele") und die Grenze.
- **Sonst:** sagt, wo man die Struktur erzeugt.

## Zwei Funde nebenbei

**Die Listen lagen doppelt.** Der Adminbereich pflegte eigene Kopien der Turnier- und Strukturlisten neben den gemeinsamen — deshalb standen dort noch die alten Begriffe, obwohl die zentrale Datei schon geändert war. Jetzt gibt es nur noch eine Quelle. Das ist ein kleiner Teil dessen, was du mit „das Admin-Menü ist zu unübersichtlich" meinst.

**Der Generieren-Knopf war gesperrt.** `AUTO_STAGE_TYPES` kannte nur Single/Double Elimination und die freien Bäume — für Liga, Gruppen und Einzelrunde war „Mit Teilnehmern generieren" ausgegraut, obwohl das Backend diese Strukturen längst bauen kann.

## Prüfung

- Backend 748 grün, Frontend 110 grün, Build sauber
- Zwei Windows-Flakes in Shell-Skript-Tests (`prepare-security-env`, `backup-offsite-policy`) — beide einzeln grün, CI läuft auf Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
