### PR TITLE
Block 7: ein Turnierbaum statt zwei, Spieltage als Spieltage

### DIFF
--- a/frontend/e2e/admin-downloads.spec.js
+++ b/frontend/e2e/admin-downloads.spec.js
@@ -121,8 +121,15 @@ async function mockDownloadsData(page, options = {}) {
           { id: "r1", display_name: "Koblauchgeist" },
           { id: "r2", display_name: "DerSushi" },
         ],
-        matches: [{ id: "m1", participant_a_id: "r1", participant_b_id: "r2", station_id: "station-a", station_label: "Station A" }],
-        matches_v2: [],
+        matches_v2: [{
+          id: "m1",
+          station_id: "station-a",
+          station_label: "Station A",
+          slots: [
+            { slot: 1, registration_id: "r1" },
+            { slot: 2, registration_id: "r2" },
+          ],
+        }],
       }),
     });
   });

--- a/frontend/e2e/display-tv.spec.js
+++ b/frontend/e2e/display-tv.spec.js
@@ -56,14 +56,19 @@ async function mockBracketDisplay(page) {
   }));
   const matches = Array.from({ length: 12 }, (_, index) => ({
     id: `m${index + 1}`,
+    stage_id: "stage-1",
+    stage_type: "single_elimination",
+    match_type: "duel",
+    section: "WB",
+    match_key: `M${index + 1}`,
     round: index < 6 ? 1 : index < 10 ? 2 : 3,
     round_name: index < 6 ? "Runde 1" : index < 10 ? "Viertelfinale" : "Halbfinale",
-    bracket: "winner",
-    match_index: index,
-    participant_a_id: registrations[(index * 2) % registrations.length].id,
-    participant_b_id: registrations[(index * 2 + 1) % registrations.length].id,
-    score_a: 0,
-    score_b: 0,
+    order: index,
+    slots: [
+      { slot: 1, registration_id: registrations[(index * 2) % registrations.length].id, status: "filled" },
+      { slot: 2, registration_id: registrations[(index * 2 + 1) % registrations.length].id, status: "filled" },
+    ],
+    results: [],
     status: index % 3 === 0 ? "ready" : "scheduled",
     scheduled_at: "2026-06-21T13:00:00+02:00",
     station_id: index % 2 === 0 ? "A" : "B",
@@ -82,9 +87,8 @@ async function mockBracketDisplay(page) {
           status: "registration_open",
         },
         registrations,
-        matches,
-        matches_v2: [],
-        stages: [],
+        matches_v2: matches,
+        stages: [{ id: "stage-1", name: "Turnierbaum", number: 1, stage_type: "single_elimination" }],
       }),
     });
   });

--- a/frontend/src/components/tls/BracketTree.jsx
+++ b/frontend/src/components/tls/BracketTree.jsx
@@ -3,81 +3,43 @@ import { resolveMediaUrl } from "@/lib/api";
 import { formatBracketSection, formatMatchStatus, formatRoundName } from "@/lib/tournamentLabels";
 
 /**
- * Renders classic 1v1 brackets and flexible multiplayer heats.
+ * Renders a tournament structure: knockout brackets, group and league
+ * matchdays, and multiplayer heats.
  * `data` is the response from /api/tournaments/:id/bracket.
  */
 export function BracketTree({ data, compact = false, viewMode = "standard", onMatchClick }) {
-  const { matches = [], matches_v2 = [], stages = [], registrations = [] } = data || {};
-  const isTv = viewMode === "tv";
-  const podiumMap = useMemo(() => buildPodiumMap(matches, matches_v2), [matches, matches_v2]);
+  const { matches_v2 = [], stages = [], registrations = [] } = data || {};
+  const podiumMap = useMemo(() => buildPodiumMap(matches_v2), [matches_v2]);
   const regMap = useMemo(() => {
     const m = new Map();
     for (const r of registrations) m.set(r.id, r);
     return m;
   }, [registrations]);
 
-  const grouped = useMemo(() => {
-    const g = {};
-    for (const m of matches) {
-      const key = m.bracket || "winner";
-      g[key] = g[key] || {};
-      g[key][m.round] = g[key][m.round] || [];
-      g[key][m.round].push(m);
-    }
-    for (const b of Object.keys(g)) {
-      for (const r of Object.keys(g[b])) {
-        g[b][r].sort((a, c) => a.match_index - c.match_index);
-      }
-    }
-    return g;
-  }, [matches]);
-
-  if (matches_v2.length > 0 || stages.length > 0) {
-    return <StageBracketTree stages={stages} matches={matches_v2} regMap={regMap} podiumMap={podiumMap} compact={compact} viewMode={viewMode} onMatchClick={onMatchClick} />;
-  }
-
-  const renderBracket = (bracketKey, label) => {
-    const rounds = grouped[bracketKey];
-    if (!rounds) return null;
-    const roundNums = Object.keys(rounds).map(Number).sort((a, b) => a - b);
-    return (
-      <div className="space-y-3" key={bracketKey}>
-        {label && (
-          <div className="flex items-center gap-2 uppercase tracking-[0.2em] text-xs font-bold">
-            <span className="w-2 h-2 bg-[#29B6E8]" />
-            <span className="text-white/80">{label}</span>
-          </div>
-        )}
-        <div className={isTv
-          ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 overflow-hidden"
-          : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:flex gap-4 md:gap-6 xl:overflow-x-auto pb-4"
-        }>
-          {roundNums.map((rn) => (
-            <div key={rn} className={isTv ? "flex flex-col min-w-0 gap-2" : "flex flex-col min-w-0 xl:min-w-[240px] gap-4"}>
-              <div className="text-[11px] font-bold uppercase tracking-wider text-white/50 px-2">
-                {formatRoundName(rounds[rn][0].round_name, rn)}
-              </div>
-              <div className={isTv ? "flex flex-col gap-2" : "flex flex-col justify-around flex-1 gap-3"}>
-                {rounds[rn].map((m) => (
-                  <BracketNode key={m.id} match={m} regMap={regMap} podiumMap={podiumMap} compact={compact || isTv} onClick={onMatchClick} />
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  };
-
   return (
-    <div className={isTv ? "space-y-4 h-full overflow-hidden" : "space-y-8"}>
-      {renderBracket("winner", grouped.loser ? formatBracketSection("winner") : null)}
-      {renderBracket("loser", formatBracketSection("loser"))}
-      {renderBracket("grand_final", formatBracketSection("grand_final"))}
-      {renderBracket("bronze", formatBracketSection("bronze"))}
-      {renderBracket("round_robin", formatBracketSection("round_robin"))}
-    </div>
+    <StageBracketTree
+      stages={stages}
+      matches={matches_v2}
+      regMap={regMap}
+      podiumMap={podiumMap}
+      compact={compact}
+      viewMode={viewMode}
+      onMatchClick={onMatchClick}
+    />
   );
+}
+
+// Formate, die in einer Tabelle ausgespielt werden statt in einem Baum. Sie
+// laufen über Spieltage, an denen alle gleichzeitig spielen - nebeneinander
+// scrollende Runden wären dafür die falsche Form, besonders am Telefon.
+const TABLE_STAGE_TYPES = new Set(["round_robin_groups", "league", "swiss"]);
+const TABLE_SECTION_RE = /^(round_robin|liga|league|swiss|group_.+)$/i;
+
+export function isTableFormat(matches = []) {
+  const first = matches.find(Boolean);
+  if (!first) return false;
+  if (first.stage_type) return TABLE_STAGE_TYPES.has(String(first.stage_type));
+  return TABLE_SECTION_RE.test(String(first.section || ""));
 }
 
 function StageBracketTree({ stages, matches, regMap, podiumMap, compact = false, viewMode = "standard", onMatchClick }) {
@@ -143,37 +105,65 @@ function StageBracketTree({ stages, matches, regMap, podiumMap, compact = false,
   );
 }
 
+function MatchNode({ match, regMap, podiumMap, compact, onMatchClick }) {
+  const isDuel = (match.match_type || "duel") === "duel" && (match.slots || []).length <= 2;
+  const Node = isDuel ? V2DuelNode : HeatNode;
+  return <Node match={match} regMap={regMap} podiumMap={podiumMap} compact={compact} onClick={onMatchClick} />;
+}
+
 function StageSection({ section, rounds, regMap, podiumMap, compact, viewMode, onMatchClick }) {
   const isTv = viewMode === "tv";
   const roundNums = Object.keys(rounds).map(Number).sort((a, b) => a - b);
+  const asTable = isTableFormat(roundNums.flatMap((rn) => rounds[rn]));
+
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2 uppercase tracking-[0.2em] text-xs font-bold">
         <span className="w-2 h-2 bg-[#FFD700]" />
         <span className="text-white/80">{formatBracketSection(section)}</span>
       </div>
-      <div className={isTv
-        ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 overflow-hidden"
-        : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:flex gap-4 md:gap-6 xl:overflow-x-auto pb-4"
-      }>
-        {roundNums.map((rn) => (
-          <div key={rn} className={isTv ? "flex flex-col min-w-0 gap-2" : `flex flex-col min-w-0 self-stretch ${compact ? "xl:min-w-[220px]" : "xl:min-w-[280px]"} gap-4`}>
-            <div className="text-[11px] font-bold uppercase tracking-wider text-white/50 px-2">
-              {formatRoundName(rounds[rn][0].round_name, rn)}
+
+      {asTable ? (
+        // Spieltage untereinander: an einem Spieltag spielen alle gleichzeitig,
+        // es gibt keinen Fluss von links nach rechts.
+        <div className="space-y-5">
+          {roundNums.map((rn) => (
+            <div key={rn} className="space-y-2">
+              <div className="text-[11px] font-bold uppercase tracking-wider text-white/50 px-2">
+                {formatRoundName(rounds[rn][0].round_name, rn)}
+              </div>
+              <div className={isTv
+                ? "grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3"
+                : "grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4"
+              }>
+                {rounds[rn].map((match) => (
+                  <MatchNode key={match.id} match={match} regMap={regMap} podiumMap={podiumMap}
+                             compact={compact || isTv} onMatchClick={onMatchClick} />
+                ))}
+              </div>
             </div>
-            <div className={isTv ? "flex flex-col gap-2" : "flex flex-col justify-around flex-1 gap-3"}>
-              {rounds[rn].map((match) => {
-                const isDuel = (match.match_type || "duel") === "duel" && (match.slots || []).length <= 2;
-                return isDuel ? (
-                  <V2DuelNode key={match.id} match={match} regMap={regMap} podiumMap={podiumMap} compact={compact || isTv} onClick={onMatchClick} />
-                ) : (
-                  <HeatNode key={match.id} match={match} regMap={regMap} podiumMap={podiumMap} compact={compact || isTv} onClick={onMatchClick} />
-                );
-              })}
+          ))}
+        </div>
+      ) : (
+        <div className={isTv
+          ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 overflow-hidden"
+          : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:flex gap-4 md:gap-6 xl:overflow-x-auto pb-4"
+        }>
+          {roundNums.map((rn) => (
+            <div key={rn} className={isTv ? "flex flex-col min-w-0 gap-2" : `flex flex-col min-w-0 self-stretch ${compact ? "xl:min-w-[220px]" : "xl:min-w-[280px]"} gap-4`}>
+              <div className="text-[11px] font-bold uppercase tracking-wider text-white/50 px-2">
+                {formatRoundName(rounds[rn][0].round_name, rn)}
+              </div>
+              <div className={isTv ? "flex flex-col gap-2" : "flex flex-col justify-around flex-1 gap-3"}>
+                {rounds[rn].map((match) => (
+                  <MatchNode key={match.id} match={match} regMap={regMap} podiumMap={podiumMap}
+                             compact={compact || isTv} onMatchClick={onMatchClick} />
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -320,46 +310,6 @@ function HeatRow({ slot, registration, result, qualified, podiumRank, compact = 
   );
 }
 
-function BracketNode({ match, regMap, podiumMap, compact = false, onClick }) {
-  const a = regMap.get(match.participant_a_id);
-  const b = regMap.get(match.participant_b_id);
-  const winnerA = match.winner_id && match.winner_id === match.participant_a_id;
-  const winnerB = match.winner_id && match.winner_id === match.participant_b_id;
-  const nodePodium = topPodiumRank([match.participant_a_id, match.participant_b_id], podiumMap);
-
-  return (
-    <button
-      type="button"
-      onClick={() => onClick?.(match)}
-      data-testid={`bracket-match-${match.id}`}
-      className={`tls-bracket-node relative text-left rounded-sm overflow-hidden border ${podiumBorderClass(nodePodium)} hover:border-[#29B6E8]/60 transition-all group`}
-    >
-      <Row
-        label={a?.display_name || a?.user?.display_name || a?.ingame_name || (match.participant_a_id ? "-" : "Offen")}
-        score={match.score_a}
-        isWinner={winnerA}
-        podiumRank={podiumMap?.get(match.participant_a_id)}
-        avatar={a?.user?.avatar_url}
-        compact={compact}
-      />
-      <div className="h-px bg-white/5" />
-      <Row
-        label={b?.display_name || b?.user?.display_name || b?.ingame_name || (match.participant_b_id ? "-" : "Offen")}
-        score={match.score_b}
-        isWinner={winnerB}
-        podiumRank={podiumMap?.get(match.participant_b_id)}
-        avatar={b?.user?.avatar_url}
-        compact={compact}
-      />
-      <MatchMeta match={match} compact={compact} />
-      <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-white/40 border-t border-white/5 flex items-center justify-between font-display">
-        <span>Spiel #{match.match_index + 1}</span>
-        <span><LiveStatus status={match.status} /></span>
-      </div>
-    </button>
-  );
-}
-
 function Row({ label, score, isWinner, podiumRank, avatar, compact = false }) {
   const podium = podiumMeta(podiumRank);
   return (
@@ -403,7 +353,7 @@ function isBronzeMatch(match) {
   return haystack.includes("bronze") || haystack.includes("platz 3") || haystack.includes("third");
 }
 
-function buildPodiumMap(matches = [], matchesV2 = []) {
+function buildPodiumMap(matchesV2 = []) {
   const podium = new Map();
   const place = (id, rank) => {
     if (!id || ![1, 2, 3].includes(rank)) return;
@@ -443,26 +393,6 @@ function buildPodiumMap(matches = [], matchesV2 = []) {
     if (lowerFinal) {
       const loser = (match.results || []).find((result) => Number(result.rank) === 2);
       place(loser?.registration_id, 3);
-    }
-  }
-
-  const maxRoundByBracket = new Map();
-  for (const match of matches) {
-    const bracket = normalizeSection(match.bracket || "winner");
-    const round = Number(match.round || 1);
-    maxRoundByBracket.set(bracket, Math.max(maxRoundByBracket.get(bracket) || 0, round));
-  }
-  const hasLegacyGrandFinal = matches.some((match) => ["gf", "grand_final"].includes(normalizeSection(match.bracket)));
-  for (const match of matches) {
-    if (!isCompleted(match) && !match.winner_id) continue;
-    const bracket = normalizeSection(match.bracket || "winner");
-    const finalMatch = ["gf", "grand_final"].includes(bracket) || (!hasLegacyGrandFinal && ["winner", "main"].includes(bracket) && Number(match.round || 1) === maxRoundByBracket.get(bracket));
-    if (isBronzeMatch(match)) {
-      place(match.winner_id, 3);
-    } else if (finalMatch) {
-      place(match.winner_id, 1);
-      const loserId = match.participant_a_id === match.winner_id ? match.participant_b_id : match.participant_a_id;
-      place(loserId, 2);
     }
   }
 

--- a/frontend/src/components/tls/BracketTree.test.jsx
+++ b/frontend/src/components/tls/BracketTree.test.jsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { isTableFormat } from "./BracketTree";
+
+describe("isTableFormat", () => {
+  it("erkennt Formate, die über Spieltage laufen", () => {
+    // Liga, Gruppen und Schweizer System spielen alle gleichzeitig an einem
+    // Spieltag - nebeneinander scrollende Runden wären dafür die falsche Form.
+    for (const stage_type of ["league", "round_robin_groups", "swiss"]) {
+      expect(isTableFormat([{ stage_type }])).toBe(true);
+    }
+  });
+
+  it("erkennt K.-o.-Bäume, die von links nach rechts fließen", () => {
+    for (const stage_type of ["single_elimination", "double_elimination", "custom_bracket", "simple"]) {
+      expect(isTableFormat([{ stage_type }])).toBe(false);
+    }
+  });
+
+  it("fällt auf den Abschnittsnamen zurück, wenn der Typ fehlt", () => {
+    expect(isTableFormat([{ section: "group_A" }])).toBe(true);
+    expect(isTableFormat([{ section: "LIGA" }])).toBe(true);
+    expect(isTableFormat([{ section: "round_robin" }])).toBe(true);
+    expect(isTableFormat([{ section: "swiss" }])).toBe(true);
+    expect(isTableFormat([{ section: "WB" }])).toBe(false);
+    expect(isTableFormat([{ section: "GF" }])).toBe(false);
+  });
+
+  it("zieht den Typ dem Abschnittsnamen vor", () => {
+    expect(isTableFormat([{ stage_type: "single_elimination", section: "group_A" }])).toBe(false);
+  });
+
+  it("kommt mit leeren Angaben zurecht", () => {
+    expect(isTableFormat([])).toBe(false);
+    expect(isTableFormat()).toBe(false);
+    expect(isTableFormat([{}])).toBe(false);
+  });
+});

--- a/frontend/src/components/tls/TournamentFlowStepper.jsx
+++ b/frontend/src/components/tls/TournamentFlowStepper.jsx
@@ -23,7 +23,7 @@ function rank(status) {
   return STATUS_RANK[status] ?? 0;
 }
 
-export function TournamentFlowStepper({ tournament, registrations = [], bracket, matchesV2 = [], onNavigate }) {
+export function TournamentFlowStepper({ tournament, registrations = [], matchesV2 = [], onNavigate }) {
   const status = tournament?.status || "draft";
   const r = rank(status);
 
@@ -31,9 +31,8 @@ export function TournamentFlowStepper({ tournament, registrations = [], bracket,
   const checkedIn = registrations.filter(
     (x) => CHECKED_IN.has(x.status) || x.checked_in_at
   ).length;
-  const bracketMatches = bracket?.matches?.length || 0;
-  const totalMatches = bracketMatches + (matchesV2?.length || 0);
-  const allMatches = [...(bracket?.matches || []), ...(matchesV2 || [])];
+  const allMatches = matchesV2 || [];
+  const totalMatches = allMatches.length;
   const completedMatches = allMatches.filter((m) => DONE_MATCH.has(m.status)).length;
   const hasBracket = totalMatches > 0;
   const published = status === "results_published" || status === "archived";

--- a/frontend/src/pages/admin/AdminStationsPage.jsx
+++ b/frontend/src/pages/admin/AdminStationsPage.jsx
@@ -95,9 +95,7 @@ export default function AdminStationsPage() {
       const { data } = await api.get(`/tournaments/${activeTid}/bracket`);
       if (matchesRequestRef.current !== requestId) return;
       const tournament = data?.tournament || {};
-      const duelMatches = safeArray(data?.matches).map((m) => ({ ...m, is_multi_slot: false, tournament }));
-      const multiSlotMatches = safeArray(data?.matches_v2).map((m) => ({ ...m, is_multi_slot: true, tournament }));
-      setMatches([...duelMatches, ...multiSlotMatches]);
+      setMatches(safeArray(data?.matches_v2).map((m) => ({ ...m, is_multi_slot: true, tournament })));
       setRegs(safeArray(data?.registrations));
       setPageError("");
     } catch (e) {

--- a/frontend/src/pages/admin/AdminTournamentEditPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.jsx
@@ -505,34 +505,6 @@ export default function AdminTournamentEditPage() {
       toast.error(formatRequestError(e, locked ? "Turnier konnte nicht gesperrt werden." : "Turnier konnte nicht entsperrt werden."));
     }
   };
-  const updateMatchResult = async (m, scoreA, scoreB, winnerId) => {
-    try {
-      await api.patch(`/matches/${m.id}`, {
-        score_a: Number(scoreA) || 0,
-        score_b: Number(scoreB) || 0,
-        winner_id: winnerId || null,
-        status: winnerId ? "completed" : "waiting_result",
-      });
-      toast.success("Ergebnis gespeichert.");
-      load();
-    } catch (e) { toast.error(formatApiError(e.response?.data?.detail)); }
-  };
-  const updateMatchSchedule = async (match, payload) => {
-    try {
-      const scheduledAt = payload.scheduled_at ? fromDateTimeLocal(payload.scheduled_at) : null;
-      const body = {
-        scheduled_at: scheduledAt,
-        duration_minutes: payload.duration_minutes === "" ? null : Number(payload.duration_minutes),
-        station_id: payload.station_id || null,
-      };
-      if (scheduledAt && ["pending", "ready", "preview"].includes(match.status)) body.status = "scheduled";
-      await api.patch(`/matches/${match.id}`, body);
-      toast.success("Matchplanung gespeichert.");
-      load();
-    } catch (err) {
-      toast.error(formatRequestError(err, "Matchplanung konnte nicht gespeichert werden."));
-    }
-  };
   const updateMatchV2Schedule = async (match, payload) => {
     try {
       await api.patch(`/matches/${match.id}`, {
@@ -602,7 +574,6 @@ export default function AdminTournamentEditPage() {
         : <div className="p-10 text-white/40">Lade…</div>}
     </AdminLayout>
   );
-  const hasFlexibleStructure = stages.length > 0 || matchesV2.length > 0;
   const canRecordResults = ["live", "paused"].includes(t.status);
   const availableTabs = [
     ["participants", "Teilnehmer"],
@@ -711,7 +682,6 @@ export default function AdminTournamentEditPage() {
       <TournamentFlowStepper
         tournament={t}
         registrations={regs}
-        bracket={bracket}
         matchesV2={matchesV2}
         onNavigate={(key) => selectTab(key)}
       />
@@ -854,7 +824,7 @@ export default function AdminTournamentEditPage() {
 
       {activeTab === "bracket" && bracket && (
         <div className="bg-[#0A0A0A] rounded-sm p-4 border border-white/10">
-          {(bracket.matches?.length || 0) + (bracket.matches_v2?.length || 0) === 0 ? (
+          {(bracket.matches_v2?.length || 0) === 0 ? (
             <EmptyBracketNotice tournament={t} />
           ) : (
             <BracketTree data={bracket} />
@@ -862,84 +832,7 @@ export default function AdminTournamentEditPage() {
         </div>
       )}
 
-      {activeTab === "stages" && !hasFlexibleStructure && bracket?.matches && (
-        <div className="border border-white/10 rounded-sm bg-[#121212] overflow-hidden">
-          <div className="lg:hidden divide-y divide-white/5">
-            {bracket.matches.map((m) => {
-              const a = bracket.registrations.find((r) => r.id === m.participant_a_id);
-              const b = bracket.registrations.find((r) => r.id === m.participant_b_id);
-              return (
-                <div key={m.id} className="p-4 space-y-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="text-[10px] uppercase tracking-widest text-white/35">{m.round_name || m.round}</div>
-                      <div className="mt-1 grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1 text-sm">
-                        <span className="truncate">{a?.display_name || "Offen"}</span>
-                        <span className="font-display font-bold tabular-nums">{m.score_a}</span>
-                        <span className="truncate">{b?.display_name || "Offen"}</span>
-                        <span className="font-display font-bold tabular-nums">{m.score_b}</span>
-                      </div>
-                      <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-wider text-white/45">
-                        <span>{stationDisplay(m, stations) ? `Station ${stationDisplay(m, stations)}` : "Station offen"}</span>
-                        {m.scheduled_at && <span>{formatDateTime(m.scheduled_at)}</span>}
-                      </div>
-                    </div>
-                    <StatusBadge status={m.status} />
-                  </div>
-                  <div className="space-y-2">
-                    {isModerator && canRecordResults && a && b && (
-                      <MatchResultControls match={m} a={a} b={b} onSave={updateMatchResult} />
-                    )}
-                    {isModerator && <MatchScheduleControls match={m} stations={stations} defaultScheduledAt={t.start_date} onSave={updateMatchSchedule} />}
-                    <Link to={`/matches/${m.id}`} className="inline-flex text-[#29B6E8] text-xs font-bold uppercase hover:text-white">Öffnen</Link>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          <div className="hidden lg:block overflow-x-auto">
-          <table className="w-full text-sm min-w-[720px]">
-            <thead className="bg-[#0A0A0A] text-[11px] uppercase tracking-widest text-white/50">
-              <tr>
-                <th className="text-left px-4 py-3">Runde</th>
-                <th className="text-left px-4 py-3">Teilnehmer A</th>
-                <th className="text-left px-4 py-3">Teilnehmer B</th>
-                <th className="text-center px-4 py-3">Ergebnis</th>
-                <th className="text-left px-4 py-3">Station</th>
-                <th className="text-left px-4 py-3">Status</th>
-                <th className="text-right px-4 py-3">Aktion</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-white/5">
-              {bracket.matches.map((m) => {
-                const a = bracket.registrations.find((r) => r.id === m.participant_a_id);
-                const b = bracket.registrations.find((r) => r.id === m.participant_b_id);
-                return (
-                  <tr key={m.id}>
-                    <td className="px-4 py-3 text-white/70">{m.round_name || m.round}</td>
-                    <td className="px-4 py-3">{a?.display_name || "Offen"}</td>
-                    <td className="px-4 py-3">{b?.display_name || "Offen"}</td>
-                    <td className="px-4 py-3 text-center font-display font-bold">{m.score_a} : {m.score_b}</td>
-                    <td className="px-4 py-3 text-white/60">{stationDisplay(m, stations) || "Offen"}</td>
-                    <td className="px-4 py-3"><StatusBadge status={m.status} /></td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex flex-col items-end gap-2">
-                        {isModerator && canRecordResults && a && b && (
-                          <MatchResultControls match={m} a={a} b={b} onSave={updateMatchResult} />
-                        )}
-                        {isModerator && <MatchScheduleControls match={m} stations={stations} defaultScheduledAt={t.start_date} onSave={updateMatchSchedule} />}
-                        <Link to={`/matches/${m.id}`} className="text-[#29B6E8] text-xs font-bold uppercase hover:text-white">Öffnen →</Link>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          </div>
-        </div>
-      )}
-      {activeTab === "stages" && hasFlexibleStructure && (
+      {activeTab === "stages" && (
         <TournamentStagesPanel
           tournamentId={t.id}
           stages={stages}
@@ -2223,34 +2116,6 @@ function TournamentStaffPanel({ tournamentId, staff, users, onChanged }) {
           </table>
         </div>
       </div>
-    </div>
-  );
-}
-
-function MatchResultControls({ match, a, b, onSave }) {
-  const [scoreA, setScoreA] = useState(match.score_a ?? 0);
-  const [scoreB, setScoreB] = useState(match.score_b ?? 0);
-  const winnerId = Number(scoreA) > Number(scoreB)
-    ? a.id
-    : Number(scoreB) > Number(scoreA)
-      ? b.id
-      : "";
-  return (
-    <div className="w-full min-w-[18rem] grid sm:grid-cols-[minmax(6rem,1fr)_minmax(6rem,1fr)_minmax(9rem,1fr)_auto] items-end gap-2">
-      <label className="block">
-        <span className="block text-[10px] text-white/45 mb-1 break-words">{a.display_name || "Spieler A"}</span>
-        <input type="number" min="0" value={scoreA} onChange={(e)=>setScoreA(e.target.value)} className="w-full bg-[#0A0A0A] border border-white/10 px-2 py-1 rounded-sm text-xs text-center" aria-label="Punkte A" placeholder="Punkte" />
-      </label>
-      <label className="block">
-        <span className="block text-[10px] text-white/45 mb-1 break-words">{b.display_name || "Spieler B"}</span>
-        <input type="number" min="0" value={scoreB} onChange={(e)=>setScoreB(e.target.value)} className="w-full bg-[#0A0A0A] border border-white/10 px-2 py-1 rounded-sm text-xs text-center" aria-label="Punkte B" placeholder="Punkte" />
-      </label>
-      <select value={winnerId} onChange={(e)=>onSave(match, scoreA, scoreB, e.target.value)} className="bg-[#0A0A0A] border border-white/10 px-2 py-1 rounded-sm text-xs" aria-label="Gewinner">
-        <option value="">Gewinner wählen</option>
-        <option value={a.id}>{a.display_name || "A"}</option>
-        <option value={b.id}>{b.display_name || "B"}</option>
-      </select>
-      <button type="button" onClick={()=>onSave(match, scoreA, scoreB, winnerId)} className="px-3 py-1 border border-[#29B6E8]/50 text-[#29B6E8] rounded-sm text-[10px] font-bold uppercase">Speichern</button>
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminWidgetsPage.jsx
+++ b/frontend/src/pages/admin/AdminWidgetsPage.jsx
@@ -229,16 +229,6 @@ export default function AdminWidgetsPage() {
 function qrMatchesFromBracket(payload) {
   const registrations = new Map((payload?.registrations || []).map((registration) => [registration.id, registration]));
   const tournament = payload?.tournament || {};
-  const legacy = (payload?.matches || []).map((match) => ({
-    id: match.id,
-    tournamentTitle: tournament.title,
-    stationId: match.station_id,
-    stationLabel: match.station_label || match.station_name || match.station?.name || match.station_id,
-    label: [registrations.get(match.participant_a_id), registrations.get(match.participant_b_id)]
-      .map((registration) => registration?.display_name || registration?.ingame_name)
-      .filter(Boolean)
-      .join(" vs. ") || match.round_name || `Match ${match.match_key || match.id}`,
-  }));
   const multi = (payload?.matches_v2 || []).map((match) => ({
     id: match.id,
     tournamentTitle: tournament.title,
@@ -249,7 +239,7 @@ function qrMatchesFromBracket(payload) {
       .filter(Boolean)
       .join(" vs. ") || match.round_name || `Match ${match.match_key || match.id}`,
   }));
-  return [...legacy, ...multi].filter((match) => match.id).slice(0, 80);
+  return multi.filter((match) => match.id).slice(0, 80);
 }
 
 function buildQrLinks({ event, stations, matches, albums, base }) {

--- a/frontend/src/pages/display/BracketTVPage.jsx
+++ b/frontend/src/pages/display/BracketTVPage.jsx
@@ -14,7 +14,6 @@ import {
   formatBracketSection,
   formatMatchKind,
   formatMatchStatus,
-  formatRoundName,
   formatScheduleGroupLabel,
 } from "@/lib/tournamentLabels";
 
@@ -74,7 +73,7 @@ export default function BracketTVPage() {
   const t = data.tournament;
   const publicUrl = `${window.location.origin}/tournaments/${t.slug || t.id}/bracket`;
   const activeView = views[viewIndex % Math.max(views.length, 1)] || { title: "Turnierbaum", columns: [], registrations: [] };
-  const hasMatches = (data.matches?.length || 0) + (data.matches_v2?.length || 0) > 0;
+  const hasMatches = (data.matches_v2?.length || 0) > 0;
 
   return (
     <div className="h-screen tv-bg text-white flex flex-col overflow-hidden">
@@ -330,9 +329,7 @@ function stationLabel(match) {
 function buildTvViews(data, mode = "active") {
   if (!data) return [];
   const registrations = data.registrations || [];
-  const columns = (data.matches_v2 || []).length > 0
-    ? buildV2Columns(data)
-    : buildLegacyColumns(data);
+  const columns = buildV2Columns(data);
   if (mode === "tree") {
     const pages = chunk(expandColumnsForDisplay(columns), MAX_COLUMNS_PER_VIEW);
     return pages.map((page, index) => ({
@@ -386,34 +383,6 @@ function buildV2Columns(data) {
         round,
         sectionLabel: [stage.name || "Phase", formatBracketSection(section)].filter(Boolean).join(" · "),
         roundLabel: formatScheduleGroupLabel(sortedMatches[0], data.tournament),
-        matches: sortedMatches,
-      });
-    })
-    .sort(sortColumns);
-}
-
-function buildLegacyColumns(data) {
-  const groups = new Map();
-  for (const match of data.matches || []) {
-    const round = Number(match.round || 1);
-    const section = match.bracket || "winner";
-    const key = `${section}::${round}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(match);
-  }
-
-  return [...groups.entries()]
-    .map(([key, matches]) => {
-      const [section, roundValue] = key.split("::");
-      const round = Number(roundValue || 1);
-      const sortedMatches = sortMatches(matches);
-      return makeColumn({
-        key,
-        stageNumber: 1,
-        section,
-        round,
-        sectionLabel: formatBracketSection(section),
-        roundLabel: formatRoundName(sortedMatches[0]?.round_name, round),
         matches: sortedMatches,
       });
     })
@@ -480,7 +449,7 @@ function isMatchDone(match) {
 }
 
 function buildUpcomingViews(data, registrations) {
-  const matches = [...(data.matches_v2 || []), ...(data.matches || [])]
+  const matches = [...(data.matches_v2 || [])]
     .filter((match) => !isMatchDone(match))
     .sort((a, b) => {
       const ad = Date.parse(a.scheduled_at || "") || Number.MAX_SAFE_INTEGER;
@@ -572,7 +541,7 @@ function useMatchFlash(data) {
 
   useEffect(() => {
     if (!data) return undefined;
-    const all = [...(data.matches || []), ...(data.matches_v2 || [])];
+    const all = data.matches_v2 || [];
     const snapshot = {};
     const fresh = {};
     for (const match of all) {

--- a/frontend/src/pages/display/EventTVPage.jsx
+++ b/frontend/src/pages/display/EventTVPage.jsx
@@ -272,7 +272,7 @@ function buildStationMatchLookup(bracketPayloads) {
   for (const payload of bracketPayloads || []) {
     const registrations = new Map((payload?.registrations || []).map((registration) => [registration.id, registration]));
     const tournamentTitle = payload?.tournament?.title || "Turnier";
-    for (const match of [...(payload?.matches_v2 || []), ...(payload?.matches || [])]) {
+    for (const match of payload?.matches_v2 || []) {
       if (!match?.id || isDoneMatch(match)) continue;
       const detail = stationMatchDetail(match, registrations, tournamentTitle);
       entries.push(detail);

--- a/frontend/src/pages/public/EventLivePage.jsx
+++ b/frontend/src/pages/public/EventLivePage.jsx
@@ -46,13 +46,6 @@ function slotLabel(slot, registrationMap) {
   return participantLabel(registration) || slot.source?.raw || "Offen";
 }
 
-function legacyLabels(match, registrationMap) {
-  return [
-    participantLabel(registrationMap.get(match.participant_a_id)),
-    participantLabel(registrationMap.get(match.participant_b_id)),
-  ];
-}
-
 function resultLine(match, registrationMap) {
   if (Array.isArray(match.results) && match.results.length) {
     return match.results
@@ -85,16 +78,7 @@ function normalizeBracketRows(payload) {
     source: "v2",
   }));
 
-  const legacyRows = (payload?.matches || []).map((match) => ({
-    ...match,
-    tournament,
-    labels: legacyLabels(match, registrationMap),
-    groupLabel: match.round_name || (match.round ? `Runde ${match.round}` : "Runde"),
-    resultText: resultLine(match, registrationMap),
-    source: "legacy",
-  }));
-
-  return [...v2Rows, ...legacyRows].map((match) => ({
+  return v2Rows.map((match) => ({
     ...match,
     sortTime: matchSortValue(match),
     publicUrl: `/matches/${match.id}`,

--- a/frontend/src/pages/public/TournamentBracketPage.jsx
+++ b/frontend/src/pages/public/TournamentBracketPage.jsx
@@ -72,7 +72,7 @@ export default function TournamentBracketPage() {
             </Link>
           )}
         </div>
-        {(data.matches?.length || 0) + (data.matches_v2?.length || 0) === 0 ? (
+        {(data.matches_v2?.length || 0) === 0 ? (
           <div className="border border-white/10 rounded-sm bg-[#121212] p-12 text-center">
             <div className="text-white/50 font-display tracking-widest">TURNIERBAUM WURDE NOCH NICHT GENERIERT</div>
           </div>

--- a/mobile/src/screens/main/TournamentDetailScreen.tsx
+++ b/mobile/src/screens/main/TournamentDetailScreen.tsx
@@ -22,7 +22,6 @@ type Props = NativeStackScreenProps<TournamentStackParamList, "TournamentDetail"
 type TabKey = "overview" | "bracket" | "matches" | "standings" | "participants" | "rules";
 type BracketPayload = {
   tournament?: Tournament;
-  matches?: any[];
   matches_v2?: any[];
   stages?: any[];
   registrations?: any[];
@@ -118,9 +117,7 @@ export function TournamentDetailScreen({ navigation, route }: Props) {
     registrations.forEach((registration) => map.set(registration.id, registration));
     return map;
   }, [registrations]);
-  const legacyMatches = bracket.matches || tournament?.matches || [];
-  const v2Matches = bracket.matches_v2 || [];
-  const allMatches = v2Matches.length ? v2Matches : legacyMatches;
+  const allMatches = bracket.matches_v2 || [];
   const upcomingMatches = useMemo(() => {
     const open = allMatches.filter((match) => OPEN_MATCH_STATUSES.has(String(match.status || "")));
     if (!ownRegistration?.id) return open.slice(0, 5);
@@ -310,7 +307,7 @@ export function TournamentDetailScreen({ navigation, route }: Props) {
               <View style={styles.statGrid}>
                 <Stat label="Matches" value={String(allMatches.length)} />
                 <Stat label="Spieler" value={String(registrations.length || tournament.participant_count || 0)} tone="gold" />
-                <Stat label="Engine" value={bracket.engine || "legacy"} />
+                <Stat label="Engine" value={bracket.engine || "—"} />
               </View>
               <Info label="Event" value={tournament.event?.name || "-"} />
               <Info label="Ort" value={tournament.event?.location || "-"} />
@@ -536,9 +533,8 @@ function RegistrationModal({
 
 function BracketView({ payload, regMap, onOpenMatch }: { payload: BracketPayload; regMap: Map<string, any>; onOpenMatch?: (id: string) => void }) {
   const matchesV2 = payload.matches_v2 || [];
-  const legacy = payload.matches || [];
   const sections = useMemo(() => {
-    const source = matchesV2.length ? matchesV2 : legacy;
+    const source = matchesV2;
     const grouped = new Map<string, Map<number, any[]>>();
     source.forEach((match) => {
       const section = match.section || match.bracket || "MAIN";
@@ -551,7 +547,7 @@ function BracketView({ payload, regMap, onOpenMatch }: { payload: BracketPayload
       section,
       rounds: Array.from(roundMap.entries()).sort((a, b) => a[0] - b[0]),
     }));
-  }, [legacy, matchesV2]);
+  }, [matchesV2]);
 
   return (
     <View style={styles.bracketWrap}>


### PR DESCRIPTION
Der Turnierbaum verzweigte nach Datenform: klassische A-gegen-B-Matches in den einen Renderer, Graph-Matches in den anderen. Seit der klassische Speicher **nachweislich leer** ist, war der eine Zweig unerreichbar.

**362 Zeilen weg, 93 dazu.**

## Was alles am toten Zweig hing

Nicht nur der Renderer — beim Ziehen kam einiges mit:

| Stelle | Was dort lag |
| --- | --- |
| `BracketTree.jsx` | Der klassische Renderer samt `BracketNode` und der klassischen Hälfte der Podiumsberechnung |
| `AdminTournamentEditPage` | **Ein zweiter Ergebnis-Editor** — Kartenliste für Handy, Tabelle für Desktop, plus `MatchResultControls` und zwei Speicherfunktionen |
| `BracketTVPage` | Eigene TV-Spalten (`buildLegacyColumns`) |
| `AdminWidgetsPage`, `EventLivePage` | Eigene Widget- und Live-Zeilen |
| `TournamentFlowStepper`, `AdminStationsPage` | Zählten beide Speicher zusammen |
| App: `TournamentDetailScreen` | Dieselbe Verzweigung, kleiner |

Der Linter hat dabei gut geführt: Nach dem Entfernen des Editors meldete er vier verwaiste Helfer, die nur daran hingen.

## Die Darstellung, die dein Praxistest gebraucht hätte

Liga, Gruppen und Schweizer Runden wurden als **K.-o.-Baum** gezeichnet — nebeneinander scrollende Spalten, eine je Runde. Das ist die falsche Form: An einem Spieltag spielen alle gleichzeitig, es gibt keinen Fluss von links nach rechts. Bei deiner Liga mit sechs Spieltagen bedeutete das sechs Spalten zum Seitwärtsscrollen, am Telefon unbedienbar.

Diese Formate stehen jetzt **untereinander, ein Block je Spieltag**, mit den Partien in einem Raster. Die Entscheidung hängt am Strukturtyp und fällt nur auf den Abschnittsnamen zurück, wenn der Typ fehlt.

## Eine Einordnung zur Reihenfolge

Das Frontend liest ab jetzt den klassischen Speicher nicht mehr, obwohl das Backend ihn noch zurückgibt — der fällt erst in Block 8. Für diese Installation ist das folgenlos: Der Trockenlauf hat **0 Dokumente** gezählt. Für eine Installation mit Altbestand wäre es einer, deshalb steht es hier ausdrücklich.

## Prüfung

- Backend 781 grün, Frontend 115 grün (+5), App 20 grün und typecheck sauber, Build sauber
- Die Layout-Entscheidung ist als eigener Test festgehalten

🤖 Generated with [Claude Code](https://claude.com/claude-code)
