### PR TITLE
Block 9 (6/n): Einstellungen — dreizehn gleiche Chips, fünf davon Mail

### DIFF
--- a/frontend/e2e/admin-settings.spec.js
+++ b/frontend/e2e/admin-settings.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require("@playwright/test");
+
+// Dreizehn Reiter, davon fünf zum Mailversand. Die Gruppen sagen, wozu ein
+// Reiter gehört; dieser Test prüft, dass sie im echten Browser stehen und dass
+// die Seite am Telefon nicht quer läuft - die Mail-Queue zeigt eine breite
+// Tabelle.
+
+async function mockSettings(page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true,
+      external_media: false,
+      analytics: false,
+      meta: false,
+      tiktok: false,
+      saved_at: Date.now(),
+      expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }));
+  });
+  const json = (body) => ({ contentType: "application/json", body: JSON.stringify(body) });
+
+  await page.route("**/api/auth/me", (r) => r.fulfill(json({
+    id: "admin-1", email: "admin@example.test", display_name: "Admin", username: "admin",
+    role: "superadmin", is_tournament_staff: true, mfa_enabled: true, auth_mfa_verified: true,
+  })));
+  await page.route("**/api/settings/public", (r) => r.fulfill(json({ club_name: "THE LION SQUAD" })));
+  await page.route("**/api/settings/auth", (r) => r.fulfill(json({ password_login_enabled: true, google_login_enabled: false, registration_enabled: true })));
+  await page.route("**/api/settings/email/logs**", (r) => r.fulfill(json([])));
+  await page.route("**/api/settings/email", (r) => r.fulfill(json({ enabled: true, sender_name: "THE LION SQUAD", sender_email: "noreply@lionsquad.at" })));
+  await page.route("**/api/settings/branding", (r) => r.fulfill(json({ club_name: "THE LION SQUAD" })));
+  await page.route("**/api/settings/discord", (r) => r.fulfill(json({ enabled: false })));
+  await page.route("**/api/settings/smtp", (r) => r.fulfill(json({ smtp_host: "mail.example.test" })));
+  await page.route("**/api/settings/mail-queue/stats", (r) => r.fulfill(json({ due_pending: 0 })));
+  await page.route("**/api/settings/mail-queue**", (r) => r.fulfill(json([])));
+  await page.route("**/api/settings/site-banners/admin", (r) => r.fulfill(json([])));
+  await page.route("**/api/admin/system-status", (r) => r.fulfill(json({
+    database: { ok: true }, smtp: { ok: true }, discord: { ok: false },
+    scheduler: { running: true, jobs: [] }, mail_queue: { pending: 0, failed: 0 },
+  })));
+  await page.route("**/api/admin/streams/status", (r) => r.fulfill(json({})));
+  await page.route("**/api/admin/discord/counters**", (r) => r.fulfill(json([])));
+}
+
+test.describe("Einstellungen", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSettings(page);
+  });
+
+  test("die fünf Mail-Reiter stehen zusammen in ihrer Gruppe", async ({ page }) => {
+    await page.goto("/admin/settings?tab=email");
+    await expect(page.getByTestId("settings-tabs")).toBeVisible();
+
+    const mail = page.getByTestId("settings-group-E-Mail");
+    await expect(mail).toBeVisible();
+    for (const key of ["email", "smtp", "newsletter", "queue", "logs"]) {
+      await expect(mail.getByTestId(`settings-tab-${key}`)).toBeVisible();
+    }
+    await expect(page.getByTestId("settings-group-Auftritt")).toBeVisible();
+    await expect(page.getByTestId("settings-group-Zugang")).toBeVisible();
+  });
+
+  test("die Seite läuft am Telefon nicht quer, auch nicht bei der Mail-Queue", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/admin/settings?tab=queue");
+    await expect(page.getByTestId("settings-tabs")).toBeVisible();
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/pages/admin/AdminSettingsPage.jsx
+++ b/frontend/src/pages/admin/AdminSettingsPage.jsx
@@ -45,21 +45,37 @@ const STATUS_LABELS = {
   skipped: "übersprungen",
 };
 
-const SETTINGS_TABS = [
-  ["auth", "Login & Google", LogIn],
-  ["email", "Resend", Mail],
-  ["smtp", "SMTP", Server],
-  ["newsletter", "Newsletter", Mail],
-  ["queue", "Mail-Queue", Inbox],
-  ["discord", "Discord", MessageSquare],
-  ["twitch", "Twitch", Radio],
-  ["brand", "Branding", Palette],
-  ["socials", "Socials", Share2],
-  ["seo", "SEO & Analytics", Search],
-  ["legal", "Rechtliches", FileText],
-  ["system", "Status", Activity],
-  ["logs", "Versandlogs", Send],
+// Dreizehn gleich aussehende Reiter, von denen fünf den Mailversand betreffen:
+// "Resend", "SMTP", "Newsletter", "Mail-Queue" und "Versandlogs" sagen einzeln
+// nicht, welcher davon gemeint ist, und sie standen verstreut zwischen
+// Branding und Rechtlichem. Die Gruppen stehen jetzt über den Reitern - alles
+// bleibt einen Klick entfernt, aber man sieht, wozu es gehört.
+const SETTINGS_GROUPS = [
+  { label: "Zugang", tabs: [
+    ["auth", "Login & Google", LogIn],
+  ] },
+  { label: "E-Mail", tabs: [
+    ["email", "Resend", Mail],
+    ["smtp", "SMTP", Server],
+    ["newsletter", "Newsletter", Mail],
+    ["queue", "Mail-Queue", Inbox],
+    ["logs", "Versandlogs", Send],
+  ] },
+  { label: "Auftritt", tabs: [
+    ["brand", "Branding", Palette],
+    ["socials", "Socials", Share2],
+    ["seo", "SEO & Analytics", Search],
+    ["legal", "Rechtliches", FileText],
+  ] },
+  { label: "Verbindungen", tabs: [
+    ["discord", "Discord", MessageSquare],
+    ["twitch", "Twitch", Radio],
+  ] },
+  { label: "System", tabs: [
+    ["system", "Status", Activity],
+  ] },
 ];
+const SETTINGS_TABS = SETTINGS_GROUPS.flatMap((group) => group.tabs);
 const SETTINGS_TAB_KEYS = new Set(SETTINGS_TABS.map(([key]) => key));
 const INDEXNOW_DEFAULT_PATHS = ["/", "/sitemap.xml", "/sitemap-news.xml", "/news", "/events", "/esports", "/tournaments", "/fastlap", "/galerie", "/members"];
 
@@ -332,17 +348,20 @@ export default function AdminSettingsPage() {
       originalDiscordRef.current = discordPayload(next);
       return next;
     });
-    if (l) setLogs(l);
+    // Listen nur übernehmen, wenn es welche sind: unten stehen .map und
+    // .filter darauf, und ein unerwartet geformter Wert nähme die ganze Seite
+    // mit in die Fehlergrenze statt nur diesen einen Bereich leer zu lassen.
+    if (Array.isArray(l)) setLogs(l);
     if (sm) setSmtp((prev) => {
       const next = { ...prev, ...sm, smtp_pass: "", smtp_pass_masked: sm.smtp_pass_masked || "" };
       originalSmtpRef.current = smtpPayload(next);
       return next;
     });
-    if (q) setQueue(q);
+    if (Array.isArray(q)) setQueue(q);
     if (qs) setQueueStats(qs);
     if (st) setSystemStatus(st);
     if (tw) setTwitchStatus(tw);
-    if (dc) setDiscordCounters(dc);
+    if (Array.isArray(dc)) setDiscordCounters(dc);
     if (sb) setSiteBanners(Array.isArray(sb) ? sb : []);
     if (ac) setAuthConfig((prev) => ({ ...prev, ...ac }));
     const failed = requests
@@ -874,15 +893,30 @@ export default function AdminSettingsPage() {
       <span className="text-[11px] font-bold uppercase tracking-[0.3em] text-[#29B6E8]">System</span>
       <h1 className="font-heading text-3xl md:text-4xl font-black uppercase mt-1 mb-6">Einstellungen</h1>
 
-      <div className="flex flex-wrap gap-2 mb-6 border-b border-white/10 pb-3">
-        {SETTINGS_TABS.filter(([key]) => key !== "auth" || isSuperadmin).map(([k, l, Icn]) => {
-          const isDirty = dirtyTabs.has(k);
+      <div className="flex flex-wrap gap-x-7 gap-y-4 mb-6 border-b border-white/10 pb-4" data-testid="settings-tabs">
+        {SETTINGS_GROUPS.map((group) => {
+          const tabs = group.tabs.filter(([key]) => key !== "auth" || isSuperadmin);
+          if (!tabs.length) return null;
+          const groupIsDirty = tabs.some(([key]) => dirtyTabs.has(key));
           return (
-            <button key={k} onClick={() => selectTab(k)} data-testid={`settings-tab-${k}`}
-              className={`px-3 py-2 text-xs font-bold uppercase tracking-wider inline-flex items-center gap-2 whitespace-nowrap rounded-sm border transition ${tab === k ? "border-[#29B6E8]/70 bg-[#29B6E8]/10 text-[#29B6E8]" : "border-white/10 text-white/60 hover:border-white/25 hover:text-white"}`}>
-              <Icn className="w-3.5 h-3.5" />{l}
-              {isDirty && <span className="w-1.5 h-1.5 rounded-full bg-[#FFD700] shadow-[0_0_8px_rgba(255,215,0,0.8)]" title="Ungespeicherte Änderungen" />}
-            </button>
+            <div key={group.label} data-testid={`settings-group-${group.label}`}>
+              <div className="mb-1.5 inline-flex items-center gap-1.5 text-[9px] font-black uppercase tracking-[0.25em] text-white/25">
+                {group.label}
+                {groupIsDirty && <span className="w-1.5 h-1.5 rounded-full bg-[#FFD700]" title="Ungespeicherte Änderungen in dieser Gruppe" />}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {tabs.map(([k, l, Icn]) => {
+                  const isDirty = dirtyTabs.has(k);
+                  return (
+                    <button key={k} onClick={() => selectTab(k)} data-testid={`settings-tab-${k}`}
+                      className={`px-3 py-2 text-xs font-bold uppercase tracking-wider inline-flex items-center gap-2 whitespace-nowrap rounded-sm border transition ${tab === k ? "border-[#29B6E8]/70 bg-[#29B6E8]/10 text-[#29B6E8]" : "border-white/10 text-white/60 hover:border-white/25 hover:text-white"}`}>
+                      <Icn className="w-3.5 h-3.5" />{l}
+                      {isDirty && <span className="w-1.5 h-1.5 rounded-full bg-[#FFD700] shadow-[0_0_8px_rgba(255,215,0,0.8)]" title="Ungespeicherte Änderungen" />}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           );
         })}
       </div>

--- a/frontend/src/pages/admin/AdminSettingsPage.test.jsx
+++ b/frontend/src/pages/admin/AdminSettingsPage.test.jsx
@@ -154,3 +154,42 @@ test("ein Ausfall einzelner Bereiche legt die Seite nicht lahm", async () => {
   await waitForLoadedEmailTab();
   expect(screen.getByTestId("admin-layout")).toBeInTheDocument();
 });
+
+// Dreizehn gleich aussehende Reiter, davon fuenf zum Mailversand. Die Gruppen
+// sagen, wozu ein Reiter gehoert - "Resend" und "Versandlogs" allein tun das
+// nicht.
+
+test("die Reiter stehen in benannten Gruppen", async () => {
+  renderPage();
+  await waitForLoadedEmailTab();
+
+  const mail = screen.getByTestId("settings-group-E-Mail");
+  for (const key of ["email", "smtp", "newsletter", "queue", "logs"]) {
+    expect(mail).toContainElement(screen.getByTestId(`settings-tab-${key}`));
+  }
+
+  const look = screen.getByTestId("settings-group-Auftritt");
+  expect(look).toContainElement(screen.getByTestId("settings-tab-brand"));
+  expect(look).not.toContainElement(screen.getByTestId("settings-tab-smtp"));
+
+  // Ohne Superadmin-Rechte gibt es die Zugangsgruppe nicht.
+  expect(screen.queryByTestId("settings-group-Zugang")).not.toBeInTheDocument();
+});
+
+test("eine unerwartet geformte Antwort legt nicht die ganze Seite lahm", async () => {
+  // Der Kern: unten stehen queue.filter, logs.map und discordCounters.map.
+  // Kam statt einer Liste etwas anderes, riss das die komplette Seite in die
+  // Fehlergrenze - statt nur diesen einen Bereich leer zu lassen.
+  apiMock.get.mockImplementation((url) => {
+    const path = String(url);
+    if (path.startsWith("/settings/mail-queue?")) return Promise.resolve({ data: { items: [] } });
+    if (path.startsWith("/settings/email/logs")) return Promise.resolve({ data: { items: [] } });
+    if (path.startsWith("/admin/discord/counters")) return Promise.resolve({ data: {} });
+    return Promise.resolve(responseFor(path));
+  });
+
+  renderPage();
+
+  await waitForLoadedEmailTab();
+  expect(screen.getByTestId("settings-tab-queue")).toBeInTheDocument();
+});


### PR DESCRIPTION
> Unabhängig von #183, #184 und #185 — andere Dateien, kein Stapel.

## Das Problem

Die Einstellungsseite hat **13 Reiter**, die alle gleich aussehen. **Fünf davon betreffen den Mailversand:**

`Resend` · `SMTP` · `Newsletter` · `Mail-Queue` · `Versandlogs`

Einzeln sagt keiner davon, welcher gemeint ist — und sie standen verstreut zwischen `Branding` und `Rechtliches`. Wer die Absenderadresse ändern wollte, hatte fünf ähnlich klingende Chips zur Auswahl und keinen Hinweis, welcher der richtige ist.

## Was sich ändert

Die Reiter stehen jetzt unter Gruppennamen:

| Gruppe | Reiter |
|---|---|
| **Zugang** | Login & Google |
| **E-Mail** | Resend, SMTP, Newsletter, Mail-Queue, Versandlogs |
| **Auftritt** | Branding, Socials, SEO & Analytics, Rechtliches |
| **Verbindungen** | Discord, Twitch |
| **System** | Status |

**Keine zweite Ebene** — nur eine Beschriftung darüber. Alles bleibt einen Klick entfernt, wie vorher. Neu ist ein Punkt an der Gruppe, wenn in einem ihrer Reiter etwas ungespeichert ist; bisher sah man das nur am Reiter selbst.

## Ein Absturz, der mir dabei aufgefallen ist

Beim Vermessen des Adminmenüs (#185) lieferte mein grober Test-Mock `{}` statt einer Liste — und die **komplette Einstellungsseite** war weg, in der Fehlergrenze:

```
TypeError: queue.filter is not a function
```

Ursache: `setLogs`, `setQueue` und `setDiscordCounters` übernahmen jeden truthy Wert, obwohl weiter unten `.map` und `.filter` darauf stehen. Kam von einem dieser Endpunkte etwas anderes als eine Liste, riss das die ganze Seite mit, statt nur diesen einen Bereich leer zu lassen.

Das ist keine erfundene Sorge: **`setSiteBanners` hat den Schutz in derselben Funktion bereits** (`Array.isArray(sb) ? sb : []`). Die anderen drei ziehen nach — eine Inkonsistenz an einer Stelle, nicht eine neue Regel.

Mit der echten API ist es latent, nicht aktiv. Aber „ein Endpunkt antwortet unerwartet" ist kein Grund, warum die Seite zum Ändern der SMTP-Zugangsdaten unbenutzbar sein sollte.

## Nachweise

- **2 neue Komponententests**: Gruppenzuordnung, und die unerwartete Antwort legt die Seite nicht mehr lahm
- **Gegenprobe:** beide fallen am Stand davor, der zweite mit genau `TypeError: queue.filter is not a function`
- **2 neue Playwright-Tests** × 2 Projekte: die fünf Mail-Reiter stehen zusammen, und die Seite läuft am Telefon nicht quer — auch nicht auf dem Reiter mit der breiten Mail-Queue-Tabelle
- Frontend: 123 Vitest-Tests, ESLint ohne Fehler, Build sauber
- Playwright gesamt: **100 bestanden**, 8 übersprungen, 0 Fehlschläge

**Zu den Testläufen:** mit zwei parallelen Arbeitern fielen lokal bis zu 89 Tests, auch solche auf öffentlichen Seiten, die diese Änderung nicht berührt. Mit `--workers=1` laufen alle durch, und jeder Fehlschlag bestand einzeln. Das ist Ressourcenknappheit auf meiner Maschine nach vielen Läufen hintereinander, kein Codeproblem — nachgeprüft, nicht angenommen. Verbindlich ist die CI hier im PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)