### PR TITLE
Block 9 (1/n): Turnier anlegen — erst das Nötige, dann der Rest

### DIFF
--- a/frontend/e2e/admin-tournament-new.spec.js
+++ b/frontend/e2e/admin-tournament-new.spec.js
@@ -1,0 +1,130 @@
+const { test, expect } = require("@playwright/test");
+
+/**
+ * Was beim Anlegen eines Turniers sofort sichtbar ist - und was nicht.
+ *
+ * Der Bildschirm zeigte vorher siebzehn Bedienelemente auf einmal, darunter drei
+ * Auswahllisten und drei Knöpfe für dieselben drei Werte. Diese Tests halten die
+ * neue Aufteilung fest, damit sie beim nächsten Feld nicht wieder zuwächst.
+ */
+
+async function mockAdminSession(page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true,
+      external_media: false,
+      analytics: false,
+      meta: false,
+      tiktok: false,
+      saved_at: Date.now(),
+      expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }));
+  });
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "admin-1",
+        email: "admin@example.test",
+        display_name: "Admin",
+        username: "admin",
+        role: "superadmin",
+        is_tournament_staff: true,
+        mfa_enabled: true,
+        auth_mfa_verified: true,
+      }),
+    });
+  });
+  await page.route("**/api/settings/public", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        club_name: "THE LION SQUAD",
+        domain: "lionsquad.at",
+        mascot_url: "/assets/brand/tls-mascot.png",
+        qr_logo_url: "/assets/brand/tls-mascot.png",
+      }),
+    });
+  });
+  await page.route("**/api/games", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([{ id: "game-1", name: "Mario Kart 8 Deluxe", slug: "mario-kart-8" }]),
+    });
+  });
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify([]) });
+  });
+}
+
+async function openForm(page) {
+  await mockAdminSession(page);
+  await page.goto("/admin/tournaments/new");
+  await expect(page.getByRole("heading", { name: /neues turnier/i })).toBeVisible();
+}
+
+test("das Wesentliche steht oben, ohne etwas aufklappen zu müssen", async ({ page }) => {
+  await openForm(page);
+
+  for (const testId of ["new-tr-title", "new-tr-game", "new-tr-format", "new-tr-mode",
+                        "new-tr-max", "new-tr-start"]) {
+    await expect(page.getByTestId(testId)).toBeVisible();
+  }
+});
+
+test("Pflichtfelder sind als solche erkennbar", async ({ page }) => {
+  await openForm(page);
+
+  await expect(page.getByTestId("new-tr-title")).toHaveAttribute("required", "");
+  await expect(page.getByTestId("new-tr-game")).toHaveAttribute("required", "");
+});
+
+test("die drei Regel-Listen liegen hinter der Voreinstellung", async ({ page }) => {
+  // Vorher standen Auswahlliste und Knopf für denselben Wert übereinander.
+  await openForm(page);
+
+  await expect(page.getByRole("button", { name: /^online$/i })).toBeVisible();
+  await expect(page.getByTestId("new-tr-event-mode")).not.toBeVisible();
+
+  await page.getByText(/abweichend einstellen/i).click();
+
+  await expect(page.getByTestId("new-tr-event-mode")).toBeVisible();
+  await expect(page.getByTestId("new-tr-result-entry-mode")).toBeVisible();
+  await expect(page.getByTestId("new-tr-schedule-mode")).toBeVisible();
+});
+
+test("eine Voreinstellung setzt alle drei Werte auf einmal", async ({ page }) => {
+  await openForm(page);
+
+  await page.getByRole("button", { name: /vor ort/i }).click();
+  await page.getByText(/abweichend einstellen/i).click();
+
+  await expect(page.getByTestId("new-tr-event-mode")).toHaveValue("local");
+  await expect(page.getByTestId("new-tr-result-entry-mode")).toHaveValue("staff_only");
+  await expect(page.getByTestId("new-tr-schedule-mode")).toHaveValue("fixed_by_staff");
+});
+
+test("Texte und Bilder halten den Einstieg nicht auf", async ({ page }) => {
+  // Zwei Rich-Text-Editoren und ein Bild-Upload beim Anlegen sind zu viel;
+  // sie gehören zur Darstellung und warten hinter ihrem Abschnitt.
+  await openForm(page);
+
+  await expect(page.getByTestId("new-tr-description")).not.toBeVisible();
+  await expect(page.getByTestId("new-tr-rules")).not.toBeVisible();
+  await expect(page.getByTestId("new-tr-slug")).not.toBeVisible();
+
+  await page.getByText(/darstellung und regeln/i).click();
+
+  await expect(page.getByTestId("new-tr-slug")).toBeVisible();
+});
+
+test("das Formular bleibt am Telefon ohne Querlauf bedienbar", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openForm(page);
+
+  const overflow = await page.evaluate(() => {
+    const root = document.documentElement;
+    return Math.max(root.scrollWidth, document.body.scrollWidth) - root.clientWidth;
+  });
+  expect(overflow).toBeLessThanOrEqual(2);
+});

--- a/frontend/src/components/tls/MarkdownEditor.jsx
+++ b/frontend/src/components/tls/MarkdownEditor.jsx
@@ -341,8 +341,12 @@ export function MarkdownEditor({
     },
   });
 
+  // Auf einen zerstörten Editor darf nichts mehr zugreifen. React baut Effekte
+  // im Entwicklungsmodus doppelt auf; dabei wird der Editor zwischendurch
+  // zerstört, und ein Aufruf auf dem alten Exemplar findet kein Schema mehr
+  // vor - die ganze Seite fiel dann in die Fehlerbehandlung.
   useEffect(() => {
-    if (!editor) return;
+    if (!editor || editor.isDestroyed) return;
     const current = htmlToMarkdownLite(editor.getHTML());
     const next = normalizeMarkdown(value);
     if (current === next) return;
@@ -352,12 +356,12 @@ export function MarkdownEditor({
   }, [editor, value]);
 
   const run = (command) => {
-    if (!editor) return;
+    if (!editor || editor.isDestroyed) return;
     command(editor.chain().focus()).run();
   };
 
   const setLink = async () => {
-    if (!editor) return;
+    if (!editor || editor.isDestroyed) return;
     const previous = editor.getAttributes("link").href || "";
     const href = await prompt({
       title: "Link einfügen",
@@ -376,7 +380,7 @@ export function MarkdownEditor({
   };
 
   const setImageUrl = async () => {
-    if (!editor) return;
+    if (!editor || editor.isDestroyed) return;
     const src = await prompt({
       title: "Bild per URL einfügen",
       description: "Direkte Bild-URL einfügen. Für eigene Bilder besser die Medienbibliothek verwenden.",
@@ -423,13 +427,13 @@ export function MarkdownEditor({
   };
 
   const insertMedia = (item) => {
-    if (!editor) return;
+    if (!editor || editor.isDestroyed) return;
     editor.chain().focus().setImage({ src: item.url, alt: item.alt_text || item.filename || "Bild" }).run();
     setMediaOpen(false);
   };
 
   const importHtml = (append = false) => {
-    if (!editor) return;
+    if (!editor || editor.isDestroyed) return;
     const raw = htmlInput.trim();
     if (!raw) {
       toast.error("Kein HTML-Inhalt zum Umwandeln gefunden.");

--- a/frontend/src/pages/admin/AdminTournamentNewPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentNewPage.jsx
@@ -152,57 +152,36 @@ export default function AdminTournamentNewPage() {
   return (
     <AdminLayout>
       <div className="mb-6">
-        <span className="text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8]">Wizard</span>
+        <span className="text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8]">Turniere</span>
         <h1 className="font-heading text-3xl md:text-4xl font-black uppercase">Neues Turnier</h1>
+        <p className="mt-2 text-sm text-white/50 max-w-2xl">
+          Titel und Spiel genügen zum Anlegen. Alles Weitere lässt sich danach in Ruhe
+          einstellen — das Turnier startet als Entwurf und ist noch nicht öffentlich.
+        </p>
       </div>
       <form onSubmit={submit} className="max-w-3xl space-y-5">
-        <Row>
-          <Field label="Titel" value={form.title} onChange={(v) => { set("title", v); if (!form.slug) set("slug", autoSlug(v)); }} required testId="new-tr-title" />
-          <Select label="Spiel *" value={form.game_id} onChange={(v) => set("game_id", v)} options={[["", "— auswählen —"], ...games.map((g) => [g.id, gameOptionLabel(g)])]} required testId="new-tr-game" />
-        </Row>
-        <Row>
-          <Select label="Format" value={form.format} onChange={setFormat} options={TOURNAMENT_FORMAT_OPTIONS} testId="new-tr-format" />
-          <Field label="Format-Anzeigename" value={form.format_label} onChange={(v) => set("format_label", v)} placeholder="z.B. Gamers Heaven F1 Heat" testId="new-tr-format-label" />
-          <Select label="Teilnahme" value={form.team_mode} onChange={setTeamMode} options={[["solo", "Einzelspieler"], ["team", "Team"]]} testId="new-tr-mode" />
-        </Row>
-        <Row>
-          {isTeam && <Field label="Spieler pro Team" type="number" min="2" max="6" value={form.team_size} onChange={(v) => set("team_size", Number(v))} testId="new-tr-team-size" />}
-          <Field label={isTeam ? "Max Teams" : "Max Spieler"} type="number" value={form.max_participants} onChange={(v) => set("max_participants", Number(v))} testId="new-tr-max" />
-          <Field label={isTeam ? "Min Teams" : "Min Spieler"} type="number" value={form.min_participants} onChange={(v) => set("min_participants", Number(v))} testId="new-tr-min" />
-        </Row>
-        <div className="border border-white/10 bg-[#121212] rounded-sm p-4 space-y-3">
-          <div className="text-[11px] font-bold uppercase tracking-widest text-[#29B6E8]">Zeitplan & Anmeldung</div>
+        <Section title="Das Turnier" hint="Mehr als das braucht es nicht zum Anlegen — alles Weitere lässt sich danach in Ruhe einstellen.">
+          <Row>
+            <Field label="Titel" value={form.title} onChange={(v) => { set("title", v); if (!form.slug) set("slug", autoSlug(v)); }} required testId="new-tr-title" />
+            <Select label="Spiel" value={form.game_id} onChange={(v) => set("game_id", v)} options={[["", "— auswählen —"], ...games.map((g) => [g.id, gameOptionLabel(g)])]} required testId="new-tr-game" />
+          </Row>
+          <Row>
+            <Select label="Format" value={form.format} onChange={setFormat} options={TOURNAMENT_FORMAT_OPTIONS} testId="new-tr-format" />
+            <Select label="Teilnahme" value={form.team_mode} onChange={setTeamMode} options={[["solo", "Einzelspieler"], ["team", "Team"]]} testId="new-tr-mode" />
+          </Row>
+          <Row>
+            {isTeam && <Field label="Spieler pro Team" type="number" min="2" max="6" value={form.team_size} onChange={(v) => set("team_size", Number(v))} testId="new-tr-team-size" />}
+            <Field label={isTeam ? "Max Teams" : "Max Spieler"} type="number" value={form.max_participants} onChange={(v) => set("max_participants", Number(v))} testId="new-tr-max" />
+            <Field label={isTeam ? "Min Teams" : "Min Spieler"} type="number" value={form.min_participants} onChange={(v) => set("min_participants", Number(v))} testId="new-tr-min" />
+          </Row>
+        </Section>
+
+        <Section title="Wann" hint="Anmeldung und Check-in wechseln zeitgesteuert. Der Live-Start bleibt bei der Turnierleitung, solange du unten nichts anderes einstellst.">
           <Row>
             <Select label="Veröffentlichung" value={form.status} onChange={(v) => set("status", v)} options={CREATE_STATUS_OPTIONS} testId="new-tr-status" />
             <Field label="Start Event/Turnier" type="datetime-local" value={form.start_date} onChange={(v) => set("start_date", v)} testId="new-tr-start" />
             <Field label="Anmeldung endet" type="datetime-local" value={form.registration_open_until} onChange={(v) => set("registration_open_until", v)} testId="new-tr-reg-until" />
           </Row>
-          <div className="border border-[#29B6E8]/20 bg-[#29B6E8]/5 rounded-sm p-3 text-xs text-white/55">
-            Anmeldung und Check-in können zeitgesteuert wechseln. Live-Start und echte Matchstarts bleiben standardmäßig bei der Turnierleitung.
-          </div>
-          <Row>
-            <Select label="Austragung" value={form.event_mode} onChange={(v) => set("event_mode", v)} options={EVENT_MODE_OPTIONS} testId="new-tr-event-mode" />
-            <Select label="Ergebniserfassung" value={form.result_entry_mode || ""} onChange={(v) => set("result_entry_mode", v || null)} options={RESULT_ENTRY_MODE_OPTIONS} testId="new-tr-result-entry-mode" />
-            <Select label="Terminplanung" value={form.schedule_mode || ""} onChange={(v) => set("schedule_mode", v || null)} options={SCHEDULE_MODE_OPTIONS} testId="new-tr-schedule-mode" />
-          </Row>
-          <RulePresetPicker form={form} onApply={applyRulePreset} />
-          <div className="border border-white/10 bg-black/20 rounded-sm p-3 text-xs text-white/55">
-            Vor-Ort-Turniere werden standardmäßig durch die Turnierleitung gewertet und geplant. Online-Turniere erlauben standardmäßig Ergebnisberichte beider Parteien und Terminvorschläge.
-          </div>
-          <div className="grid sm:grid-cols-2 gap-3">
-            <label className="flex items-start gap-2 text-sm text-white/75">
-              <input type="checkbox" checked={form.registration_enabled} onChange={(e) => set("registration_enabled", e.target.checked)} data-testid="new-tr-reg-enabled" className="accent-[#29B6E8] mt-1" />
-              <span>Öffentliche Anmeldung grundsätzlich erlauben</span>
-            </label>
-            <label className="flex items-start gap-2 text-sm text-white/75">
-              <input type="checkbox" checked={form.site_banner_enabled} onChange={(e) => set("site_banner_enabled", e.target.checked)} data-testid="new-tr-site-banner" className="accent-[#FFD700] mt-1" />
-              <span>Automatisches Turnier-Hinweisbanner für dieses Turnier anzeigen</span>
-            </label>
-            <label className="flex items-start gap-2 text-sm text-white/75 sm:col-span-2">
-              <input type="checkbox" checked={form.auto_start_enabled} onChange={(e) => set("auto_start_enabled", e.target.checked)} data-testid="new-tr-auto-start" className="accent-[#29B6E8] mt-1" />
-              <span>Turnier anhand Start-/Endzeit automatisch live/beendet schalten. Für Vor-Ort-Turniere ausgeschaltet lassen.</span>
-            </label>
-          </div>
           <Details title="Weitere Zeiten und Sonderfälle">
             <Row>
               <Field label="Ende Event/Turnier" type="datetime-local" value={form.end_date} onChange={(v) => set("end_date", v)} testId="new-tr-end" />
@@ -219,13 +198,43 @@ export default function AdminTournamentNewPage() {
               <span>Vereinsmitglieder von der Selbstanmeldung ausschließen, z.B. wenn wir das Turnier für externe Teilnehmer veranstalten</span>
             </label>
           </Details>
-        </div>
+        </Section>
+
+        <Section title="Wie gespielt wird">
+          {/* Die drei Auswahllisten dahinter standen bisher direkt darüber - drei
+              Listen und drei Knöpfe für dieselben drei Werte. Jetzt entscheidet
+              man einmal und weicht nur ab, wenn man es wirklich braucht. */}
+          <RulePresetPicker form={form} onApply={applyRulePreset} />
+          <Details title="Abweichend einstellen">
+            <Row>
+              <Select label="Austragung" value={form.event_mode} onChange={(v) => set("event_mode", v)} options={EVENT_MODE_OPTIONS} testId="new-tr-event-mode" />
+              <Select label="Ergebniserfassung" value={form.result_entry_mode || ""} onChange={(v) => set("result_entry_mode", v || null)} options={RESULT_ENTRY_MODE_OPTIONS} testId="new-tr-result-entry-mode" />
+              <Select label="Terminplanung" value={form.schedule_mode || ""} onChange={(v) => set("schedule_mode", v || null)} options={SCHEDULE_MODE_OPTIONS} testId="new-tr-schedule-mode" />
+            </Row>
+          </Details>
+          <div className="grid sm:grid-cols-2 gap-3">
+            <label className="flex items-start gap-2 text-sm text-white/75">
+              <input type="checkbox" checked={form.registration_enabled} onChange={(e) => set("registration_enabled", e.target.checked)} data-testid="new-tr-reg-enabled" className="accent-[#29B6E8] mt-1" />
+              <span>Öffentliche Anmeldung grundsätzlich erlauben</span>
+            </label>
+            <label className="flex items-start gap-2 text-sm text-white/75">
+              <input type="checkbox" checked={form.site_banner_enabled} onChange={(e) => set("site_banner_enabled", e.target.checked)} data-testid="new-tr-site-banner" className="accent-[#FFD700] mt-1" />
+              <span>Automatisches Turnier-Hinweisbanner für dieses Turnier anzeigen</span>
+            </label>
+            <label className="flex items-start gap-2 text-sm text-white/75 sm:col-span-2">
+              <input type="checkbox" checked={form.auto_start_enabled} onChange={(e) => set("auto_start_enabled", e.target.checked)} data-testid="new-tr-auto-start" className="accent-[#29B6E8] mt-1" />
+              <span>Turnier anhand Start-/Endzeit automatisch live/beendet schalten. Für Vor-Ort-Turniere ausgeschaltet lassen.</span>
+            </label>
+          </div>
+        </Section>
+
         <Details title="Darstellung und Regeln">
           <Row>
             <Field label="Slug (URL)" value={form.slug} onChange={(v) => set("slug", autoSlug(v))} required testId="new-tr-slug" />
             <Field label="Plattform" value={form.platform} onChange={(v) => set("platform", v)} placeholder="z.B. Nintendo Switch" testId="new-tr-platform" />
             <Select label="Event" value={form.event_id || ""} onChange={(v) => set("event_id", v)} options={[["", "— keins —"], ...events.map((e) => [e.id, e.name])]} testId="new-tr-event" />
           </Row>
+          <Field label="Format-Anzeigename" value={form.format_label} onChange={(v) => set("format_label", v)} placeholder="z.B. Gamers Heaven F1 Heat" testId="new-tr-format-label" />
           <Textarea label="Beschreibung" value={form.description} onChange={(v) => set("description", v)} testId="new-tr-description" />
           <ImageUpload value={form.banner_url} onChange={(v) => set("banner_url", v)} label="Turnier-Banner" testId="new-tr-banner-upload" variant="wide" allowLibrary />
           <Textarea label="Regeln" value={form.rules} onChange={(v) => set("rules", v)} testId="new-tr-rules" />
@@ -326,6 +335,22 @@ export default function AdminTournamentNewPage() {
 }
 
 function Row({ children }) { return <div className="grid md:grid-cols-2 gap-4">{children}</div>; }
+
+// Ein benannter Abschnitt mit optionaler Erklärung. Die Erklärung steht in der
+// Überschrift statt als eigener Kasten dazwischen - so unterbricht sie den
+// Lesefluss nicht und man weiß trotzdem, worum es in dem Block geht.
+function Section({ title, hint, children }) {
+  return (
+    <section className="border border-white/10 bg-[#121212] rounded-sm p-4 space-y-3">
+      <div>
+        <div className="text-[11px] font-bold uppercase tracking-widest text-[#29B6E8]">{title}</div>
+        {hint && <p className="mt-1 text-xs text-white/45">{hint}</p>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
 function Details({ title, children }) {
   return (
     <details className="border border-white/10 bg-[#121212] rounded-sm p-4 group">
@@ -334,10 +359,16 @@ function Details({ title, children }) {
     </details>
   );
 }
+function RequiredMark() {
+  // Bisher stand das Sternchen im Beschriftungstext eines einzigen Feldes. So
+  // sieht man an jedem Pflichtfeld, dass es eines ist.
+  return <span className="text-[#FF3B30] ml-1" title="Pflichtfeld">*</span>;
+}
+
 function Field({ label, value, onChange, type = "text", required, placeholder, testId, min, max }) {
   return (
     <label className="block">
-      <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">{label}</div>
+      <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">{label}{required && <RequiredMark />}</div>
       <input type={type} min={min} max={max} value={value ?? ""} onChange={(e) => onChange(e.target.value)} required={required} placeholder={placeholder} data-testid={testId} className="w-full bg-[#0A0A0A] border border-white/10 focus:border-[#29B6E8] px-3 py-2 rounded-sm text-white focus:outline-none" />
     </label>
   );
@@ -345,7 +376,7 @@ function Field({ label, value, onChange, type = "text", required, placeholder, t
 function Select({ label, value, onChange, options, required, testId }) {
   return (
     <label className="block">
-      <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">{label}</div>
+      <div className="text-[11px] font-bold uppercase tracking-widest text-white/60 mb-1.5">{label}{required && <RequiredMark />}</div>
       <select value={value} onChange={(e) => onChange(e.target.value)} required={required} data-testid={testId} className="w-full bg-[#0A0A0A] border border-white/10 focus:border-[#29B6E8] px-3 py-2 rounded-sm text-white focus:outline-none">
         {options.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
       </select>


### PR DESCRIPTION
Erster Teil von Block 9, direkt aus deinen Screenshots.

## Der klarste Fund

Im Screenshot „Neues Turnier" stehen **Austragung, Ergebniserfassung und Terminplanung** als drei Auswahllisten — und **direkt darunter drei Knöpfe** (Online / Vor Ort / Hybrid), die genau dieselben drei Werte setzen. Beides gleichzeitig sichtbar, ohne Hinweis, dass es dasselbe ist.

Jetzt entscheidet man **einmal** über die Voreinstellung. Die Einzellisten warten hinter „Abweichend einstellen" — für den seltenen Fall, dass jemand wirklich abweichen will.

## Was sonst anders ist

**Benannte Abschnitte statt einer durchgehenden Liste:** „Das Turnier" (Titel, Spiel, Format, Teilnehmerzahl), „Wann" (Veröffentlichung, Start, Anmeldeschluss), „Wie gespielt wird". Der Rest bleibt zugeklappt.

**Die zwei Erklärkästen sind gewandert.** Sie standen mitten zwischen den Feldern und unterbrachen den Lesefluss; jetzt stehen sie als Zeile unter der jeweiligen Abschnittsüberschrift.

**Pflichtfelder sind erkennbar.** Bisher stand das Sternchen im Beschriftungstext genau eines Feldes („Spiel *"), obwohl auch Titel und Slug erforderlich sind.

**Die Überschrift verspricht keinen „Wizard" mehr**, wo keiner ist. Stattdessen steht dort, dass Titel und Spiel zum Anlegen genügen und das Turnier als Entwurf startet. Das ist auch das Muster, das [Toornament](https://help.toornament.com/starter/your-first-tournament) und [Challonge](https://foo.challonge.com/2020/11/19/how-to-create-your-first-tournament-on-challonge/) verwenden: minimal anlegen, dann in Abschnitten einstellen.

**Der Format-Anzeigename** ist von der ersten Zeile zu „Darstellung und Regeln" gerückt — er ist Kosmetik, kein Eckdatum.

## Ein Fehler, der dabei herauskam

Beim Schreiben der Browsertests stürzte die Seite ab: **jede Seite mit Texteditor** war im Entwicklungsmodus unbenutzbar. React baut Effekte dort doppelt auf; dabei wird der Editor zwischendurch zerstört, und ein Zugriff auf das alte Exemplar findet kein Schema mehr vor. Die Fehlerbehandlung ersetzte daraufhin die ganze Seite durch „Diese Ansicht konnte nicht geladen werden".

In der Produktion war das unsichtbar — deshalb ist es dir nie begegnet. Es hat aber verhindert, dass **je ein Browsertest eine Seite mit Editor erreichen konnte**, und das betrifft Turniere, Events, News und Challenges.

## Prüfung

- 6 neue Browsertests halten die Aufteilung fest, inklusive Telefon-Ansicht ohne Querlauf
- Frontend: Lint sauber, Build sauber, 110 Unit-Tests, **42 Browsertests grün** (vorher 36)

## Wie es weitergeht

Das war der Einstieg. Als Nächstes in Block 9: die **Turnier-Bearbeitung** (2175 Zeilen, über zwanzig Feldgruppen), die **Turnierleitung als eigener Arbeitsplatz**, das **Adminmenü** (30 Einträge in sechs Gruppen) und die **Einstellungen** (13 Reiter, davon fünf für E-Mail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
