### PR TITLE
Live-Aktualisierung: nachgeprüft — und ein Filtereintrag, der nie zutreffen konnte

### DIFF
--- a/frontend/src/lib/apiInvalidation.test.js
+++ b/frontend/src/lib/apiInvalidation.test.js
@@ -22,6 +22,39 @@ describe("API invalidation stream", () => {
     expect(invalidationMatches(event, ["news"])).toBe(false);
   });
 
+  // Der Server leitet die Ressource aus dem Pfad ab: /api/matches-v2/... wird
+  // zu "matches-v2" mit Bindestrich. Drei Ansichten filterten auf
+  // "matches_v2" mit Unterstrich - eine Zeichenkette, die nie zutreffen kann.
+  // Gerettet hat sie nur, dass sie zusaetzlich "matches" auffuehrten; eine
+  // Ansicht, die allein darauf gesetzt haette, waere nie aktualisiert worden.
+  test("a v2 match change reaches the views that ask for it", () => {
+    const event = { path: "/api/matches-v2/m-1/result", resource: "matches-v2" };
+
+    expect(invalidationMatches(event, ["matches-v2"])).toBe(true);
+    expect(invalidationMatches(event, ["matches"])).toBe(true);
+    expect(invalidationMatches(event, ["tournaments"])).toBe(true);
+    expect(invalidationMatches(event, ["matches_v2"])).toBe(false);
+  });
+
+  test("no view filters on a resource key the server never emits", async () => {
+    const modules = import.meta.glob("../pages/**/*.jsx", { query: "?raw", import: "default", eager: true });
+    const used = new Set();
+    for (const source of Object.values(modules)) {
+      for (const call of String(source).matchAll(/useApiInvalidation\([^)]*?\[([^\]]*)\]/g)) {
+        for (const part of call[1].split(",")) {
+          const name = part.trim().replace(/^["'`]|["'`]$/g, "");
+          if (name) used.add(name);
+        }
+      }
+    }
+    expect(used.size).toBeGreaterThan(10);
+
+    // Unterstriche gibt es in keinem API-Pfad; sie sind das verlaessliche
+    // Kennzeichen einer Zeichenkette, die nie zutrifft.
+    const impossible = [...used].filter((name) => name.includes("_"));
+    expect(impossible).toEqual([]);
+  });
+
   test("the same server event is emitted only once", () => {
     const received = [];
     const unsubscribe = subscribeApiInvalidation((event) => received.push(event));

--- a/frontend/src/pages/display/EventTVPage.jsx
+++ b/frontend/src/pages/display/EventTVPage.jsx
@@ -60,7 +60,7 @@ export default function EventTVPage() {
     const interval = setInterval(load, 15000);
     return () => clearInterval(interval);
   }, [load]);
-  useApiInvalidation(load, ["events", "tournaments", "matches", "matches_v2", "stations", "f1"]);
+  useApiInvalidation(load, ["events", "tournaments", "matches", "matches-v2", "stations", "f1"]);
 
   const activity = useMemo(() => {
     if (!event) return [];

--- a/frontend/src/pages/public/MatchPage.jsx
+++ b/frontend/src/pages/public/MatchPage.jsx
@@ -120,7 +120,7 @@ export default function MatchPage() {
       document.removeEventListener("visibilitychange", refreshVisible);
     };
   }, [load]);
-  useApiInvalidation(load, ["matches", "matches_v2", "tournaments"]);
+  useApiInvalidation(load, ["matches", "matches-v2", "tournaments"]);
 
   const title = data?.tournament?.title ? `${data.matchday_label} - ${data.tournament.title}` : "Match";
   const description = data?.tournament?.title

--- a/frontend/src/pages/public/TournamentSchedulePage.jsx
+++ b/frontend/src/pages/public/TournamentSchedulePage.jsx
@@ -52,7 +52,7 @@ export default function TournamentSchedulePage() {
     const interval = setInterval(load, 7000);
     return () => clearInterval(interval);
   }, [load]);
-  useApiInvalidation(load, ["tournaments", "matches", "matches_v2"]);
+  useApiInvalidation(load, ["tournaments", "matches", "matches-v2"]);
 
   const groups = useMemo(() => {
     const tournament = data?.tournament || {};


### PR DESCRIPTION
> Unabhängig von #183, #184, #185 und #186 — andere Dateien.

## Was ich geprüft habe

Dein Punkt: *„wenn Ergebnisse eingetragen sind, dass alles sofort live aktualisiert ohne die Webseite zu aktualisieren"*. Im Plan stand von mir, es fehle „die flächendeckende Anwendung". Bevor ich danach baue, habe ich nachgesehen — und **das war so nicht richtig.**

| Prüfung | Ergebnis |
|---|---|
| Welche Ansichten hängen am Änderungsstrom? | Praktisch alle — 94 Seiten, fast jede mit `useApiInvalidation` |
| Sendet das Backend beim Ergebniseintrag? | Ja. Eine Middleware sendet für **jeden** erfolgreichen schreibenden API-Aufruf |
| Erreicht das auch Zuschauer, nicht nur Personal? | Ja. `matches`, `matches-v2` und `tournaments` stehen in `PUBLIC_RESOURCES` |
| Die Vorbedingung aus `change_events.py` — genau ein API-Arbeiter? | Eingehalten: `--workers 1` steht fest im `docker-entrypoint.py` |

**Für das Web ist an dieser Stelle nichts offen.** Der Plan hat die Lücke überzeichnet; ich korrigiere das, sobald #184 gemergt ist (sonst kollidieren die beiden in derselben Datei).

## Was dabei doch aufgefallen ist

Der Server leitet die Ressource aus dem Pfad ab: aus `/api/matches-v2/...` wird **`matches-v2`** mit Bindestrich. Drei Ansichten filterten aber auf **`matches_v2`** mit Unterstrich:

- `public/MatchPage.jsx`
- `public/TournamentSchedulePage.jsx`
- `display/EventTVPage.jsx`

In keinem API-Pfad kommt ein Unterstrich vor — die Zeichenkette konnte **nie** zutreffen.

**Folgenlos war das nur durch Zufall:** alle drei führten zusätzlich `"matches"` auf, und der Server gibt für `matches-v2` ohnehin die Aliasse `matches` und `tournaments` mit. Eine Ansicht, die allein auf `matches_v2` gesetzt hätte, wäre nie aktualisiert worden. Das ist keine aktive Störung, aber eine Falle für die nächste Ansicht.

## Nachweise

- **2 neue Unit-Tests.** Der erste hält fest, welche Filter ein v2-Ergebnis erreichen muss (`matches-v2`, `matches`, `tournaments` — und `matches_v2` ausdrücklich nicht). Der zweite liest **alle** Filternamen aus allen Seiten und lässt keinen mit Unterstrich durch
- **Gegenprobe:** der zweite fällt am alten Stand mit `expected [ 'matches_v2' ] to deeply equal []`
- Frontend: 123 Vitest-Tests, ESLint ohne Fehler, Build sauber
- Playwright: **96 bestanden**, 8 übersprungen, 0 Fehlschläge

## Was das für die App heißt

Nachgesehen statt aus dem Plan abgeschrieben: **die App hat keine SSE-Anbindung** — weder `EventSource` noch `changes/stream` kommen im Mobil-Quellcode vor. Sie fragt in Intervallen ab:

| Ansicht | Intervall |
|---|---|
| Chat | 7 s |
| Dashboard | 10 s |
| Turnierdetail | 10 s |
| Turnierliste | 30 s |

„Sofort live" heißt in der App also bis zu 30 Sekunden. Das ist Block 14 und laut `RESTPLAN.md` ausdrücklich pausiert — ich fasse es hier nicht an, aber du solltest die Zahl kennen, wenn du die App mit dem Browser vergleichst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)