### PR TITLE
Block 9 (5/n): Adminmenü — 34 Einträge, von denen zwölf sichtbar waren

### DIFF
--- a/frontend/e2e/admin-navigation.spec.js
+++ b/frontend/e2e/admin-navigation.spec.js
@@ -1,0 +1,143 @@
+const { test, expect } = require("@playwright/test");
+
+// Das Adminmenü führt 34 Einträge in 6 Gruppen. Offen ergab das eine 1689 px
+// hohe Liste, von der bei 1440x900 zwölf Einträge gleichzeitig sichtbar waren -
+// und wer auf einer Seite weit unten stand, sah im Menü nicht, wo er ist: die
+// Liste blieb oben stehen.
+
+async function mockAdminSession(page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true,
+      external_media: false,
+      analytics: false,
+      meta: false,
+      tiktok: false,
+      saved_at: Date.now(),
+      expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }));
+  });
+  await page.route("**/api/auth/me", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      id: "admin-1",
+      email: "admin@example.test",
+      display_name: "Admin",
+      username: "admin",
+      role: "superadmin",
+      is_tournament_staff: true,
+      mfa_enabled: true,
+      auth_mfa_verified: true,
+    }),
+  }));
+  await page.route("**/api/settings/public", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ club_name: "THE LION SQUAD", domain: "lionsquad.at" }),
+  }));
+  await page.route("**/api/setup/status", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ completed: true, health_score: 100, missing: [] }),
+  }));
+  await page.route("**/api/admin/dashboard", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ recent_audit_logs: [] }),
+  }));
+  await page.route("**/api/admin/growth-stats**", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ days: [] }),
+  }));
+  await page.route("**/api/admin/system-status", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ database: { ok: true }, smtp: { ok: true }, discord: { ok: false }, scheduler: { running: true, jobs: [] }, mail_queue: { pending: 0, failed: 0 } }),
+  }));
+  await page.route("**/api/mobile/push/**", (route) => route.fulfill({ contentType: "application/json", body: "[]" }));
+}
+
+function navMetrics(page) {
+  return page.evaluate(() => {
+    const nav = document.querySelector("nav.admin-scroll");
+    const navBox = nav.getBoundingClientRect();
+    const links = [...nav.querySelectorAll("a")];
+    const active = nav.querySelector("[aria-current='page']");
+    const inView = (el) => {
+      const r = el.getBoundingClientRect();
+      return r.top >= navBox.top - 1 && r.bottom <= navBox.bottom + 1;
+    };
+    return {
+      entries: links.length,
+      contentHeight: Math.round(nav.scrollHeight),
+      visibleHeight: Math.round(nav.clientHeight),
+      activeLabel: active ? active.textContent.trim() : null,
+      activeInView: active ? inView(active) : null,
+    };
+  });
+}
+
+test.describe("Adminmenü", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAdminSession(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+  });
+
+  test("beim ersten Besuch ist nur die aktuelle Gruppe offen", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+
+    await expect(page.getByTestId("admin-nav-group-Übersicht")).toHaveAttribute("aria-expanded", "true");
+    for (const group of ["Mitglieder", "eSports", "Content", "Verein", "System"]) {
+      await expect(page.getByTestId(`admin-nav-group-${group}`)).toHaveAttribute("aria-expanded", "false");
+    }
+
+    // Alle sechs Gruppennamen sind da; die Liste passt jetzt in den Bereich.
+    const metrics = await navMetrics(page);
+    expect(metrics.contentHeight).toBeLessThanOrEqual(metrics.visibleHeight);
+  });
+
+  test("eine Gruppe lässt sich öffnen und der Zustand überlebt das Neuladen", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+
+    const esports = page.getByTestId("admin-nav-group-eSports");
+    await expect(page.getByTestId("admin-nav-tournaments")).toBeHidden();
+    await esports.click();
+    await expect(page.getByTestId("admin-nav-tournaments")).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+    await expect(page.getByTestId("admin-nav-tournaments")).toBeVisible();
+  });
+
+  test("wer tief unten landet, sieht seinen Eintrag im Menü", async ({ page }) => {
+    await page.goto("/admin/mobile-push");
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+
+    await expect(page.getByTestId("admin-nav-group-System")).toHaveAttribute("aria-expanded", "true");
+    const metrics = await navMetrics(page);
+    expect(metrics.activeLabel).toBe("Push-Tests");
+    expect(metrics.activeInView).toBe(true);
+  });
+
+  test("die Suche zeigt Treffer aus zugeklappten Gruppen", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+    await expect(page.getByTestId("admin-nav-sponsors")).toBeHidden();
+
+    await page.getByTestId("admin-nav-search").fill("sponsor");
+
+    await expect(page.getByTestId("admin-nav-sponsors")).toBeVisible();
+    await expect(page.getByTestId("admin-nav-group-Verein")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("am Telefon bleibt das Menü im Schubfach bedienbar", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-nav-search")).toBeHidden();
+
+    await page.getByTestId("admin-menu-open").click();
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+    await expect(page.getByTestId("admin-nav-group-eSports")).toBeVisible();
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/tls/AdminLayout.jsx
+++ b/frontend/src/components/tls/AdminLayout.jsx
@@ -8,9 +8,9 @@ import {
   ShieldCheck, Code2, Star, Crown, Gift, Image as ImageIcon,
   Award, Inbox, UserCheck, Medal,
   FolderOpen, FileText, AlertTriangle, Handshake, Bug, BellRing,
-  Search, Server, QrCode, Activity, MessagesSquare,
+  Search, Server, QrCode, Activity, MessagesSquare, ChevronDown,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // Sidebar-Gruppen für bessere Übersicht
 const ADMIN_GROUPS = [
@@ -144,6 +144,44 @@ const MODERATOR_ROUTES = [
   "/admin/moderation",
 ];
 
+// 34 Einträge ergaben eine 1689 Pixel hohe Liste, von der bei 1440x900 genau
+// zwölf gleichzeitig sichtbar waren. Wer auf "Push-Tests" stand, sah im Menü
+// nicht, wo er ist: die Liste blieb oben stehen. Gruppen lassen sich deshalb
+// zuklappen, und die Gruppe der aktuellen Seite geht beim Navigieren auf.
+const NAV_GROUPS_STORAGE_KEY = "tls_admin_nav_collapsed_v1";
+
+function readCollapsedGroups() {
+  try {
+    const stored = JSON.parse(window.localStorage.getItem(NAV_GROUPS_STORAGE_KEY));
+    return Array.isArray(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCollapsedGroups(labels) {
+  try {
+    window.localStorage.setItem(NAV_GROUPS_STORAGE_KEY, JSON.stringify(labels));
+  } catch {
+    // Privates Fenster oder gesperrter Speicher: dann wird es eben nicht gemerkt.
+  }
+}
+
+// Der längste passende Eintrag gewinnt, damit "/admin" nicht jede Unterseite
+// für sich beansprucht.
+function groupLabelForPath(pathname) {
+  let best = null;
+  for (const group of ADMIN_GROUPS) {
+    for (const item of group.items) {
+      const hit = pathname === item.to || (!item.end && pathname.startsWith(`${item.to}/`));
+      if (hit && (!best || item.to.length > best.route.length)) {
+        best = { route: item.to, label: group.label };
+      }
+    }
+  }
+  return best ? best.label : null;
+}
+
 export function AdminLayout({ children }) {
   const { user, logout, isAdmin } = useAuth();
   const nav = useNavigate();
@@ -176,6 +214,48 @@ export function AdminLayout({ children }) {
       items: group.items.filter((item) => (!item.clubOnly || canSeeClub) && itemMatchesQuery(item, group.label, searchQuery)),
     })).filter((group) => group.items.length > 0);
   }, [isAdmin, searchQuery, user?.role]);
+
+  const activeGroup = groupLabelForPath(location.pathname);
+  const [collapsedGroups, setCollapsedGroups] = useState(() => {
+    const stored = readCollapsedGroups();
+    if (stored) return new Set(stored);
+    // Beim ersten Mal ist nur die Gruppe offen, in der man gerade steht.
+    const current = groupLabelForPath(location.pathname);
+    return new Set(ADMIN_GROUPS.map((group) => group.label).filter((label) => label !== current));
+  });
+
+  const toggleGroup = useCallback((label) => {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      writeCollapsedGroups([...next]);
+      return next;
+    });
+  }, []);
+
+  // Beim Seitenwechsel geht die zugehörige Gruppe auf. Zuklappen darf man sie
+  // danach wieder - beim nächsten Wechsel dorthin steht sie erneut offen.
+  useEffect(() => {
+    if (!activeGroup) return;
+    setCollapsedGroups((current) => {
+      if (!current.has(activeGroup)) return current;
+      const next = new Set(current);
+      next.delete(activeGroup);
+      writeCollapsedGroups([...next]);
+      return next;
+    });
+  }, [activeGroup]);
+
+  // Während einer Suche sind alle Treffer offen, sonst zählt der gemerkte Zustand.
+  const groupIsOpen = (label) => Boolean(searchQuery) || !collapsedGroups.has(label);
+
+  // Ohne das blieb die Liste beim Seitenwechsel oben stehen: man war auf
+  // "Push-Tests" und sah im Menü nur die Gruppe "Übersicht".
+  const navRef = useRef(null);
+  useEffect(() => {
+    navRef.current?.querySelector("[aria-current='page']")?.scrollIntoView({ block: "nearest" });
+  }, [location.pathname, collapsedGroups, searchQuery]);
 
   return (
     <div className="min-h-screen bg-[#0A0A0A] text-white flex">
@@ -218,35 +298,51 @@ export function AdminLayout({ children }) {
           </label>
         </div>
 
-        <nav className="flex-1 overflow-y-auto p-3 admin-scroll">
-          {visibleGroups.map((group) => (
-            <div key={group.label} className="mb-4">
-              <div className="px-3 py-1.5 text-[9px] font-black uppercase tracking-[0.25em] text-white/25 select-none">
-                {group.label}
+        <nav ref={navRef} className="flex-1 overflow-y-auto p-3 admin-scroll">
+          {visibleGroups.map((group) => {
+            const open = groupIsOpen(group.label);
+            return (
+              <div key={group.label} className="mb-3">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group.label)}
+                  aria-expanded={open}
+                  data-testid={`admin-nav-group-${group.label}`}
+                  className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-[9px] font-black uppercase tracking-[0.25em] text-white/25 hover:text-white/60 transition-colors"
+                >
+                  <span className="truncate">{group.label}</span>
+                  <span className="flex items-center gap-1.5 shrink-0">
+                    {!open && <span className="tabular-nums tracking-normal text-white/20">{group.items.length}</span>}
+                    {group.label === activeGroup && !open && <span className="w-1.5 h-1.5 rounded-full bg-[#29B6E8]" />}
+                    <ChevronDown className={`w-3 h-3 transition-transform ${open ? "" : "-rotate-90"}`} />
+                  </span>
+                </button>
+                {open && (
+                  <div className="space-y-0.5">
+                    {group.items.map((it) => (
+                      <NavLink
+                        key={it.to}
+                        to={it.to}
+                        end={it.end}
+                        onClick={() => setOpenMobile(false)}
+                        data-testid={`admin-nav-${it.to.split("/").pop() || "dashboard"}`}
+                        className={({ isActive }) =>
+                          `flex items-center gap-3 px-3 py-2.5 rounded-sm text-sm font-semibold transition-all ${
+                            isActive
+                              ? "bg-[#29B6E8]/15 text-[#29B6E8] border-l-2 border-[#29B6E8]"
+                              : "text-white/70 hover:text-white hover:bg-white/5"
+                          }`
+                        }
+                      >
+                        <it.icon className="w-4 h-4 shrink-0" />
+                        <span className="truncate">{it.label}</span>
+                      </NavLink>
+                    ))}
+                  </div>
+                )}
               </div>
-              <div className="space-y-0.5">
-                {group.items.map((it) => (
-                  <NavLink
-                    key={it.to}
-                    to={it.to}
-                    end={it.end}
-                    onClick={() => setOpenMobile(false)}
-                    data-testid={`admin-nav-${it.to.split("/").pop() || "dashboard"}`}
-                    className={({ isActive }) =>
-                      `flex items-center gap-3 px-3 py-2.5 rounded-sm text-sm font-semibold transition-all ${
-                        isActive
-                          ? "bg-[#29B6E8]/15 text-[#29B6E8] border-l-2 border-[#29B6E8]"
-                          : "text-white/70 hover:text-white hover:bg-white/5"
-                      }`
-                    }
-                  >
-                    <it.icon className="w-4 h-4 shrink-0" />
-                    <span className="truncate">{it.label}</span>
-                  </NavLink>
-                ))}
-              </div>
-            </div>
-          ))}
+            );
+          })}
           {visibleGroups.length === 0 && (
             <div className="px-3 py-8 text-center text-xs text-white/40">
               <div>Keine Admin-Seite gefunden.</div>


### PR DESCRIPTION
> Unabhängig von #183 und #184 — andere Dateien, kein Stapel. In beliebiger Reihenfolge mergebar.

## Gemessen, nicht geschätzt

Bei 1440×900:

| | |
|---|---|
| Einträge | 34 in 6 Gruppen |
| Höhe der Liste | 1689 px |
| davon sichtbar | 655 px |
| **gleichzeitig sichtbar** | **12 von 34** |
| Scrollweg | 1034 px |
| „Einstellungen" liegt bei | 1621 px |

Dazu ein zweiter Befund, den ich nicht gesucht hatte: auf `/admin/mobile-push` stand die Liste bei `scrollTop: 0`. Man war auf **„Push-Tests"** und sah im Menü nur die Gruppe „Übersicht". Die eigene Position war schlicht nicht im Bild — auf jeder Seite der unteren zwei Drittel.

## Was sich ändert

**Gruppen lassen sich zuklappen**, der Zustand wird im Browser gemerkt. Zugeklappte Gruppen zeigen ihre Anzahl (`Mitglieder 7`, `eSports 8`), damit die Leiste als Inhaltsverzeichnis lesbar bleibt statt als Liste nackter Überschriften.

**Beim Seitenwechsel geht die Gruppe der aufgerufenen Seite auf**, und der aktive Eintrag wird in den sichtbaren Bereich geholt. Damit ist „wo bin ich" beantwortet, ohne zu scrollen.

**Die Suche bleibt quer über alles.** Während einer Suche sind alle Treffergruppen offen — man findet „Sponsoren" auch dann, wenn „Verein" zugeklappt ist.

Speicherzugriffe sind eingefasst: in einem privaten Fenster wird der Zustand eben nicht gemerkt, statt die Leiste kaputtzumachen.

**Ergebnis:** 1689 px → **655 px**, Scrollweg 1034 px → **0**.

## Eine Abwägung, die dir gehört

Voreinstellung beim ersten Besuch ist: **nur die Gruppe der aktuellen Seite ist offen.** Auf dem Dashboard heißt das, die Leiste zeigt sechs Gruppennamen mit Anzahl und einen Link — ein kompaktes Inhaltsverzeichnis statt einer Wand.

Das ist bewusst gewählt, aber es ist ein Tausch: weniger auf einmal, dafür ein Klick mehr, wenn man das Ziel schon kennt. Die Alternative wäre, beim ersten Besuch alles offen zu lassen und dich selbst zuklappen zu lassen — dann bleibt es aber für alle, die nie zuklappen, bei den zwölf von 34.

**Sag mir, was dir lieber ist** — die Umkehrung ist eine Zeile. Schau es dir am besten einmal an, bevor du entscheidest.

## Nachweise

- **5 neue Playwright-Tests** × 2 Projekte: Voreinstellung, Zuklappen mit Merken über einen Neuladevorgang, aktiver Eintrag im Blick, Suche quer durch zugeklappte Gruppen, Schubfach am Telefon ohne Querlauf
- **Gegenprobe:** alle fünf fallen am Stand davor, alle zehn stehen danach
- Frontend: 121 Vitest-Tests, ESLint ohne Fehler, Build sauber
- Playwright gesamt: **106 bestanden**, 8 übersprungen, 0 Fehlschläge

## Nebenbefund, hier nicht behoben

Beim Vermessen ist mir `AdminSettingsPage.jsx:341` aufgefallen: `if (q) setQueue(q)` nimmt jeden truthy Wert, und `queue.filter(...)` in Zeile 847 reißt dann die ganze Seite in die Fehlergrenze. Ausgelöst hat es mein grober Test-Mock, der `{}` statt einer Liste lieferte — die echte API gibt eine Liste zurück, es ist also latent, nicht aktiv. Eine Zeile (`Array.isArray(q)`) würde es abfangen. Gehört nicht in diesen PR; sag Bescheid, wenn ich es mitnehmen soll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)