### PR TITLE
Block 9 (4/n): Turnierseite — dreizehn Knöpfe werden vier

### DIFF
--- a/frontend/e2e/admin-tournament-edit.spec.js
+++ b/frontend/e2e/admin-tournament-edit.spec.js
@@ -1,0 +1,120 @@
+const { test, expect } = require("@playwright/test");
+
+// Der Kopf der Turnierseite trug dreizehn Bedienelemente in einer Reihe. Am
+// Telefon wurde daraus eine Wand aus Knöpfen, bevor überhaupt ein Reiter
+// sichtbar war. Diese Tests prüfen die Bedienbarkeit im echten Browser - die
+// Aufteilung selbst ist in AdminTournamentEditPage.test.jsx festgehalten.
+
+const TOURNAMENT = {
+  id: "t-1",
+  slug: "winter-cup",
+  title: "Winter Cup 2026",
+  status: "registration_open",
+  format: "single_elim",
+  team_mode: "solo",
+  max_participants: 16,
+  can_manage_structure: true,
+};
+
+async function mockAdminSession(page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true,
+      external_media: false,
+      analytics: false,
+      meta: false,
+      tiktok: false,
+      saved_at: Date.now(),
+      expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }));
+  });
+  await page.route("**/api/auth/me", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      id: "admin-1",
+      email: "admin@example.test",
+      display_name: "Admin",
+      username: "admin",
+      role: "superadmin",
+      is_tournament_staff: true,
+      mfa_enabled: true,
+      auth_mfa_verified: true,
+    }),
+  }));
+  await page.route("**/api/settings/public", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ club_name: "THE LION SQUAD", domain: "lionsquad.at" }),
+  }));
+}
+
+async function mockTournament(page, overrides = {}) {
+  const tournament = { ...TOURNAMENT, ...overrides };
+  const empty = (route) => route.fulfill({ contentType: "application/json", body: "[]" });
+
+  await page.route("**/api/tournaments/t-1/registrations**", empty);
+  await page.route("**/api/tournaments/t-1/bracket**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ rounds: [] }),
+  }));
+  await page.route("**/api/tournaments/t-1/stages**", empty);
+  await page.route("**/api/tournaments/t-1/matches-v2**", empty);
+  await page.route("**/api/tournaments/t-1/groups**", empty);
+  await page.route("**/api/tournaments/t-1/staff**", empty);
+  await page.route("**/api/stations**", empty);
+  await page.route("**/api/users**", empty);
+  await page.route("**/api/teams**", empty);
+  await page.route("**/api/games**", empty);
+  await page.route("**/api/events**", empty);
+  await page.route("**/api/access-links**", empty);
+  await page.route("**/api/tournaments/t-1?**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(tournament),
+  }));
+}
+
+test.describe("Turnierseite: Kopf und Werkzeuge", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAdminSession(page);
+  });
+
+  test("Werkzeuge und Downloads liegen eingeklappt hinter ihrer Beschriftung", async ({ page }) => {
+    await mockTournament(page);
+    await page.goto("/admin/tournaments/t-1");
+    await expect(page.getByRole("heading", { name: "Winter Cup 2026" })).toBeVisible();
+
+    await expect(page.getByTestId("admin-tr-primary-action")).toBeVisible();
+    await expect(page.getByTestId("admin-tr-download-participants")).toBeHidden();
+
+    await page.getByTestId("admin-tr-downloads").locator("summary").click();
+    await expect(page.getByTestId("admin-tr-download-participants")).toBeVisible();
+
+    await page.getByTestId("admin-tr-tools").locator("summary").click();
+    await expect(page.getByTestId("admin-tr-planning-check")).toBeVisible();
+  });
+
+  test("der Kopf läuft am Telefon nicht über", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockTournament(page);
+    await page.goto("/admin/tournaments/t-1");
+    await expect(page.getByRole("heading", { name: "Winter Cup 2026" })).toBeVisible();
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+
+  test("am Telefon sind die Reiter ohne langes Scrollen erreichbar", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockTournament(page);
+    await page.goto("/admin/tournaments/t-1");
+    await expect(page.getByRole("heading", { name: "Winter Cup 2026" })).toBeVisible();
+
+    // Die Reiter sind der Einstieg in die Arbeit. Vorher lagen sie bei 1290 px:
+    // die Speziallink-Tafel allein war offen 696 px hoch, mehr als doppelt so
+    // viel wie der Kopf. Eingeklappt sind es 78 px, und die Reiter beginnen bei
+    // 673 px. Die Schranke lässt Luft für Schriftgrößen, schlägt aber an, wenn
+    // wieder ein ganzer Block dazwischenrutscht.
+    const tabs = page.getByTestId("admin-tr-tab-participants");
+    const box = await tabs.boundingBox();
+    expect(box.y).toBeLessThan(800);
+  });
+});

--- a/frontend/src/components/tls/AccessLinksPanel.jsx
+++ b/frontend/src/components/tls/AccessLinksPanel.jsx
@@ -33,7 +33,7 @@ async function copyText(value) {
   await navigator.clipboard?.writeText(value).catch(() => null);
 }
 
-export function AccessLinksPanel({ targetType, targetId, allowRegister = false }) {
+export function AccessLinksPanel({ targetType, targetId, allowRegister = false, collapsible = false }) {
   const [links, setLinks] = useState([]);
   const [users, setUsers] = useState([]);
   const [busy, setBusy] = useState(false);
@@ -126,27 +126,30 @@ export function AccessLinksPanel({ targetType, targetId, allowRegister = false }
     }
   };
 
-  return (
-    <section className="border border-[#FFD700]/25 bg-[#FFD700]/5 rounded-sm p-4 space-y-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <div className="inline-flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold text-[#FFD700]">
-            <Link2 className="w-3.5 h-3.5" /> Speziallinks
-          </div>
-          <p className="mt-1 text-xs text-white/50">
-            Gezielt Zugriff auf gesperrte oder interne {TARGET_LABELS[targetType] || "Inhalte"} geben.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={create}
-          disabled={busy}
-          className="inline-flex items-center gap-2 px-3 py-2 bg-[#FFD700] text-black rounded-sm text-xs uppercase tracking-wider font-bold disabled:opacity-50"
-        >
-          <Plus className="w-3.5 h-3.5" /> Erstellen
-        </button>
+  const title = (
+    <div>
+      <div className="inline-flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold text-[#FFD700]">
+        <Link2 className="w-3.5 h-3.5" /> Speziallinks
       </div>
+      <p className="mt-1 text-xs text-white/50">
+        Gezielt Zugriff auf gesperrte oder interne {TARGET_LABELS[targetType] || "Inhalte"} geben.
+      </p>
+    </div>
+  );
+  const createButton = (
+    <button
+      type="button"
+      onClick={create}
+      disabled={busy}
+      className="inline-flex items-center gap-2 px-3 py-2 bg-[#FFD700] text-black rounded-sm text-xs uppercase tracking-wider font-bold disabled:opacity-50"
+    >
+      <Plus className="w-3.5 h-3.5" /> Erstellen
+    </button>
+  );
 
+  const body = (
+    <>
+      {collapsible && <div className="flex justify-end">{createButton}</div>}
       <div className="flex flex-wrap items-center justify-between gap-2 border border-white/10 bg-[#0A0A0A]/50 rounded-sm px-3 py-2">
         <label className="inline-flex items-center gap-2 text-xs text-white/65">
           <input type="checkbox" checked={includeInactive} onChange={(event) => setIncludeInactive(event.target.checked)} className="accent-[#FFD700]" />
@@ -300,6 +303,33 @@ export function AccessLinksPanel({ targetType, targetId, allowRegister = false }
         ))}
         {links.length === 0 && <div className="text-xs text-white/40 border border-dashed border-white/10 rounded-sm p-3">Noch keine aktiven Speziallinks.</div>}
       </div>
+    </>
+  );
+
+  // Eingeklappt braucht die Tafel rund 40 statt 700 Pixel. Auf der
+  // Turnierseite stand sie am Telefon zwischen Kopf und Reitern und schob
+  // damit die eigentliche Arbeit unter den Bildschirmrand. Der Knopf
+  // "Erstellen" wandert dabei in den Inhalt: ein Knopf in der Aufklappzeile
+  // würde beim Drücken auch die Tafel zuklappen.
+  if (collapsible) {
+    return (
+      <details className="border border-[#FFD700]/25 bg-[#FFD700]/5 rounded-sm p-4 group" data-testid="access-links-details">
+        <summary className="cursor-pointer list-none flex items-start justify-between gap-3">
+          {title}
+          <span className="text-[#FFD700] shrink-0 transition-transform group-open:rotate-90">→</span>
+        </summary>
+        <div className="mt-4 space-y-4">{body}</div>
+      </details>
+    );
+  }
+
+  return (
+    <section className="border border-[#FFD700]/25 bg-[#FFD700]/5 rounded-sm p-4 space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        {title}
+        {createButton}
+      </div>
+      {body}
     </section>
   );
 }

--- a/frontend/src/pages/admin/AdminTournamentEditPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.jsx
@@ -569,6 +569,15 @@ export default function AdminTournamentEditPage() {
       toast.error(formatRequestError(e, "Gruppen konnten nicht generiert werden."));
     }
   };
+  const generateSwissRound = async () => {
+    try {
+      const { data } = await api.post(`/tournaments/${id}/swiss/next-round`);
+      toast.success(`Runde ${data.round} mit ${data.match_count} Spielen generiert`);
+      load();
+    } catch (e) {
+      toast.error(formatRequestError(e, "Schweizer Runde konnte nicht generiert werden."));
+    }
+  };
 
   if (!t) return (
     <AdminLayout>
@@ -611,76 +620,109 @@ export default function AdminTournamentEditPage() {
   const visibleStatusOptions = isAdmin
     ? TOURNAMENT_STATUS_OPTIONS
     : TOURNAMENT_STATUS_OPTIONS.filter(([value]) => OPERATIONAL_STATUS_VALUES.has(value));
+  // Werkzeuge: braucht man gelegentlich, nicht bei jedem Blick auf die Seite.
+  // "Zurücksetzen" steht bewusst zuletzt und rot, weil es den Baum verwirft.
+  const canLockTournament = isAdmin && ["completed", "results_published", "archived", "cancelled"].includes(t.status);
+  const toolActions = [
+    isModerator && stations.length > 0 && (
+      <button key="stations" type="button" onClick={() => autoAssignStations()} data-testid="admin-tr-auto-stations" className="px-3 py-2 border border-[#29B6E8]/50 text-[#29B6E8] font-bold uppercase tracking-wider rounded-sm text-xs hover:bg-[#29B6E8]/10 inline-flex items-center gap-2">
+        <Zap className="w-3.5 h-3.5" /> Stationen automatisch
+      </button>
+    ),
+    isModerator && (
+      <button key="planning" type="button" onClick={() => runPlanningCheck()} data-testid="admin-tr-planning-check" className="px-3 py-2 border border-[#FFD700]/50 text-[#FFD700] font-bold uppercase tracking-wider rounded-sm text-xs hover:bg-[#FFD700]/10 inline-flex items-center gap-2">
+        <Eye className="w-3.5 h-3.5" /> Planung prüfen
+      </button>
+    ),
+    canLockTournament && (
+      <button key="lock" type="button" onClick={() => setTournamentLock(!t.locked_at)} data-testid="admin-tr-lock" className={`px-3 py-2 border font-bold uppercase tracking-wider rounded-sm text-xs ${t.locked_at ? "border-[#00FF88]/40 text-[#00FF88] hover:bg-[#00FF88]/10" : "border-[#FFD700]/50 text-[#FFD700] hover:bg-[#FFD700]/10"}`}>
+        {t.locked_at ? "Entsperren" : "Sperren"}
+      </button>
+    ),
+    isModerator && (
+      <button key="reset" type="button" onClick={reset} data-testid="admin-tr-reset" className="px-3 py-2 border border-[#FF3B30]/40 text-[#FF3B30] font-bold uppercase tracking-wider rounded-sm text-xs hover:bg-[#FF3B30]/10 inline-flex items-center gap-2">
+        <RefreshCw className="w-3.5 h-3.5" /> Zurücksetzen
+      </button>
+    ),
+  ].filter(Boolean);
+  const downloadActions = [
+    { key: "participants", href: `${API}/exports/tournaments/${t.id}/participants.pdf`, label: "PDF Teilnehmer" },
+    { key: "checkin", href: `${API}/exports/tournaments/${t.id}/checkin.pdf`, label: "PDF Check-in" },
+    { key: "registration-qr", href: `${API}/exports/tournaments/${t.id}/registration-qr.pdf`, label: "PDF Anmeldung QR", highlight: true },
+    { key: "matches", href: `${API}/exports/tournaments/${t.id}/matches.pdf`, label: "PDF Spiele" },
+    isModerator && { key: "match-plan", href: `${API}/tournaments/${t.id}/match-plan.csv`, label: "CSV Matchplan" },
+  ].filter(Boolean);
 
   return (
     <AdminLayout>
-      <div className="flex items-center justify-between flex-wrap gap-3 mb-6">
-        <div>
-          <Link to="/admin/tournaments" className="text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8] hover:text-white">← Turniere</Link>
-          <h1 className="font-heading text-3xl md:text-4xl font-black uppercase mt-1">{t.title}</h1>
-          <div className="mt-2 flex items-center gap-3 flex-wrap">
-            <StatusBadge status={t.status} />
-            {t.locked_at && <span className="px-2 py-1 border border-[#FFD700]/40 text-[#FFD700] text-[10px] font-bold uppercase tracking-widest rounded-sm">Gesperrt</span>}
-            <span className="text-white/60 text-sm">{formatTournamentDisplay(t)}</span>
-            <Link to={`/tournaments/${t.slug || t.id}`} target="_blank" className="text-[#29B6E8] text-xs uppercase tracking-wider font-bold hover:text-white inline-flex items-center gap-1"><Eye className="w-3 h-3" /> Öffentliche Seite</Link>
+      <div className="mb-6 space-y-4">
+        <div className="flex items-start justify-between flex-wrap gap-3">
+          <div>
+            <Link to="/admin/tournaments" className="text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8] hover:text-white">← Turniere</Link>
+            <h1 className="font-heading text-3xl md:text-4xl font-black uppercase mt-1">{t.title}</h1>
+            <div className="mt-2 flex items-center gap-3 flex-wrap">
+              <StatusBadge status={t.status} />
+              {t.locked_at && <span className="px-2 py-1 border border-[#FFD700]/40 text-[#FFD700] text-[10px] font-bold uppercase tracking-widest rounded-sm">Gesperrt</span>}
+              <span className="text-white/60 text-sm">{formatTournamentDisplay(t)}</span>
+              <Link to={`/tournaments/${t.slug || t.id}`} target="_blank" className="text-[#29B6E8] text-xs uppercase tracking-wider font-bold hover:text-white inline-flex items-center gap-1"><Eye className="w-3 h-3" /> Öffentliche Seite</Link>
+            </div>
+          </div>
+          {/* Hier steht nur, was das Turnier weiterschiebt: der nächste Schritt,
+              die Runde für Formate die eine brauchen, und der Status. Alles
+              andere liegt unten in den Gruppen. */}
+          <div className="flex items-start gap-2 flex-wrap">
+            {canOperateTournament && primaryAction && (
+              <button
+                type="button"
+                onClick={() => setTournStatus(primaryAction.status)}
+                data-testid="admin-tr-primary-action"
+                className="px-4 py-2 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm text-sm hover:bg-[#1E95C2] inline-flex items-center gap-2"
+              >
+                <Zap className="w-3.5 h-3.5" /> {primaryAction.label}
+              </button>
+            )}
+            {isAdmin && t.format === "swiss" && (
+              <button type="button" onClick={generateSwissRound} data-testid="admin-tr-swiss-next" className="px-4 py-2 border border-[#29B6E8] text-[#29B6E8] font-bold uppercase tracking-wider rounded-sm text-sm hover:bg-[#29B6E8]/10">Schweizer Runde</button>
+            )}
+            {isAdmin && t.format === "groups" && (
+              <button type="button" onClick={generateGroups} data-testid="admin-tr-groups" className="px-4 py-2 border border-[#29B6E8] text-[#29B6E8] font-bold uppercase tracking-wider rounded-sm text-sm hover:bg-[#29B6E8]/10">Gruppen generieren</button>
+            )}
+            {canOperateTournament && (
+              <div>
+                <select value={t.status} onChange={(e) => setTournStatus(e.target.value)} data-testid="admin-tr-status-select" className="bg-[#0A0A0A] border border-white/10 px-3 py-2 text-sm rounded-sm">
+                  {!visibleStatusOptions.some(([value]) => value === t.status) && <option key={t.status} value={t.status}>{TOURNAMENT_STATUS_OPTIONS.find(([value]) => value === t.status)?.[1] || t.status}</option>}
+                  {visibleStatusOptions.map(([s, label]) => <option key={s} value={s}>{label}</option>)}
+                </select>
+                <div className="mt-1 max-w-[16rem] text-[10px] text-white/40">Operativ durch Turnierleitung; Zeitautomatik nur wenn ausdrücklich aktiviert.</div>
+              </div>
+            )}
           </div>
         </div>
-        <div className="flex gap-2 flex-wrap">
-          {canOperateTournament && primaryAction && (
-            <button
-              type="button"
-              onClick={() => setTournStatus(primaryAction.status)}
-              data-testid="admin-tr-primary-action"
-              className="px-4 py-2 bg-[#29B6E8] text-black font-bold uppercase tracking-wider rounded-sm text-sm hover:bg-[#1E95C2] inline-flex items-center gap-2"
-            >
-              <Zap className="w-3.5 h-3.5" /> {primaryAction.label}
-            </button>
+
+        <div className="flex flex-wrap gap-2" data-testid="admin-tr-toolbar">
+          {toolActions.length > 0 && (
+            <ActionGroup title="Werkzeuge" count={toolActions.length} testId="admin-tr-tools">
+              {toolActions}
+            </ActionGroup>
           )}
-          {canOperateTournament && (
-            <div>
-              <select value={t.status} onChange={(e) => setTournStatus(e.target.value)} data-testid="admin-tr-status-select" className="bg-[#0A0A0A] border border-white/10 px-3 py-2 text-sm rounded-sm">
-                {!visibleStatusOptions.some(([value]) => value === t.status) && <option key={t.status} value={t.status}>{TOURNAMENT_STATUS_OPTIONS.find(([value]) => value === t.status)?.[1] || t.status}</option>}
-                {visibleStatusOptions.map(([s, label]) => <option key={s} value={s}>{label}</option>)}
-              </select>
-              <div className="mt-1 text-[10px] text-white/40">Operativ durch Turnierleitung; Zeitautomatik nur wenn ausdrücklich aktiviert.</div>
-            </div>
-          )}
-          {isAdmin && ["completed", "results_published", "archived", "cancelled"].includes(t.status) && (
-            <button
-              type="button"
-              onClick={() => setTournamentLock(!t.locked_at)}
-              data-testid="admin-tr-lock"
-              className={`px-4 py-2 border font-bold uppercase tracking-wider rounded-sm text-sm ${t.locked_at ? "border-[#00FF88]/40 text-[#00FF88] hover:bg-[#00FF88]/10" : "border-[#FFD700]/50 text-[#FFD700] hover:bg-[#FFD700]/10"}`}
-            >
-              {t.locked_at ? "Entsperren" : "Sperren"}
-            </button>
-          )}
-          {isModerator && stations.length > 0 && <button onClick={() => autoAssignStations()} data-testid="admin-tr-auto-stations" className="px-4 py-2 border border-[#29B6E8]/50 text-[#29B6E8] font-bold uppercase tracking-wider rounded-sm text-sm hover:bg-[#29B6E8]/10 inline-flex items-center gap-2">
-            <Zap className="w-3.5 h-3.5" /> Stationen automatisch
-          </button>}
-          {isModerator && <button onClick={() => runPlanningCheck()} data-testid="admin-tr-planning-check" className="px-4 py-2 border border-[#FFD700]/50 text-[#FFD700] font-bold uppercase tracking-wider rounded-sm text-sm hover:bg-[#FFD700]/10 inline-flex items-center gap-2">
-            <Eye className="w-3.5 h-3.5" /> Planung prüfen
-          </button>}
-          {isModerator && <button onClick={reset} data-testid="admin-tr-reset" className="px-4 py-2 border border-white/20 text-white font-bold uppercase tracking-wider rounded-sm text-sm hover:border-[#FF3B30]/60 hover:text-[#FF3B30] inline-flex items-center gap-2">
-            <RefreshCw className="w-3.5 h-3.5" /> Zurücksetzen
-          </button>}
-          {isAdmin && t.format === "swiss" && (
-            <button onClick={async()=>{ try{ const {data} = await api.post(`/tournaments/${id}/swiss/next-round`); toast.success(`Runde ${data.round} mit ${data.match_count} Spielen generiert`); load(); }catch(e){ toast.error(formatRequestError(e, "Schweizer Runde konnte nicht generiert werden.")); } }} data-testid="admin-tr-swiss-next" className="px-4 py-2 border border-[#29B6E8] text-[#29B6E8] font-bold uppercase tracking-wider rounded-sm text-sm">Schweizer Runde</button>
-          )}
-          {isAdmin && t.format === "groups" && (
-            <button onClick={generateGroups} data-testid="admin-tr-groups" className="px-4 py-2 border border-[#29B6E8] text-[#29B6E8] font-bold uppercase tracking-wider rounded-sm text-sm">Gruppen generieren</button>
-          )}
-          <div className="grid grid-cols-2 sm:flex gap-1 w-full sm:w-auto">
-            <a href={`${API}/exports/tournaments/${t.id}/participants.pdf`} className="px-3 py-2 border border-white/20 text-white/80 text-xs uppercase font-bold rounded-sm hover:border-[#29B6E8]/40 text-center" target="_blank" rel="noreferrer">PDF Teilnehmer</a>
-            <a href={`${API}/exports/tournaments/${t.id}/checkin.pdf`} className="px-3 py-2 border border-white/20 text-white/80 text-xs uppercase font-bold rounded-sm hover:border-[#29B6E8]/40 text-center" target="_blank" rel="noreferrer">PDF Check-in</a>
-            <a href={`${API}/exports/tournaments/${t.id}/registration-qr.pdf`} className="px-3 py-2 border border-[#FFD700]/40 text-[#FFD700] text-xs uppercase font-bold rounded-sm hover:bg-[#FFD700]/10 text-center" target="_blank" rel="noreferrer">PDF Anmeldung QR</a>
-            <a href={`${API}/exports/tournaments/${t.id}/matches.pdf`} className="px-3 py-2 border border-white/20 text-white/80 text-xs uppercase font-bold rounded-sm hover:border-[#29B6E8]/40 text-center" target="_blank" rel="noreferrer">PDF Spiele</a>
-            {isModerator && <a href={`${API}/tournaments/${t.id}/match-plan.csv`} className="px-3 py-2 border border-white/20 text-white/80 text-xs uppercase font-bold rounded-sm hover:border-[#29B6E8]/40 text-center" target="_blank" rel="noreferrer">CSV Matchplan</a>}
-          </div>
+          <ActionGroup title="Downloads" count={downloadActions.length} testId="admin-tr-downloads">
+            {downloadActions.map((item) => (
+              <a
+                key={item.key}
+                href={item.href}
+                target="_blank"
+                rel="noreferrer"
+                data-testid={`admin-tr-download-${item.key}`}
+                className={`px-3 py-2 border text-xs uppercase font-bold rounded-sm text-center ${item.highlight ? "border-[#FFD700]/40 text-[#FFD700] hover:bg-[#FFD700]/10" : "border-white/20 text-white/80 hover:border-[#29B6E8]/40"}`}
+              >
+                {item.label}
+              </a>
+            ))}
+          </ActionGroup>
         </div>
       </div>
 
-      {isAdmin && <div className="mb-5"><AccessLinksPanel targetType="tournament" targetId={t.id} allowRegister /></div>}
+      {isAdmin && <div className="mb-5"><AccessLinksPanel targetType="tournament" targetId={t.id} allowRegister collapsible /></div>}
 
       <TournamentFlowStepper
         tournament={t}
@@ -1997,6 +2039,25 @@ function Details({ title, children }) {
     <details className="border border-white/10 bg-[#121212] rounded-sm p-4 group">
       <summary className="cursor-pointer select-none text-[11px] font-bold uppercase tracking-widest text-[#29B6E8]">{title}</summary>
       <div className="mt-4 space-y-4">{children}</div>
+    </details>
+  );
+}
+
+// Werkzeuge und Downloads lagen bisher offen im Kopf, zusammen mit den
+// Ablaufaktionen: dreizehn Bedienelemente in einer Reihe. Sie sind selten nötig
+// und stehen jetzt hinter einer Beschriftung, die sagt, was drin ist und wie
+// viel. Bewusst ein <details> statt eines Menüs - das ist die Form, die diese
+// Anwendung überall verwendet, und sie funktioniert ohne weiteres Zutun mit
+// Tastatur und Vorlesehilfen.
+function ActionGroup({ title, count, testId, children }) {
+  return (
+    <details className="group" data-testid={testId}>
+      <summary className="cursor-pointer list-none inline-flex items-center gap-2 rounded-sm border border-white/10 bg-[#121212] px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-white/60 hover:border-[#29B6E8]/50 hover:text-white">
+        {title}
+        <span className="text-white/35 tabular-nums">{count}</span>
+        <span className="text-[#29B6E8] transition-transform group-open:rotate-90">→</span>
+      </summary>
+      <div className="mt-2 flex flex-wrap gap-2 rounded-sm border border-white/10 bg-[#0A0A0A] p-3">{children}</div>
     </details>
   );
 }

--- a/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
@@ -147,6 +147,59 @@ test("ein Ladefehler wird angezeigt statt endlos zu laden", async () => {
   expect(screen.queryByRole("heading", { name: "Winter Cup 2026" })).not.toBeInTheDocument();
 });
 
+// Der Kopf trug dreizehn Bedienelemente in einer Reihe: nächster Schritt,
+// Status, Sperren, Stationen, Planung, Zurücksetzen, Format-Aktion und fünf
+// Downloads. Die Tests halten fest, dass oben nur noch steht, was das Turnier
+// weiterschiebt, und der Rest hinter benannten Gruppen liegt.
+
+test("der Kopf zeigt nur die Ablaufaktionen, Werkzeuge liegen in einer Gruppe", async () => {
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  expect(screen.getByTestId("admin-tr-primary-action")).toBeInTheDocument();
+  expect(screen.getByTestId("admin-tr-status-select")).toBeInTheDocument();
+
+  const tools = screen.getByTestId("admin-tr-tools");
+  expect(tools).not.toHaveAttribute("open");
+  expect(tools).toContainElement(screen.getByTestId("admin-tr-planning-check"));
+  expect(tools).toContainElement(screen.getByTestId("admin-tr-reset"));
+});
+
+test("die Werkzeuggruppe lässt sich öffnen und nennt ihre Anzahl", async () => {
+  const user = userEvent.setup();
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  const tools = screen.getByTestId("admin-tr-tools");
+  // Ohne Stationen bleiben Planung prüfen und Zurücksetzen.
+  expect(tools.querySelector("summary")).toHaveTextContent(/Werkzeuge\s*2/);
+
+  await user.click(tools.querySelector("summary"));
+
+  expect(tools).toHaveAttribute("open");
+});
+
+test("die Downloads liegen vollständig in ihrer eigenen Gruppe", async () => {
+  renderPage();
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  const downloads = screen.getByTestId("admin-tr-downloads");
+  expect(downloads).not.toHaveAttribute("open");
+  for (const key of ["participants", "checkin", "registration-qr", "matches", "match-plan"]) {
+    expect(downloads).toContainElement(screen.getByTestId(`admin-tr-download-${key}`));
+  }
+});
+
+test("die Format-Aktion steht oben und nicht in den Werkzeugen", async () => {
+  renderPageWithFormat("swiss");
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+
+  const swiss = screen.getByTestId("admin-tr-swiss-next");
+  expect(swiss).toBeInTheDocument();
+  expect(screen.getByTestId("admin-tr-tools")).not.toContainElement(swiss);
+  expect(screen.getByTestId("admin-tr-downloads")).not.toContainElement(swiss);
+});
+
 // Die Turnierstruktur ist das einzige Strukturfeld, das im Bearbeiten-Formular
 // sichtbar ist. Welcher Strukturtyp daraus folgt, entscheidet das Backend
 // (services/competition_formats.py). Schickt das Formular dabei einen eigenen


### PR DESCRIPTION
> **Ersetzt #182.** Den hatte ich auf den Zweig von #181 gestapelt statt auf `main`. Als du beide gemergt hast, landete #182 im bereits abgehakten Zweig statt in `main` — die Arbeit war auf GitHub als „merged" markiert, ist aber nie auf `main` angekommen. Mein Fehler bei der Wahl der Basis. Dieselben zwei Commits, jetzt direkt auf `main` (`cca97df`), inhaltlich unverändert und neu geprüft.

## Der Kopf

Die Turnierseite trug alles nebeneinander: nächster Schritt, Status, Sperren, Stationen automatisch, Planung prüfen, Zurücksetzen, die Format-Aktion und fünf Downloads. **Dreizehn Bedienelemente in einer Reihe**, ohne Rangfolge — „Zurücksetzen", das den Turnierbaum verwirft, sah aus wie „PDF Teilnehmer".

Oben steht jetzt nur, was das Turnier weiterschiebt:

**Nächster Schritt · Schweizer Runde / Gruppen generieren · Status**

Werkzeuge und Downloads liegen darunter hinter einer Beschriftung, die sagt, was drin ist und wie viel: `Werkzeuge 2 →`, `Downloads 5 →`. „Zurücksetzen" ist jetzt durchgehend rot statt erst beim Darüberfahren.

Bewusst `<details>` statt eines Menüs: das ist die Form, die diese Anwendung überall verwendet, sie funktioniert ohne Zutun mit Tastatur und Vorlesehilfen, und der im Repo liegende Radix-Dropdown wird bisher **nirgends** benutzt — den hierfür erstmals einzuführen wäre neue Oberfläche ohne Not.

Nebenbei: die Erzeugung der Schweizer Runde stand als anonyme `async`-Funktion mitten im JSX und heißt jetzt `generateSwissRound`, neben `generateGroups`.

## Der eigentliche Grund fürs Scrollen war ein anderer

Mein erster Handy-Test ist gefallen — er behauptete, die Reiter lägen jetzt weit genug oben. Sie lagen bei **1290 px**. Also nachgemessen statt geraten:

| Block | vorher | nachher |
| --- | --- | --- |
| Kopfbereich | 301 px | 301 px |
| **Speziallinks** | **696 px** | **78 px** |
| Ablauf-Stepper | 153 px | 153 px |
| → Reiter beginnen bei | **1290 px** | **673 px** |
| Seitenhöhe gesamt | 2305 px | **1688 px** |

Ein Spezialwerkzeug — Zugriff auf gesperrte Turniere geben — fraß am Telefon mehr als doppelt so viel Platz wie der Kopf, bevor man überhaupt zu den Reitern kam. `AccessLinksPanel` bekommt deshalb eine einklappbare Variante.

Nur die Turnierseite benutzt sie. Events und Fast Lap bleiben unverändert — dort liegt nichts darunter, das verdeckt würde. Der Knopf „Erstellen" wandert in der eingeklappten Variante in den Inhalt: ein Knopf in der Aufklappzeile würde beim Drücken auch die Tafel zuklappen.

## Nachweise

- **4 neue Komponententests** halten die Aufteilung fest; alle vier fallen am Stand davor, die 12 bestehenden laufen weiter
- **3 neue Playwright-Tests** × 2 Projekte: Gruppen eingeklappt und aufklappbar, kein Querlauf bei 390 px, Reiter unter 800 px. Die Schranke ist an den gemessenen 673 px gewählt und schlägt an, wenn wieder ein ganzer Block dazwischenrutscht
- Frontend: 125 Vitest-Tests, ESLint ohne Fehler
- Playwright für Turnierseite und Dashboard: 18 bestanden
- CI war für denselben Inhalt in #182 bereits vollständig grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)