### PR TITLE
Adminmenü: Voreinstellung ist offen

### DIFF
--- a/frontend/e2e/admin-navigation.spec.js
+++ b/frontend/e2e/admin-navigation.spec.js
@@ -79,32 +79,44 @@ test.describe("Adminmenü", () => {
     await page.setViewportSize({ width: 1440, height: 900 });
   });
 
-  test("beim ersten Besuch ist nur die aktuelle Gruppe offen", async ({ page }) => {
+  test("beim ersten Besuch ist alles offen, nichts ist weggeräumt", async ({ page }) => {
     await page.goto("/admin");
     await expect(page.getByTestId("admin-nav-search")).toBeVisible();
 
-    await expect(page.getByTestId("admin-nav-group-Übersicht")).toHaveAttribute("aria-expanded", "true");
-    for (const group of ["Mitglieder", "eSports", "Content", "Verein", "System"]) {
-      await expect(page.getByTestId(`admin-nav-group-${group}`)).toHaveAttribute("aria-expanded", "false");
+    // Wer das Zuklappen noch nicht kennt, soll nichts vermissen.
+    for (const group of ["Übersicht", "Mitglieder", "eSports", "Content", "Verein", "System"]) {
+      await expect(page.getByTestId(`admin-nav-group-${group}`)).toHaveAttribute("aria-expanded", "true");
     }
-
-    // Alle sechs Gruppennamen sind da; die Liste passt jetzt in den Bereich.
-    const metrics = await navMetrics(page);
-    expect(metrics.contentHeight).toBeLessThanOrEqual(metrics.visibleHeight);
+    await expect(page.getByTestId("admin-nav-tournaments")).toBeVisible();
+    expect((await navMetrics(page)).entries).toBe(34);
   });
 
-  test("eine Gruppe lässt sich öffnen und der Zustand überlebt das Neuladen", async ({ page }) => {
+  test("eine Gruppe lässt sich zuklappen und bleibt es nach dem Neuladen", async ({ page }) => {
     await page.goto("/admin");
     await expect(page.getByTestId("admin-nav-search")).toBeVisible();
 
-    const esports = page.getByTestId("admin-nav-group-eSports");
-    await expect(page.getByTestId("admin-nav-tournaments")).toBeHidden();
-    await esports.click();
-    await expect(page.getByTestId("admin-nav-tournaments")).toBeVisible();
+    const content = page.getByTestId("admin-nav-group-Content");
+    await expect(page.getByTestId("admin-nav-news")).toBeVisible();
+    await content.click();
+    await expect(page.getByTestId("admin-nav-news")).toBeHidden();
 
     await page.reload();
     await expect(page.getByTestId("admin-nav-search")).toBeVisible();
-    await expect(page.getByTestId("admin-nav-tournaments")).toBeVisible();
+    await expect(page.getByTestId("admin-nav-news")).toBeHidden();
+    await expect(page.getByTestId("admin-nav-group-Content")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("zuklappen verkürzt die Liste spürbar", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+    const before = await navMetrics(page);
+
+    for (const group of ["Mitglieder", "Content", "Verein", "System"]) {
+      await page.getByTestId(`admin-nav-group-${group}`).click();
+    }
+
+    const after = await navMetrics(page);
+    expect(after.contentHeight).toBeLessThan(before.contentHeight / 2);
   });
 
   test("wer tief unten landet, sieht seinen Eintrag im Menü", async ({ page }) => {
@@ -120,6 +132,7 @@ test.describe("Adminmenü", () => {
   test("die Suche zeigt Treffer aus zugeklappten Gruppen", async ({ page }) => {
     await page.goto("/admin");
     await expect(page.getByTestId("admin-nav-search")).toBeVisible();
+    await page.getByTestId("admin-nav-group-Verein").click();
     await expect(page.getByTestId("admin-nav-sponsors")).toBeHidden();
 
     await page.getByTestId("admin-nav-search").fill("sponsor");

--- a/frontend/src/components/tls/AdminLayout.jsx
+++ b/frontend/src/components/tls/AdminLayout.jsx
@@ -218,10 +218,11 @@ export function AdminLayout({ children }) {
   const activeGroup = groupLabelForPath(location.pathname);
   const [collapsedGroups, setCollapsedGroups] = useState(() => {
     const stored = readCollapsedGroups();
-    if (stored) return new Set(stored);
-    // Beim ersten Mal ist nur die Gruppe offen, in der man gerade steht.
-    const current = groupLabelForPath(location.pathname);
-    return new Set(ADMIN_GROUPS.map((group) => group.label).filter((label) => label !== current));
+    // Voreinstellung: alles offen. Eine Voreinstellung, die etwas wegräumt,
+    // trifft genau die Leute, die das Zuklappen noch nicht kennen - und "wo
+    // bin ich gerade" beantwortet ohnehin das Nachführen zum aktiven Eintrag.
+    // Wer es kompakt will, klappt einmal zu; das wird gemerkt.
+    return new Set(stored || []);
   });
 
   const toggleGroup = useCallback((label) => {


### PR DESCRIPTION
Beantwortet die offene Frage aus #185. Du hast mir die Entscheidung überlassen — hier ist sie, samt Begründung.

## Die Entscheidung: offen

Zugeklappt als Voreinstellung trifft genau die Leute, die das Zuklappen noch nicht kennen. Die sehen sechs Überschriften und suchen ihre Einträge.

Und der eigentliche Befund aus #185 — auf `/admin/mobile-push` stand die Liste bei `scrollTop: 0`, man sah im Menü nicht, wo man ist — ist durch das **Nachführen zum aktiven Eintrag** gelöst. Dafür braucht es das Zuklappen gar nicht.

## Was bleibt

Alles andere aus #185 ist unverändert:

- Gruppen lassen sich zuklappen, der Zustand wird im Browser gemerkt
- Zugeklappte Gruppen zeigen ihre Anzahl (`Mitglieder 7`, `eSports 8`)
- Beim Seitenwechsel geht die Gruppe der aufgerufenen Seite auf
- Der aktive Eintrag wird in den sichtbaren Bereich geholt
- Die Suche öffnet Treffergruppen, auch zugeklappte

Wer es kompakt will, klappt einmal zu — und das bleibt. Ein neuer Test hält fest, dass **vier zugeklappte Gruppen die Liste mehr als halbieren**.

## Nachweise

- 6 Playwright-Tests × 2 Projekte, alle grün: Voreinstellung offen mit allen 34 Einträgen sichtbar, Zuklappen überlebt das Neuladen, Zuklappen halbiert die Liste, aktiver Eintrag im Blick, Suche quer durch Zugeklapptes, Schubfach am Telefon
- ESLint ohne Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)