### PR TITLE
Block 9 (2/n): Dashboard — erst was ansteht, dann die Zahlen

### DIFF
--- a/frontend/e2e/admin-dashboard.spec.js
+++ b/frontend/e2e/admin-dashboard.spec.js
@@ -1,0 +1,175 @@
+const { test, expect } = require("@playwright/test");
+
+async function mockAdminSession(page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true,
+      external_media: false,
+      analytics: false,
+      meta: false,
+      tiktok: false,
+      saved_at: Date.now(),
+      expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }));
+  });
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "admin-1",
+        email: "admin@example.test",
+        display_name: "Admin",
+        username: "admin",
+        role: "superadmin",
+        is_tournament_staff: true,
+        mfa_enabled: true,
+        auth_mfa_verified: true,
+      }),
+    });
+  });
+  await page.route("**/api/settings/public", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ club_name: "THE LION SQUAD", domain: "lionsquad.at" }),
+    });
+  });
+  await page.route("**/api/settings/auth", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ password_login_enabled: true, google_login_enabled: false, registration_enabled: true }),
+    });
+  });
+  await page.route("**/api/admin/system-status", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        database: { ok: true },
+        smtp: { ok: true, provider: "resend" },
+        discord: { ok: false },
+        scheduler: { running: true, jobs: [] },
+        mail_queue: { pending: 0, failed: 0 },
+      }),
+    });
+  });
+  await page.route("**/api/admin/growth-stats**", async (route) => {
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ days: [] }) });
+  });
+}
+
+/**
+ * `busy: false` ist der ruhige Betrieb - nichts offen. `busy: true` stellt
+ * genau zwei echte Aufgaben scharf: Einsprüche und Mitgliedsanträge.
+ */
+async function mockDashboard(page, { busy = false } = {}) {
+  await page.route("**/api/setup/status", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ completed: true, health_score: 100, missing: [] }),
+    });
+  });
+  await page.route("**/api/admin/dashboard", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        player_count: 42,
+        team_count: 7,
+        active_tournaments: 2,
+        registration_open: 1,
+        today_matches: 3,
+        active_f1: 0,
+        total_events: 11,
+        open_disputes: busy ? 4 : 0,
+        membership_applications: { pending: busy ? 2 : 0 },
+        tournament_registrations: { pending: 0 },
+        prize_pickups: { pending: 0, ready: 0 },
+        mobile_push: { active_tokens: 12, ticket_errors: 0, receipt_errors: 0 },
+        client_logs: { open: 0, critical_open: 0, high_open: 0 },
+        recent_audit_logs: [],
+      }),
+    });
+  });
+}
+
+test.describe("admin dashboard layout", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAdminSession(page);
+  });
+
+  test("offene Aufgaben stehen über den Kennzahlen", async ({ page }) => {
+    await mockDashboard(page, { busy: true });
+    await page.goto("/admin");
+
+    const tasks = page.getByTestId("dashboard-tasks");
+    const kpis = page.getByTestId("dashboard-kpis");
+    await expect(tasks).toBeVisible();
+    await expect(kpis).toBeVisible();
+
+    const tasksBox = await tasks.boundingBox();
+    const kpisBox = await kpis.boundingBox();
+    expect(tasksBox.y).toBeLessThan(kpisBox.y);
+  });
+
+  test("Schnellzugriff liegt vor den Kennzahlen und dem Wachstumsdiagramm", async ({ page }) => {
+    await mockDashboard(page, { busy: true });
+    await page.goto("/admin");
+
+    const quick = page.getByTestId("dashboard-quick-actions");
+    await expect(quick).toBeVisible();
+    await expect(page.getByTestId("quick-new-tournament")).toBeVisible();
+
+    const quickBox = await quick.boundingBox();
+    const kpisBox = await page.getByTestId("dashboard-kpis").boundingBox();
+    const growthBox = await page.getByTestId("dashboard-growth-widget").boundingBox();
+    expect(quickBox.y).toBeLessThan(kpisBox.y);
+    expect(kpisBox.y).toBeLessThan(growthBox.y);
+  });
+
+  test("nur echte Aufgaben erscheinen in der Aufgabenliste", async ({ page }) => {
+    await mockDashboard(page, { busy: true });
+    await page.goto("/admin");
+
+    const tasks = page.getByTestId("dashboard-tasks");
+    await expect(tasks.getByRole("heading", { name: /offene aufgaben · 2/i })).toBeVisible();
+    await expect(tasks.getByRole("link", { name: /ergebnis-konflikte/i })).toBeVisible();
+    await expect(tasks.getByRole("link", { name: /mitgliedsanträge/i })).toBeVisible();
+
+    // Routinelinks bleiben in "Weitere Werkzeuge" eingeklappt, statt sich als
+    // offene Aufgabe auszugeben.
+    const details = tasks.locator("details");
+    await expect(details.getByRole("link", { name: /medien-check/i })).toBeHidden();
+    await details.locator("summary").click();
+    await expect(details.getByRole("link", { name: /medien-check/i })).toBeVisible();
+  });
+
+  test("ohne offene Punkte erscheint ein Leerhinweis statt Pseudo-Aufgaben", async ({ page }) => {
+    await mockDashboard(page, { busy: false });
+    await page.goto("/admin");
+
+    const tasks = page.getByTestId("dashboard-tasks");
+    await expect(tasks.getByTestId("dashboard-tasks-empty")).toBeVisible();
+    await expect(tasks.getByTestId("dashboard-tasks-empty")).toContainText(/nichts offen/i);
+    await expect(tasks.getByRole("heading", { name: /offene aufgaben$/i })).toBeVisible();
+  });
+
+  test("Kennzahlen wiederholen keine Aufgabenwerte", async ({ page }) => {
+    await mockDashboard(page, { busy: true });
+    await page.goto("/admin");
+
+    await expect(page.getByTestId("kpi-Spieler")).toContainText("42");
+    await expect(page.getByTestId("kpi-Events Gesamt")).toContainText("11");
+
+    for (const doubled of ["Offene Disputes", "Mitgliedsanträge", "Gewinne offen", "Push aktiv", "Offene Logs"]) {
+      await expect(page.getByTestId(`kpi-${doubled}`)).toHaveCount(0);
+    }
+  });
+
+  test("kein horizontaler Überlauf auf 390px", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockDashboard(page, { busy: true });
+    await page.goto("/admin");
+    await expect(page.getByTestId("dashboard-tasks")).toBeVisible();
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/e2e/public.spec.js
+++ b/frontend/e2e/public.spec.js
@@ -221,8 +221,16 @@ test("logout keeps the visible session when server revocation fails", async ({ p
   await acceptCookies(page);
   await expect(page.getByTestId("nav-logout")).toBeVisible();
   await page.getByTestId("nav-logout").click();
-  await expect(page.getByText("Logout derzeit nicht möglich")).toBeVisible();
+  const errorToast = page.getByText("Logout derzeit nicht möglich");
+  await expect(errorToast).toBeVisible();
   await expect(page.getByTestId("nav-logout")).toBeVisible();
+
+  // Der Toast liegt oben rechts über der Navigation. Für den zweiten Klick
+  // fährt Playwright mit dem Zeiger dorthin, und Sonner hält das Ausblenden
+  // an, solange der Zeiger darauf steht - der Klick käme nie an. Also den
+  // Zeiger wegstellen und den Toast von selbst verschwinden lassen.
+  await page.mouse.move(0, 0);
+  await expect(errorToast).toBeHidden({ timeout: 15_000 });
 
   await page.getByTestId("nav-logout").click();
   await expect(page.getByTestId("nav-logout")).toHaveCount(0);

--- a/frontend/src/pages/admin/AdminDashboardPage.jsx
+++ b/frontend/src/pages/admin/AdminDashboardPage.jsx
@@ -62,19 +62,17 @@ export default function AdminDashboardPage() {
   ];
 
 
+  // Nur Zahlen zum Nachschauen. Alles, wo jemand etwas tun muss - Einsprüche,
+  // Mitgliedsanträge, Gewinne, Push-Fehler, Logs - steht in den offenen
+  // Aufgaben und stand hier bisher ein zweites Mal.
   const kpis = [
     { label: "Spieler", value: data?.player_count, icon: UsersIcon, color: "#29B6E8" },
     { label: "Teams", value: data?.team_count, icon: UsersIcon, color: "#29B6E8" },
     { label: "Aktive Turniere", value: data?.active_tournaments, icon: Trophy, color: "#FF3B30" },
     { label: "Anmeldung offen", value: data?.registration_open, icon: GamepadIcon, color: "#00FF88" },
     { label: "Spiele heute", value: data?.today_matches, icon: Radio, color: "#FFD700" },
-    { label: "Offene Disputes", value: data?.open_disputes, icon: AlertTriangle, color: "#FF3B30" },
     { label: "Fast Lap Live", value: data?.active_f1, icon: Flag, color: "#29B6E8" },
     { label: "Events Gesamt", value: data?.total_events, icon: CalendarDays, color: "#29B6E8" },
-    { label: "Mitgliedsanträge", value: data?.membership_applications?.pending, icon: Inbox, color: "#FFD700" },
-    { label: "Gewinne offen", value: data?.prize_pickups?.pending, icon: Award, color: "#FFD700" },
-    { label: "Push aktiv", value: data?.mobile_push?.active_tokens, icon: BellRing, color: "#00FF88" },
-    { label: "Offene Logs", value: data?.client_logs?.open, icon: Bug, color: "#FFD700" },
   ];
   const pushErrors = Number(data?.mobile_push?.ticket_errors || 0) + Number(data?.mobile_push?.receipt_errors || 0);
   const pendingApplications = Number(data?.membership_applications?.pending || 0);
@@ -179,11 +177,10 @@ export default function AdminDashboardPage() {
     if (item.to === "/admin/mobile-logs") return Number(data?.client_logs?.open || 0) > 0;
     return false;
   };
-  const fallbackTaskRoutes = ["/admin/media", "/admin/audit", "/admin/settings?tab=system", "/admin/settings?tab=seo"];
+  // Steht nichts an, wird das gesagt. Früher rückten hier vier Routinelinks
+  // nach und sahen aus wie echte offene Aufgaben.
   const activeTaskItems = taskItems.filter(taskIsActive);
-  const fallbackTaskItems = taskItems.filter((item) => fallbackTaskRoutes.includes(item.to));
-  const primaryTaskItems = activeTaskItems.length ? activeTaskItems : fallbackTaskItems;
-  const secondaryTaskItems = taskItems.filter((item) => !primaryTaskItems.includes(item));
+  const secondaryTaskItems = taskItems.filter((item) => !activeTaskItems.includes(item));
 
   const growthData = (growth?.days || []).map((d) => ({
     ...d,
@@ -247,16 +244,80 @@ export default function AdminDashboardPage() {
           </div>
         </Link>
       )}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {kpis.map((k) => (
-          <div key={k.label} data-testid={`kpi-${k.label}`} className="border border-white/10 rounded-sm bg-[#121212] p-4 hover:border-[#29B6E8]/40 transition">
-            <div className="flex items-center justify-between">
-              <span className="text-[10px] uppercase tracking-widest text-white/50 font-bold">{k.label}</span>
-              <k.icon className="w-4 h-4" style={{ color: k.color }} />
-            </div>
-            <div className="mt-3 font-display font-bold text-4xl text-white">{k.value ?? "—"}</div>
+      {/* Arbeit vor Statistik: was jemand anfassen muss, steht oben. */}
+      <div className="mb-6 border border-white/10 rounded-sm bg-[#121212] p-5" data-testid="dashboard-tasks">
+        <div className="flex items-center justify-between gap-4 mb-4">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.28em] text-[#29B6E8] font-bold">Tageszentrale</div>
+            <h2 className="font-heading font-bold uppercase text-lg mt-1">
+              Offene Aufgaben{activeTaskItems.length > 0 ? ` · ${activeTaskItems.length}` : ""}
+            </h2>
           </div>
-        ))}
+          <span className="text-xs text-white/40">{new Date().toLocaleDateString("de-DE")}</span>
+        </div>
+        {activeTaskItems.length > 0 ? (
+          <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-3">
+            {activeTaskItems.map((item) => (
+              <Link key={item.label} to={item.to} className="border border-white/10 bg-[#0A0A0A] rounded-sm p-4 hover:border-[#29B6E8]/50 transition group">
+                <div className="flex items-center justify-between gap-3">
+                  <item.icon className="w-4 h-4" style={{ color: item.tone }} />
+                  <span className="text-[#29B6E8] group-hover:translate-x-0.5 transition-transform">→</span>
+                </div>
+                <div className="mt-3 text-xs font-bold uppercase tracking-wider text-white">{item.label}</div>
+                <div className="mt-1 text-xs text-white/45 leading-relaxed">{item.detail}</div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <div data-testid="dashboard-tasks-empty" className="flex items-start gap-3 rounded-sm border border-[#00FF88]/25 bg-[#00FF88]/5 px-4 py-3">
+            <ShieldCheck className="w-4 h-4 text-[#00FF88] shrink-0 mt-0.5" />
+            <span className="text-sm text-white/70">Nichts offen. Keine Konflikte, Anträge, Gewinne oder Fehler warten gerade auf dich.</span>
+          </div>
+        )}
+        {secondaryTaskItems.length > 0 && (
+          <details className="mt-4 border-t border-white/10 pt-4 group">
+            <summary className="cursor-pointer list-none text-[10px] font-bold uppercase tracking-[0.25em] text-white/45 hover:text-white inline-flex items-center gap-2">
+              Weitere Werkzeuge <span className="text-[#29B6E8] group-open:rotate-90 transition-transform">→</span>
+            </summary>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {secondaryTaskItems.map((item) => (
+                <Link
+                  key={item.label}
+                  to={item.to}
+                  className="inline-flex items-center gap-2 rounded-sm border border-white/10 bg-[#0A0A0A] px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-white/55 hover:border-[#29B6E8]/50 hover:text-white"
+                >
+                  <item.icon className="w-3.5 h-3.5" style={{ color: item.tone }} />
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </details>
+        )}
+      </div>
+
+      <div className="mb-8 border border-white/10 rounded-sm bg-[#121212] p-5" data-testid="dashboard-quick-actions">
+        <h2 className="font-heading font-bold uppercase text-lg mb-3">Schnellzugriff</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          <Link to="/admin/tournaments/new" data-testid="quick-new-tournament" className="px-4 py-3 border border-[#29B6E8]/40 text-[#29B6E8] text-sm uppercase tracking-wider font-bold rounded-sm hover:bg-[#29B6E8]/10">+ Turnier</Link>
+          <Link to="/admin/f1/new" data-testid="quick-new-f1" className="px-4 py-3 border border-[#29B6E8]/40 text-[#29B6E8] text-sm uppercase tracking-wider font-bold rounded-sm hover:bg-[#29B6E8]/10">+ Fast-Lap-Challenge</Link>
+          <Link to="/admin/events" className="px-4 py-3 border border-white/10 text-white text-sm uppercase tracking-wider font-bold rounded-sm hover:border-[#29B6E8]/40">Events</Link>
+          <Link to="/admin/stations" className="px-4 py-3 border border-white/10 text-white text-sm uppercase tracking-wider font-bold rounded-sm hover:border-[#29B6E8]/40">Stationen</Link>
+        </div>
+      </div>
+
+      <div data-testid="dashboard-kpis">
+        <h2 className="font-heading font-bold uppercase text-lg mb-3">Zahlen im Überblick</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {kpis.map((k) => (
+            <div key={k.label} data-testid={`kpi-${k.label}`} className="border border-white/10 rounded-sm bg-[#121212] p-4 hover:border-[#29B6E8]/40 transition">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] uppercase tracking-widest text-white/50 font-bold">{k.label}</span>
+                <k.icon className="w-4 h-4" style={{ color: k.color }} />
+              </div>
+              <div className="mt-3 font-display font-bold text-4xl text-white">{k.value ?? "—"}</div>
+            </div>
+          ))}
+        </div>
       </div>
 
       <div className="mt-8 border border-white/10 rounded-sm bg-[#121212] p-5" data-testid="dashboard-growth-widget">
@@ -339,71 +400,19 @@ export default function AdminDashboardPage() {
         </div>
       </div>
 
-      <div className="mt-8 border border-white/10 rounded-sm bg-[#121212] p-5">
-        <div className="flex items-center justify-between gap-4 mb-4">
-          <div>
-            <div className="text-[10px] uppercase tracking-[0.28em] text-[#29B6E8] font-bold">Tageszentrale</div>
-            <h2 className="font-heading font-bold uppercase text-lg mt-1">Offene Aufgaben</h2>
-          </div>
-          <span className="text-xs text-white/40">{new Date().toLocaleDateString("de-DE")}</span>
+      <div className="mt-8 border border-white/10 rounded-sm bg-[#121212] p-5" data-testid="dashboard-audit-log">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="font-heading font-bold uppercase text-lg flex items-center gap-2"><ShieldCheck className="w-4 h-4" /> Letzte Adminaktionen</h2>
+          <Link to="/admin/logs" className="text-[10px] font-bold uppercase tracking-widest text-[#29B6E8] hover:text-white">Alle Logs</Link>
         </div>
-        <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-3">
-          {primaryTaskItems.map((item) => (
-            <Link key={item.label} to={item.to} className="border border-white/10 bg-[#0A0A0A] rounded-sm p-4 hover:border-[#29B6E8]/50 transition group">
-              <div className="flex items-center justify-between gap-3">
-                <item.icon className="w-4 h-4" style={{ color: item.tone }} />
-                <span className="text-[#29B6E8] group-hover:translate-x-0.5 transition-transform">→</span>
-              </div>
-              <div className="mt-3 text-xs font-bold uppercase tracking-wider text-white">{item.label}</div>
-              <div className="mt-1 text-xs text-white/45 leading-relaxed">{item.detail}</div>
-            </Link>
-          ))}
-        </div>
-        {secondaryTaskItems.length > 0 && (
-          <details className="mt-4 border-t border-white/10 pt-4 group">
-            <summary className="cursor-pointer list-none text-[10px] font-bold uppercase tracking-[0.25em] text-white/45 hover:text-white inline-flex items-center gap-2">
-              Weitere Werkzeuge <span className="text-[#29B6E8] group-open:rotate-90 transition-transform">→</span>
-            </summary>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {secondaryTaskItems.map((item) => (
-                <Link
-                  key={item.label}
-                  to={item.to}
-                  className="inline-flex items-center gap-2 rounded-sm border border-white/10 bg-[#0A0A0A] px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-white/55 hover:border-[#29B6E8]/50 hover:text-white"
-                >
-                  <item.icon className="w-3.5 h-3.5" style={{ color: item.tone }} />
-                  {item.label}
-                </Link>
-              ))}
+        <div className="space-y-2 text-sm">
+          {(data?.recent_audit_logs || []).slice(0, 8).map((l, i) => (
+            <div key={i} className="flex items-center justify-between gap-3 border-b border-white/5 pb-2">
+              <span className="text-white/80 min-w-0 truncate">{l.action}</span>
+              <span className="text-white/40 text-xs shrink-0">{l.created_at && new Date(l.created_at).toLocaleString("de-DE")}</span>
             </div>
-          </details>
-        )}
-      </div>
-
-      <div className="mt-10 grid md:grid-cols-2 gap-6">
-        <div className="border border-white/10 rounded-sm bg-[#121212] p-5">
-          <h2 className="font-heading font-bold uppercase text-lg mb-3">Schnellzugriff</h2>
-          <div className="grid grid-cols-2 gap-2">
-            <Link to="/admin/tournaments/new" data-testid="quick-new-tournament" className="px-4 py-3 border border-[#29B6E8]/40 text-[#29B6E8] text-sm uppercase tracking-wider font-bold rounded-sm hover:bg-[#29B6E8]/10">+ Turnier</Link>
-            <Link to="/admin/f1/new" data-testid="quick-new-f1" className="px-4 py-3 border border-[#29B6E8]/40 text-[#29B6E8] text-sm uppercase tracking-wider font-bold rounded-sm hover:bg-[#29B6E8]/10">+ Fast-Lap-Challenge</Link>
-            <Link to="/admin/events" className="px-4 py-3 border border-white/10 text-white text-sm uppercase tracking-wider font-bold rounded-sm hover:border-[#29B6E8]/40">Events</Link>
-            <Link to="/admin/stations" className="px-4 py-3 border border-white/10 text-white text-sm uppercase tracking-wider font-bold rounded-sm hover:border-[#29B6E8]/40">Stationen</Link>
-          </div>
-        </div>
-        <div className="border border-white/10 rounded-sm bg-[#121212] p-5">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <h2 className="font-heading font-bold uppercase text-lg flex items-center gap-2"><ShieldCheck className="w-4 h-4" /> Letzte Adminaktionen</h2>
-            <Link to="/admin/logs" className="text-[10px] font-bold uppercase tracking-widest text-[#29B6E8] hover:text-white">Alle Logs</Link>
-          </div>
-          <div className="space-y-2 text-sm">
-            {(data?.recent_audit_logs || []).slice(0, 8).map((l, i) => (
-              <div key={i} className="flex items-center justify-between border-b border-white/5 pb-2">
-                <span className="text-white/80">{l.action}</span>
-                <span className="text-white/40 text-xs">{l.created_at && new Date(l.created_at).toLocaleString("de-DE")}</span>
-              </div>
-            ))}
-            {(!data || data.recent_audit_logs?.length === 0) && <div className="text-white/40">Keine Einträge.</div>}
-          </div>
+          ))}
+          {(!data || data.recent_audit_logs?.length === 0) && <div className="text-white/40">Keine Einträge.</div>}
         </div>
       </div>
     </AdminLayout>


### PR DESCRIPTION
## Warum

Das Admin-Dashboard begrüßte mit zwölf Kennzahlen-Kacheln, von denen die meisten auf null standen. Die eigentliche Arbeitsliste — „Offene Aufgaben" — lag viertletzter Stelle, unterhalb von Wachstumsdiagramm und Einstellungen-Zentrale.

Dazu kam eine Doppelung: **fünf der zwölf Kacheln** (Offene Disputes, Mitgliedsanträge, Gewinne offen, Push aktiv, Offene Logs) standen weiter unten ohnehin nochmal als Aufgabe — einmal als Zahl ohne Weg, einmal als Aufgabe mit Ziel.

## Was sich ändert

**Reihenfolge.** Statuszeile → Setup-Hinweis → **offene Aufgaben** → **Schnellzugriff** → Kennzahlen → Wachstum → Einstellungen → Logbuch. Was jemand anfassen muss, steht oben; die Statistik darunter.

**Keine Doppelungen mehr.** Die fünf doppelten Kacheln sind aus dem Kennzahlenraster raus. Übrig bleiben sieben reine Zahlen (Spieler, Teams, Aktive Turniere, Anmeldung offen, Spiele heute, Fast Lap Live, Events Gesamt). Alles Handlungspflichtige steht genau einmal — in den Aufgaben, mit Link zum Ziel.

**Ehrlicher Leerzustand.** Stand nichts an, rückten bisher vier Routinelinks (Medien-Check, Audit & Rollen, Systemstatus, SEO) nach und sahen genauso aus wie echte offene Aufgaben. Sie liegen jetzt bei den übrigen Werkzeugen im aufklappbaren Teil; die Liste sagt stattdessen klar, dass nichts offen ist. Die Überschrift zeigt bei Bedarf die Anzahl: „Offene Aufgaben · 2".

**Schnellzugriff** ist aus der Zweispalter-Kachel am Seitenende gelöst und liegt als eigene Zeile direkt unter den Aufgaben — „+ Turnier" ist die häufigste Aktion und war vorher ganz unten. „Letzte Adminaktionen" steht jetzt über die volle Breite am Ende, mit abgeschnittenen statt umbrechenden Aktionsnamen.

## Nebenbefund: ein Test, der gegen seinen eigenen Toast klickte

Beim vollen E2E-Durchlauf fiel `logout keeps the visible session when server revocation fails` — reproduzierbar 5 von 5, unabhängig von diesem Umbau (auf `main` genauso auslösbar).

Ursache: Der Test provoziert absichtlich einen Fehler-Toast und klickt danach denselben Knopf erneut. Der Toast liegt oben rechts über der Navigation. Playwright fährt für den zweiten Klick mit dem Zeiger dorthin — und Sonner hält das Ausblenden an, solange der Zeiger auf dem Toast steht. Der Toast verschwand nie, der Klick kam nie an, der Test lief in die Zeitgrenze.

Der Zeiger wird jetzt weggestellt und das Ausblenden abgewartet. In einem eigenen Commit, damit es vom Dashboard-Umbau trennbar bleibt. Ohne diesen Fix hätte CI hier rot werden können, ohne dass es etwas mit dem Dashboard zu tun hat.

## Nachweise

- Neue Playwright-Datei `frontend/e2e/admin-dashboard.spec.js`, 6 Tests × 2 Projekte (Chromium + Pixel 5), inklusive Prüfung auf horizontalen Überlauf bei 390 px
- **Gegenprobe:** alle 6 neuen Tests fallen am Stand vor dem Umbau und stehen danach — sie prüfen also wirklich etwas
- Voller Playwright-Lauf: 96 bestanden, 8 übersprungen (die brauchen echte Zugangsdaten), 0 Fehlschläge
- `logout keeps` einzeln 16 × wiederholt, alle grün
- Frontend: ESLint ohne Fehler (3 Warnungen sind Altbestand), Vite-Build sauber, 115 Vitest-Tests grün
- `test_german_copy.py` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)