### PR TITLE
Block 9 (3/n): Turnier bearbeiten — aus einer Liga wurde eine Einzelausscheidung

### DIFF
--- a/backend/tests/test_tournament_flows.py
+++ b/backend/tests/test_tournament_flows.py
@@ -349,3 +349,36 @@ async def test_a_drawn_league_match_gives_both_sides_a_point(flow):
     assert rows[first]["points"] == 1
     assert rows[second]["points"] == 1
     assert rows[first]["drawn"] == 1
+
+
+# ---------------------------------------------------------------- Format -> Struktur
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tournament_format,expected_stage_type", [
+    ("single_elim", "single_elimination"),
+    ("double_elim", "double_elimination"),
+    ("round_robin", "round_robin_groups"),
+    ("groups", "round_robin_groups"),
+    ("league", "league"),
+    ("ffa", "simple"),
+    ("battle_royale", "simple"),
+])
+async def test_the_format_alone_decides_the_structure(flow, tournament_format, expected_stage_type):
+    """Ohne mitgeschickten Strukturtyp gilt die Zuordnung aus competition_formats.
+
+    Das Bearbeiten-Formular verlaesst sich darauf: es schickt keinen eigenen
+    Strukturtyp mehr mit, wenn die Turnierleitung keinen gewaehlt hat. Frueher
+    schickte es fuer neun von zwoelf Formaten "single_elimination" - eine Liga
+    wurde damit beim Anwenden zur Einzelausscheidung.
+    """
+    staff = await flow.add_staff()
+    flow.act_as(staff)
+    tournament, _users, _regs = await flow.with_participants(4, format=tournament_format)
+
+    response = await flow.post(
+        f"/api/tournaments/{tournament['id']}/bracket/from-format?preview=false")
+    assert response.status_code == 200, response.text
+
+    stages = (await flow.get(f"/api/tournaments/{tournament['id']}/stages")).json()
+    assert stages, "Es muss eine Phase entstanden sein"
+    assert stages[0]["stage_type"] == expected_stage_type

--- a/frontend/src/pages/admin/AdminTournamentEditPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.jsx
@@ -76,6 +76,9 @@ C=[W:A:1,W:A:2,W:B:1,W:B:2]
 # Runde 1
 LA=[L:A:1,L:A:2,L:B:1,L:B:2]`;
 const CUSTOM_STAGE_TYPES = new Set(["custom_bracket", "ffa_custom_bracket"]);
+// Die beiden Turnierformate, bei denen die Turnierleitung den Baum selbst
+// schreibt. Nur hier hat das Bearbeiten-Formular überhaupt Strukturfelder.
+const CUSTOM_BRACKET_FORMATS = new Set(["custom_bracket", "ffa_custom_bracket"]);
 // Strukturen, die das Backend aus dem Format bauen kann. Schweizer Runden
 // fehlen hier bewusst: die entstehen einzeln über "Schweizer Runde".
 const AUTO_STAGE_TYPES = new Set([
@@ -1606,8 +1609,11 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
   const firstStage = stages[0] || null;
   const stageSettings = firstStage?.settings || {};
   const [structure, setStructure] = useState({
-    stage_type: firstStage?.stage_type || (tournament.format === "double_elim" ? "double_elimination" : tournament.format === "ffa_custom_bracket" ? "ffa_custom_bracket" : tournament.format === "custom_bracket" ? "custom_bracket" : "single_elimination"),
-    match_type: firstStage?.match_type || (tournament.format === "ffa_custom_bracket" ? "ffa" : "duel"),
+    // Ohne vorhandene Phase bleibt der Strukturtyp leer: welcher zu welchem
+    // Format gehört, weiß das Backend (services/competition_formats.py). Hier
+    // stand früher eine zweite, unvollständige Zuordnung.
+    stage_type: firstStage?.stage_type || null,
+    match_type: firstStage?.match_type || null,
     match_size: stageSettings.match_size || (tournament.format === "ffa_custom_bracket" ? 4 : 2),
     min_players: stageSettings.min_players || 2,
     qualifiers_per_match: stageSettings.qualifiers_per_match || (tournament.format === "ffa_custom_bracket" ? 2 : 1),
@@ -1621,14 +1627,23 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
   const set = (k, v) => setF((x) => ({ ...x, [k]: v }));
   const applyRulePreset = (preset) => setF((x) => ({ ...x, ...preset.values }));
   const setStructureField = (k, v) => setStructure((x) => ({ ...x, [k]: v }));
+  // Nach einem Formatwechsel folgt die Struktur wieder dem Format: der eigene
+  // Vorschlag wird gelöscht, nicht neu geraten. Vorher landete hier alles außer
+  // drei Sonderfällen auf "single_elimination" - aus einer Liga, Gruppen, Round
+  // Robin oder FFA wurde beim Anwenden stillschweigend eine Einzelausscheidung.
   const setFormat = (value) => {
     setF((current) => ({ ...current, format: value, bronze_match: BRONZE_FORMATS.has(value) ? current.bronze_match : false }));
-    setStructure((current) => {
-      if (value === "double_elim") return { ...current, stage_type: "double_elimination", match_type: "duel", match_size: 2, min_players: 2, qualifiers_per_match: 1 };
-      if (value === "custom_bracket") return { ...current, stage_type: "custom_bracket", match_type: "duel", match_size: 2, min_players: 2, qualifiers_per_match: 1 };
-      if (value === "ffa_custom_bracket") return { ...current, stage_type: "ffa_custom_bracket", match_type: "ffa", match_size: current.match_size || 4, min_players: 2, qualifiers_per_match: current.qualifiers_per_match || 2, schema: current.schema || DEFAULT_FFA_SCHEMA };
-      return { ...current, stage_type: "single_elimination", match_type: "duel", match_size: 2, min_players: 2, qualifiers_per_match: 1 };
-    });
+    setStructure((current) => ({
+      ...current,
+      stage_type: null,
+      match_type: null,
+      match_size: value === "ffa_custom_bracket" ? (current.match_size || 4) : 2,
+      min_players: 2,
+      qualifiers_per_match: value === "ffa_custom_bracket" ? (current.qualifiers_per_match || 2) : 1,
+      schema: value === "ffa_custom_bracket" ? (current.schema || DEFAULT_FFA_SCHEMA)
+        : value === "custom_bracket" ? current.schema
+          : "",
+    }));
   };
   const normalizeTournamentPayload = (source) => {
     const payload = { ...source };
@@ -1654,20 +1669,30 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
     if (payload.prize_places.length === 0) payload.prize_places = null;
     return payload;
   };
-  const structurePayload = () => ({
-    name: "Turnierbaum",
-    stage_type: structure.stage_type,
-    match_type: structure.match_type,
-    settings: {
-      match_size: Number(structure.match_size) || (structure.match_type === "ffa" ? 4 : 2),
-      min_players: Number(structure.min_players) || 2,
-      qualifiers_per_match: Number(structure.qualifiers_per_match) || (structure.match_type === "ffa" ? 2 : 1),
+  // Mitgeschickt wird nur, was hier wirklich gewählt wurde. Was fehlt, leitet
+  // das Backend aus dem Turnierformat ab; ein mitgeschickter Strukturtyp würde
+  // diese Ableitung überstimmen. Spielgrößen und Schema gibt es nur bei den
+  // freien Turnierbäumen - bei allen anderen Formaten sind sie nicht bedienbar
+  // und würden nur die passenden Vorgaben überschreiben.
+  const structurePayload = () => {
+    const custom = CUSTOM_BRACKET_FORMATS.has(f.format);
+    const settings = {
       duration_minutes: Number(f.match_duration_minutes) || 30,
-      schema: structure.schema || "",
       score_type: "points",
       calculation: "points",
-    },
-  });
+    };
+    if (custom) {
+      const ffa = f.format === "ffa_custom_bracket";
+      settings.schema = structure.schema || "";
+      settings.match_size = Number(structure.match_size) || (ffa ? 4 : 2);
+      settings.min_players = Number(structure.min_players) || 2;
+      settings.qualifiers_per_match = Number(structure.qualifiers_per_match) || (ffa ? 2 : 1);
+    }
+    const payload = { name: "Turnierbaum", settings };
+    if (structure.stage_type) payload.stage_type = structure.stage_type;
+    if (structure.match_type) payload.match_type = structure.match_type;
+    return payload;
+  };
   const setTeamMode = (value) => setF((current) => ({
     ...current,
     team_mode: value,
@@ -1781,7 +1806,7 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
             <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={f.substitutes_allowed} onChange={(e)=>set("substitutes_allowed",e.target.checked)} className="accent-[#29B6E8]"/><span>Ersatzspieler erlauben</span></label>
           </div>
         </Details>
-        {["custom_bracket", "ffa_custom_bracket"].includes(f.format) && (
+        {CUSTOM_BRACKET_FORMATS.has(f.format) && (
           <div className="border border-[#29B6E8]/20 bg-[#29B6E8]/5 rounded-sm p-4 space-y-3">
             <div className="text-[11px] font-bold uppercase tracking-widest text-[#29B6E8]">Freier Turnierbaum</div>
             <div className="grid md:grid-cols-3 gap-3">

--- a/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
@@ -147,6 +147,88 @@ test("ein Ladefehler wird angezeigt statt endlos zu laden", async () => {
   expect(screen.queryByRole("heading", { name: "Winter Cup 2026" })).not.toBeInTheDocument();
 });
 
+// Die Turnierstruktur ist das einzige Strukturfeld, das im Bearbeiten-Formular
+// sichtbar ist. Welcher Strukturtyp daraus folgt, entscheidet das Backend
+// (services/competition_formats.py). Schickt das Formular dabei einen eigenen
+// Strukturtyp mit, gewinnt dieser - deshalb darf es nur mitschicken, was
+// wirklich gewählt wurde.
+function renderPageWithFormat(format) {
+  apiMock.get.mockImplementation((url) => {
+    const path = String(url);
+    if (path.includes("/tournaments/t-1") && !path.includes("/registrations") && !path.includes("/bracket")
+      && !path.includes("/stages") && !path.includes("/matches-v2") && !path.includes("/groups")
+      && !path.includes("/staff") && !path.includes("/stations")) {
+      return Promise.resolve({ data: { ...TOURNAMENT, format } });
+    }
+    return Promise.resolve(routeFor(path));
+  });
+  return renderPage();
+}
+
+async function applyStructure(user) {
+  await user.click(screen.getByTestId("admin-tr-tab-edit"));
+  apiMock.post.mockClear();
+  await user.click(await screen.findByTestId("tr-edit-save-rebuild"));
+  await waitFor(() => expect(apiMock.post).toHaveBeenCalledWith(
+    expect.stringContaining("/bracket/from-format"),
+    expect.anything()
+  ));
+  const [, body] = apiMock.post.mock.calls.find(([url]) => String(url).includes("/bracket/from-format"));
+  return body;
+}
+
+test.each([
+  ["league", "single_elimination"],
+  ["round_robin", "single_elimination"],
+  ["groups", "single_elimination"],
+  ["ffa", "single_elimination"],
+])("Struktur anwenden macht aus %s keine Einzelausscheidung", async (format) => {
+  const user = userEvent.setup();
+  renderPageWithFormat(format);
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  const body = await applyStructure(user);
+
+  expect(body.stage_type).not.toBe("single_elimination");
+});
+
+test("ein Formatwechsel im Formular überschreibt den Strukturtyp nicht mehr selbst", async () => {
+  const user = userEvent.setup();
+  renderPageWithFormat("single_elim");
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+  await user.click(screen.getByTestId("admin-tr-tab-edit"));
+
+  const formatSelect = await screen.findByLabelText("Turnierstruktur");
+  await user.selectOptions(formatSelect, "league");
+
+  apiMock.post.mockClear();
+  await user.click(screen.getByTestId("tr-edit-save-rebuild"));
+  await waitFor(() => expect(apiMock.post).toHaveBeenCalledWith(
+    expect.stringContaining("/bracket/from-format"),
+    expect.anything()
+  ));
+  const [, body] = apiMock.post.mock.calls.find(([url]) => String(url).includes("/bracket/from-format"));
+
+  expect(body.stage_type).not.toBe("single_elimination");
+});
+
+test("eine vorhandene Phase behält ihren Strukturtyp", async () => {
+  const user = userEvent.setup();
+  apiMock.get.mockImplementation((url) => {
+    const path = String(url);
+    if (path.includes("/stages")) {
+      return Promise.resolve({ data: [{ id: "s-1", stage_type: "round_robin_groups", match_type: "duel", settings: {} }] });
+    }
+    return Promise.resolve(routeFor(path));
+  });
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  const body = await applyStructure(user);
+
+  expect(body.stage_type).toBe("round_robin_groups");
+});
+
 test("ein Ausfall der Nebendaten blockiert das Turnier nicht", async () => {
   // Nur Personal-, Nutzer- und Teamlisten fallen aus: die Seite muss trotzdem stehen.
   apiMock.get.mockImplementation((url) => {


### PR DESCRIPTION
## Der Fehler

Du hattest gemeldet: *„die Bearbeitung des Brackets, dann z. B. auf Einzelausscheidung usw. geht nicht sauber"*. Beim Durchsehen des Codes ist daraus etwas Konkreteres geworden — und es ist schlimmer, als es klingt.

Im Bearbeiten-Formular ist **„Turnierstruktur" das einzige sichtbare Strukturfeld**. Unsichtbar dahinter lag ein zweiter Wert — der Strukturtyp —, den das Formular selbst setzte. Und zwar so ([AdminTournamentEditPage.jsx:1624-1632](frontend/src/pages/admin/AdminTournamentEditPage.jsx#L1624-L1632), alter Stand):

```js
if (value === "double_elim")       return { ...current, stage_type: "double_elimination", ... };
if (value === "custom_bracket")    return { ...current, stage_type: "custom_bracket", ... };
if (value === "ffa_custom_bracket") return { ...current, stage_type: "ffa_custom_bracket", ... };
return { ...current, stage_type: "single_elimination", ... };   // ← alle übrigen
```

Es gibt **zwölf** Formate. Diese Zuordnung kannte **drei**. Die anderen **neun** fielen auf `single_elimination`:

| Gewählt | Gesendet | Richtig wäre |
| --- | --- | --- |
| Liga | `single_elimination` | `league` |
| Round Robin | `single_elimination` | `round_robin_groups` |
| Gruppen | `single_elimination` | `round_robin_groups` |
| Free for All | `single_elimination` | `simple` (+ `ffa`) |
| Battle Royale | `single_elimination` | `simple` (+ `ffa`) |
| Schweizer System | `single_elimination` | `swiss` |
| Zeitfahren / Grand Prix | `single_elimination` | kein Baum bzw. `ffa_league` |

Wer also eine Liga bearbeitete und **„Speichern & Struktur anwenden"** drückte, baute sich einen Einzelausscheidungs-Turnierbaum. Ohne Warnung — das Feld war nirgends zu sehen.

## Warum das passieren konnte

Das Backend kennt die richtige Zuordnung längst: `services/competition_formats.py` führt zu jedem Format den kanonischen Strukturtyp. Aber `_stage_defaults_for_tournament_format` macht

```python
stage_type = (body.stage_type if body else None) or default_stage_type
```

— **der mitgeschickte Wert gewinnt.** Und das Formular schickte immer einen mit. Die richtige Antwort war da; sie wurde jedes Mal überstimmt.

## Die Reparatur

Keine zweite Zuordnung im Frontend, sondern **eine weniger**. Das Formular schickt nur noch mit, was wirklich gewählt wurde:

- **Ohne vorhandene Phase** bleibt der Strukturtyp leer — das Backend leitet ihn ab.
- **Eine vorhandene Phase behält ihren Typ.** Wer im Phasen-Bereich bewusst etwas eingestellt hat, verliert es nicht.
- **Erst ein Formatwechsel** setzt ihn zurück, damit die Struktur dem neuen Format folgt.
- **Spielgrößen und Schema** gehen nur noch bei den freien Turnierbäumen mit, wo sie auch bedienbar sind. Bei allen anderen Formaten überschrieben sie bisher die passenden Vorgaben (z. B. `match_size: 2` für ein FFA-Turnier, das 4 braucht).

## Nachweise — in beide Richtungen

**Der Fehler ist belegt, nicht vermutet.** Die neuen Formulartests fallen am alten Stand:

```
FAIL > Struktur anwenden macht aus league keine Einzelausscheidung
FAIL > Struktur anwenden macht aus round_robin keine Einzelausscheidung
FAIL > Struktur anwenden macht aus groups keine Einzelausscheidung
FAIL > Struktur anwenden macht aus ffa keine Einzelausscheidung
FAIL > ein Formatwechsel im Formular überschreibt den Strukturtyp nicht mehr selbst
AssertionError: expected 'single_elimination' not to be 'single_elimination'
```

Nach der Reparatur stehen sie. Dazu:

- **7 neue Ablauftests** fahren die echte Route gegen eine Datenbank im Speicher und belegen je Format, dass ohne mitgeschickten Strukturtyp die richtige Phase entsteht — `single_elim`, `double_elim`, `round_robin`, `groups`, `league`, `ffa`, `battle_royale`
- **1 Test hält fest, dass eine vorhandene Phase ihren Typ behält** — er stand schon vor der Änderung und steht danach noch
- Backend: **747 bestanden**, 297 übersprungen (vorher 740)
- Frontend: **121 Vitest-Tests** (vorher 115), ESLint ohne Fehler, Build sauber
- Playwright: 84 bestanden, 8 übersprungen, 0 Fehlschläge

## Was das für dich heißt

Falls du seit einer Weile Liga- oder Gruppenturniere über **„Speichern & Struktur anwenden"** neu gebaut hast, können deren Turnierbäume als Einzelausscheidung angelegt worden sein. Beim nächsten Anwenden entsteht jetzt die richtige Struktur. Bei einem laufenden Turnier schau lieber einmal nach, bevor du neu baust — das Anwenden ersetzt den Baum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)