### PR TITLE
Block 10: Spielwochen — Spieltag ist eine Woche, mit Pfeilen durchblättern

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -457,6 +457,11 @@ class TournamentCreate(BaseModel):
     event_mode: TournamentEventMode = "online"
     result_entry_mode: Optional[TournamentResultEntryMode] = None
     schedule_mode: Optional[TournamentScheduleMode] = None
+    # Spielwochen: ein Spieltag dauert so viele Tage, und wenn sich niemand auf
+    # eine Zeit einigt, gilt dieser Wochentag (0 = Montag) zu dieser Uhrzeit.
+    matchday_days: int = Field(default=7, ge=1, le=31)
+    default_match_weekday: int = Field(default=6, ge=0, le=6)
+    default_match_time: str = "20:00"
     auto_start_enabled: bool = False
     # Phase 7
     season_weight: float = 2.0
@@ -515,6 +520,9 @@ class TournamentUpdate(BaseModel):
     event_mode: Optional[TournamentEventMode] = None
     result_entry_mode: Optional[TournamentResultEntryMode] = None
     schedule_mode: Optional[TournamentScheduleMode] = None
+    matchday_days: Optional[int] = Field(default=None, ge=1, le=31)
+    default_match_weekday: Optional[int] = Field(default=None, ge=0, le=6)
+    default_match_time: Optional[str] = None
     auto_start_enabled: Optional[bool] = None
     season_weight: Optional[float] = None
     visibility: Optional[Literal["public", "community", "members", "internal"]] = None

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -45,6 +45,7 @@ from services.competition_engine import (
     preferred_engine,
 )
 from services.competition_formats import find_format_capability
+from services.matchday_schedule import build_matchday_plan, current_matchday_number
 from services.graph_swiss import (
     next_round_number,
     open_matches as open_swiss_matches,
@@ -3397,6 +3398,35 @@ async def get_bracket_display(tid: str, me: dict = Depends(get_current_user)):
     if not t:
         raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
     return await _build_bracket_payload(db, t, me, True)
+
+
+@router.get("/{tid}/matchdays")
+async def matchdays(tid: str, access: str | None = None, user=Depends(get_optional_user)):
+    """Die Spieltage als Wochen, mit dem Termin, der je Partie gilt.
+
+    Wer eine Liga spielt, denkt in Spielwochen: Spieltag 3 ist eine Woche, nicht
+    ein Zeitpunkt. Diese Antwort liefert das Fenster je Spieltag und dazu, welcher
+    Termin je Partie gilt und warum - vereinbart, per Heimrecht oder als
+    eingestellte Standardzeit. Formate mit Runden statt Wochen bekommen
+    "applies": false und behalten ihre bisherige Gruppierung.
+    """
+    db = get_db()
+    tid = await _resolve_tid(tid)
+    access_link = await validate_access_link(db, access, "tournament", tid, user, "view")
+    if access_link:
+        t = await db.tournaments.find_one({"id": tid}, {"_id": 0})
+        if not t:
+            raise HTTPException(status_code=404, detail="Turnier nicht gefunden")
+    else:
+        t = await _get_visible_tournament(tid, user)
+
+    matches = await db.matches_v2.find(
+        {"tournament_id": tid, "is_preview": {"$ne": True}}, {"_id": 0}).to_list(3000)
+    proposals = await db.match_schedule_proposals.find(
+        {"tournament_id": tid}, {"_id": 0, "match_collection": 0}).to_list(3000)
+    plan = build_matchday_plan(t, matches, proposals)
+    plan["current"] = current_matchday_number(plan)
+    return plan
 
 
 @router.get("/{tid}/standings")

--- a/backend/services/competition_capabilities.py
+++ b/backend/services/competition_capabilities.py
@@ -120,6 +120,10 @@ CAPABILITIES: tuple[Capability, ...] = (
        note="Liefert bereits die gemeinsame Struktur mit; das Frontend liest sie noch nicht."),
     _c("standings.read", "Tabelle lesen",
        ["GET /api/tournaments/{tid}/standings"], [CLASSIC, GRAPH]),
+    _c("matchday.read", "Spielwochen und geltende Termine lesen",
+       ["GET /api/tournaments/{tid}/matchdays"], [GRAPH],
+       note="Nur Liga, Round Robin und Gruppen spielen in Wochen; andere Formate "
+            "antworten mit applies=false. Rein lesend, die Termine werden berechnet."),
     _c("planning.check", "Planungsprüfung und Spielplan-Export",
        ["GET /api/tournaments/{tid}/planning-check", "GET /api/tournaments/{tid}/match-plan.csv"], [CLASSIC, GRAPH]),
 

--- a/backend/services/matchday_schedule.py
+++ b/backend/services/matchday_schedule.py
@@ -1,0 +1,201 @@
+"""Which time a matchday finally counts as, when a matchday is a whole week.
+
+A league matchday is not a fixed slot here, it is a week. Both sides may offer
+times inside that week, and the rules the operator asked for are:
+
+* What the opponent accepts counts.
+* If only one side ever offers a time, the home side's offer decides. That is
+  why a league plays a return leg: `_auto_league_schema` swaps the sides, so
+  everybody holds home advantage for half of their fixtures.
+* If nobody offers anything, a configured default applies - Sunday 20:00 for
+  example - and it has to fall inside that week.
+
+Slot zero is the home side. That is not a new convention invented here: the
+league generator writes each fixture as ``[home, away]`` and mirrors it for the
+return leg, so the order already carries the home right.
+
+Everything is pure computation on plain dicts and aware datetimes. The write
+path decides when to ask; keeping the rules separate keeps them checkable one
+by one.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+MATCHDAY_DAYS = 7
+# Sunday 20:00 UTC, the example the operator gave. Every caller may override it.
+DEFAULT_WEEKDAY = 6
+DEFAULT_HOUR = 20
+DEFAULT_MINUTE = 0
+
+
+class MatchdayScheduleError(ValueError):
+    """Raised when the inputs cannot describe a matchday at all."""
+
+
+@dataclass(frozen=True)
+class MatchdayWindow:
+    """The week a matchday is played in, start inclusive, end exclusive."""
+
+    number: int
+    start: datetime
+    end: datetime
+
+    def contains(self, moment: datetime | None) -> bool:
+        if moment is None:
+            return False
+        return self.start <= _aware(moment) < self.end
+
+
+@dataclass(frozen=True)
+class ScheduleResolution:
+    """The time that counts, and which rule produced it.
+
+    ``source`` is deliberately part of the result: an admin screen has to be
+    able to say *why* a match sits at that time, and "nobody chose, so the
+    default applied" reads very differently from "the opponent agreed".
+    """
+
+    scheduled_at: datetime
+    source: str  # "accepted" | "home" | "default"
+    proposal_id: str | None = None
+
+
+def _aware(value: datetime) -> datetime:
+    """Treat a naive datetime as UTC rather than guessing a local zone."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _parse(value) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return _aware(value)
+    try:
+        return _aware(datetime.fromisoformat(str(value).replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def matchday_window(season_start, number: int, *, days: int = MATCHDAY_DAYS) -> MatchdayWindow:
+    """The week matchday ``number`` runs in, counted from the first matchday.
+
+    Matchday one starts when the competition starts - if the league opens on a
+    Tuesday, the first week runs Tuesday to Tuesday. The weeks do not snap to
+    Monday, because the operator's rule is "one week from the start", not "one
+    calendar week".
+    """
+    start = _parse(season_start)
+    if start is None:
+        raise MatchdayScheduleError("Ohne Startdatum lässt sich kein Spieltag berechnen")
+    if number < 1:
+        raise MatchdayScheduleError("Spieltage werden ab 1 gezählt")
+    if days < 1:
+        raise MatchdayScheduleError("Ein Spieltag muss mindestens einen Tag dauern")
+    offset = timedelta(days=days * (number - 1))
+    return MatchdayWindow(number=number, start=start + offset, end=start + offset + timedelta(days=days))
+
+
+def matchday_number_of(match: dict) -> int | None:
+    """The matchday a match belongs to, from whichever field carries it."""
+    for key in ("matchday_number", "round", "round_index"):
+        value = (match or {}).get(key)
+        if isinstance(value, int) and value >= 1:
+            return value
+        if isinstance(value, str) and value.isdigit() and int(value) >= 1:
+            return int(value)
+    return None
+
+
+def duel_sides(match: dict) -> tuple[str | None, str | None]:
+    """The two registration ids as (home, away).
+
+    Both match shapes are understood: the graph engine keeps ``slots``, the
+    classic documents kept ``participant_a_id``/``participant_b_id``. In both
+    the first side is the home side.
+    """
+    slots = (match or {}).get("slots")
+    if isinstance(slots, list) and slots:
+        ids = [(slot or {}).get("registration_id") for slot in slots[:2]]
+        while len(ids) < 2:
+            ids.append(None)
+        return ids[0], ids[1]
+    return (match or {}).get("participant_a_id"), (match or {}).get("participant_b_id")
+
+
+def home_registration_id(match: dict) -> str | None:
+    return duel_sides(match)[0]
+
+
+def default_time_in(window: MatchdayWindow, *, weekday: int = DEFAULT_WEEKDAY,
+                    hour: int = DEFAULT_HOUR, minute: int = DEFAULT_MINUTE) -> datetime | None:
+    """The configured fallback moment inside this week, or None if it misses it.
+
+    A full seven day week always contains each weekday exactly once. Shorter
+    windows may miss the configured day entirely, and then there is no honest
+    answer - saying so is better than silently moving the match.
+    """
+    if not 0 <= weekday <= 6:
+        raise MatchdayScheduleError("Wochentag muss zwischen 0 (Montag) und 6 (Sonntag) liegen")
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        raise MatchdayScheduleError("Uhrzeit liegt außerhalb des Tages")
+    day = window.start.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    while day.weekday() != weekday or day < window.start:
+        day += timedelta(days=1)
+        if day >= window.end + timedelta(days=7):
+            return None
+    return day if window.contains(day) else None
+
+
+def usable_proposals(proposals, window: MatchdayWindow) -> list[dict]:
+    """Proposals that could still decide this matchday.
+
+    Withdrawn or declined offers are out, and so is anything outside the week -
+    a time in the wrong week cannot become this matchday's time.
+    """
+    usable = []
+    for proposal in proposals or []:
+        if (proposal or {}).get("status") in {"declined", "withdrawn", "countered"}:
+            continue
+        moment = _parse((proposal or {}).get("scheduled_at"))
+        if moment is None or not window.contains(moment):
+            continue
+        usable.append({**proposal, "_moment": moment})
+    return usable
+
+
+def resolve_matchday_time(match: dict, proposals, window: MatchdayWindow, *,
+                          weekday: int = DEFAULT_WEEKDAY, hour: int = DEFAULT_HOUR,
+                          minute: int = DEFAULT_MINUTE) -> ScheduleResolution | None:
+    """The time that counts for this match, and the rule that produced it.
+
+    The order is the operator's: an accepted time wins, otherwise the home
+    side's own offer, otherwise the configured default. Returns None only when
+    no rule can produce a time at all - that is the case a human has to look at.
+    """
+    candidates = usable_proposals(proposals, window)
+
+    accepted = [p for p in candidates if p.get("status") == "accepted"]
+    if accepted:
+        # The latest agreement wins: sides may re-agree after a counter offer.
+        winner = max(accepted, key=lambda p: (_parse(p.get("updated_at")) or p["_moment"]))
+        return ScheduleResolution(winner["_moment"], "accepted", winner.get("id"))
+
+    home_id = home_registration_id(match)
+    if home_id:
+        home_offers = [p for p in candidates if p.get("actor_registration_id") == home_id]
+        if home_offers:
+            # Nothing was agreed, so home advantage decides - also when the away
+            # side offered something of its own that nobody accepted. Anything
+            # else would make the home right meaningless, and the return leg
+            # hands that right to the other side anyway.
+            winner = min(home_offers, key=lambda p: p["_moment"])
+            return ScheduleResolution(winner["_moment"], "home", winner.get("id"))
+
+    fallback = default_time_in(window, weekday=weekday, hour=hour, minute=minute)
+    if fallback is None:
+        return None
+    return ScheduleResolution(fallback, "default", None)

--- a/backend/services/matchday_schedule.py
+++ b/backend/services/matchday_schedule.py
@@ -199,3 +199,115 @@ def resolve_matchday_time(match: dict, proposals, window: MatchdayWindow, *,
     if fallback is None:
         return None
     return ScheduleResolution(fallback, "default", None)
+
+
+# Only these formats play in weekly matchdays. A knockout bracket has rounds,
+# but a round is not a week - saying so keeps the caller from inventing weeks
+# for a single elimination tree.
+MATCHDAY_FORMATS = frozenset({"league", "round_robin", "groups"})
+
+
+def plays_in_matchdays(tournament: dict) -> bool:
+    return (tournament or {}).get("format") in MATCHDAY_FORMATS
+
+
+def matchday_settings(tournament: dict) -> dict:
+    """Week length and fallback time, with the operator's defaults filled in."""
+    tournament = tournament or {}
+    days = tournament.get("matchday_days")
+    try:
+        days = int(days)
+    except (TypeError, ValueError):
+        days = MATCHDAY_DAYS
+    if days < 1:
+        days = MATCHDAY_DAYS
+
+    weekday = tournament.get("default_match_weekday")
+    try:
+        weekday = int(weekday)
+    except (TypeError, ValueError):
+        weekday = DEFAULT_WEEKDAY
+    if not 0 <= weekday <= 6:
+        weekday = DEFAULT_WEEKDAY
+
+    hour, minute = DEFAULT_HOUR, DEFAULT_MINUTE
+    raw_time = str(tournament.get("default_match_time") or "").strip()
+    if raw_time:
+        parts = raw_time.split(":")
+        try:
+            candidate_hour = int(parts[0])
+            candidate_minute = int(parts[1]) if len(parts) > 1 else 0
+            if 0 <= candidate_hour <= 23 and 0 <= candidate_minute <= 59:
+                hour, minute = candidate_hour, candidate_minute
+        except (ValueError, IndexError):
+            pass
+
+    return {"days": days, "weekday": weekday, "hour": hour, "minute": minute}
+
+
+def build_matchday_plan(tournament: dict, matches, proposals=None) -> dict:
+    """Group the fixtures into weeks and say what time each one counts as.
+
+    Returns ``applies: False`` for formats that have rounds rather than weeks,
+    so the caller can fall back to its existing grouping instead of pretending
+    a single elimination bracket has matchdays.
+    """
+    settings = matchday_settings(tournament)
+    start = _parse((tournament or {}).get("start_date"))
+    if not plays_in_matchdays(tournament) or start is None:
+        return {"applies": False, "settings": settings, "matchdays": []}
+
+    by_proposal: dict[str, list] = {}
+    for proposal in proposals or []:
+        by_proposal.setdefault((proposal or {}).get("match_id"), []).append(proposal)
+
+    numbered: dict[int, list] = {}
+    for match in matches or []:
+        number = matchday_number_of(match)
+        if number is None:
+            continue
+        numbered.setdefault(number, []).append(match)
+
+    plan = []
+    for number in sorted(numbered):
+        window = matchday_window(start, number, days=settings["days"])
+        entries = []
+        for match in numbered[number]:
+            resolution = resolve_matchday_time(
+                match, by_proposal.get(match.get("id"), []), window,
+                weekday=settings["weekday"], hour=settings["hour"], minute=settings["minute"],
+            )
+            entries.append({
+                "match_id": match.get("id"),
+                "scheduled_at": resolution.scheduled_at.isoformat() if resolution else None,
+                "schedule_source": resolution.source if resolution else None,
+                "home_registration_id": home_registration_id(match),
+            })
+        plan.append({
+            "number": number,
+            "starts_at": window.start.isoformat(),
+            "ends_at": window.end.isoformat(),
+            "matches": entries,
+        })
+    return {"applies": True, "settings": settings, "matchdays": plan}
+
+
+def current_matchday_number(plan: dict, now: datetime | None = None) -> int | None:
+    """The week we are in right now, or the nearest one otherwise.
+
+    Opening the schedule should land on the week that is being played, not on
+    matchday one of a league that started in March.
+    """
+    matchdays = (plan or {}).get("matchdays") or []
+    if not matchdays:
+        return None
+    moment = _aware(now or datetime.now(timezone.utc))
+    for entry in matchdays:
+        starts = _parse(entry.get("starts_at"))
+        ends = _parse(entry.get("ends_at"))
+        if starts and ends and starts <= moment < ends:
+            return entry["number"]
+    first = _parse(matchdays[0].get("starts_at"))
+    if first and moment < first:
+        return matchdays[0]["number"]
+    return matchdays[-1]["number"]

--- a/backend/tests/test_matchday_schedule_unit.py
+++ b/backend/tests/test_matchday_schedule_unit.py
@@ -1,0 +1,240 @@
+"""The scheduling rules the operator stated, one test per rule.
+
+These are deliberately written as the rules read, not as the implementation is
+structured: if a rule is ever changed, exactly one test should have to change
+with it.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.matchday_schedule import (
+    MatchdayScheduleError,
+    default_time_in,
+    duel_sides,
+    home_registration_id,
+    matchday_number_of,
+    matchday_window,
+    resolve_matchday_time,
+    usable_proposals,
+)
+
+
+# Die Liga startet an einem Dienstag um 18:00 UTC.
+TUESDAY = datetime(2026, 9, 8, 18, 0, tzinfo=timezone.utc)
+
+
+def match(home="reg-home", away="reg-away"):
+    return {"slots": [{"registration_id": home}, {"registration_id": away}]}
+
+
+def proposal(actor, moment, status="pending", **extra):
+    return {"id": f"p-{actor}-{moment.isoformat()}", "actor_registration_id": actor,
+            "scheduled_at": moment.isoformat(), "status": status, **extra}
+
+
+# ---------------------------------------------------------------- Die Woche
+
+def test_a_matchday_is_one_week_from_the_start():
+    window = matchday_window(TUESDAY, 1)
+
+    assert window.start == TUESDAY
+    assert window.end == TUESDAY + timedelta(days=7)
+
+
+def test_the_weeks_follow_each_other_without_gap():
+    first = matchday_window(TUESDAY, 1)
+    second = matchday_window(TUESDAY, 2)
+
+    assert second.start == first.end
+    assert second.end == TUESDAY + timedelta(days=14)
+
+
+def test_the_week_does_not_snap_to_monday():
+    """Startet die Liga am Dienstag, laeuft die Woche Dienstag bis Dienstag."""
+    window = matchday_window(TUESDAY, 1)
+
+    assert window.start.weekday() == 1
+    assert window.end.weekday() == 1
+
+
+def test_a_missing_start_date_is_refused_instead_of_guessed():
+    with pytest.raises(MatchdayScheduleError):
+        matchday_window(None, 1)
+
+
+def test_matchdays_are_counted_from_one():
+    with pytest.raises(MatchdayScheduleError):
+        matchday_window(TUESDAY, 0)
+
+
+# ---------------------------------------------------------------- Heimrecht
+
+def test_the_first_slot_is_the_home_side():
+    assert duel_sides(match()) == ("reg-home", "reg-away")
+    assert home_registration_id(match()) == "reg-home"
+
+
+def test_the_classic_match_shape_is_understood_too():
+    assert duel_sides({"participant_a_id": "a", "participant_b_id": "b"}) == ("a", "b")
+
+
+def test_the_matchday_number_is_read_from_whichever_field_carries_it():
+    assert matchday_number_of({"matchday_number": 3}) == 3
+    assert matchday_number_of({"round": 2}) == 2
+    assert matchday_number_of({"round": "0"}) is None
+    assert matchday_number_of({}) is None
+
+
+# ---------------------------------------------------------------- Standardzeit
+
+def test_without_any_choice_the_default_time_applies():
+    window = matchday_window(TUESDAY, 1)
+
+    resolution = resolve_matchday_time(match(), [], window)
+
+    assert resolution.source == "default"
+    assert resolution.scheduled_at.weekday() == 6
+    assert resolution.scheduled_at.hour == 20
+    assert window.contains(resolution.scheduled_at)
+
+
+def test_the_default_time_is_configurable():
+    window = matchday_window(TUESDAY, 1)
+
+    resolution = resolve_matchday_time(match(), [], window, weekday=4, hour=19, minute=30)
+
+    assert resolution.scheduled_at.weekday() == 4
+    assert (resolution.scheduled_at.hour, resolution.scheduled_at.minute) == (19, 30)
+
+
+def test_a_default_day_outside_a_short_week_gives_no_answer():
+    """Lieber keine Antwort als ein Termin ausserhalb des Spieltags."""
+    window = matchday_window(TUESDAY, 1, days=2)
+
+    assert default_time_in(window, weekday=6) is None
+    assert resolve_matchday_time(match(), [], window) is None
+
+
+def test_an_impossible_default_is_refused():
+    window = matchday_window(TUESDAY, 1)
+
+    with pytest.raises(MatchdayScheduleError):
+        default_time_in(window, weekday=9)
+    with pytest.raises(MatchdayScheduleError):
+        default_time_in(window, hour=25)
+
+
+# ---------------------------------------------------------------- Was gilt
+
+def test_what_the_opponent_accepts_counts():
+    window = matchday_window(TUESDAY, 1)
+    agreed = TUESDAY + timedelta(days=2, hours=1)
+
+    resolution = resolve_matchday_time(
+        match(), [proposal("reg-away", agreed, status="accepted")], window)
+
+    assert resolution.source == "accepted"
+    assert resolution.scheduled_at == agreed
+
+
+def test_an_accepted_time_beats_the_home_offer():
+    window = matchday_window(TUESDAY, 1)
+    agreed = TUESDAY + timedelta(days=2)
+    home_wish = TUESDAY + timedelta(days=4)
+
+    resolution = resolve_matchday_time(match(), [
+        proposal("reg-home", home_wish),
+        proposal("reg-away", agreed, status="accepted"),
+    ], window)
+
+    assert resolution.source == "accepted"
+    assert resolution.scheduled_at == agreed
+
+
+def test_the_home_side_decides_when_nothing_was_agreed():
+    window = matchday_window(TUESDAY, 1)
+    home_wish = TUESDAY + timedelta(days=3, hours=2)
+
+    resolution = resolve_matchday_time(match(), [proposal("reg-home", home_wish)], window)
+
+    assert resolution.source == "home"
+    assert resolution.scheduled_at == home_wish
+
+
+def test_the_home_side_also_beats_an_unanswered_away_offer():
+    """Sonst waere das Heimrecht wertlos - die Rueckrunde dreht es ohnehin um."""
+    window = matchday_window(TUESDAY, 1)
+    home_wish = TUESDAY + timedelta(days=5)
+    away_wish = TUESDAY + timedelta(days=1)
+
+    resolution = resolve_matchday_time(match(), [
+        proposal("reg-away", away_wish),
+        proposal("reg-home", home_wish),
+    ], window)
+
+    assert resolution.source == "home"
+    assert resolution.scheduled_at == home_wish
+
+
+def test_an_away_offer_alone_does_not_bind_and_the_default_applies():
+    window = matchday_window(TUESDAY, 1)
+
+    resolution = resolve_matchday_time(
+        match(), [proposal("reg-away", TUESDAY + timedelta(days=1))], window)
+
+    assert resolution.source == "default"
+
+
+def test_the_return_leg_hands_the_home_right_to_the_other_side():
+    window = matchday_window(TUESDAY, 6)
+    wish = window.start + timedelta(hours=3)
+
+    # Hinrunde: reg-home ist Heim. Rueckrunde: die Seiten sind getauscht.
+    first_leg = resolve_matchday_time(match(), [proposal("reg-home", wish)], window)
+    return_leg = resolve_matchday_time(
+        match(home="reg-away", away="reg-home"), [proposal("reg-home", wish)], window)
+
+    assert first_leg.source == "home"
+    assert return_leg.source == "default"
+
+
+# ---------------------------------------------------------------- Ausgeschlossen
+
+def test_a_time_in_the_wrong_week_cannot_decide_this_matchday():
+    window = matchday_window(TUESDAY, 1)
+    next_week = TUESDAY + timedelta(days=9)
+
+    assert usable_proposals([proposal("reg-home", next_week)], window) == []
+    assert resolve_matchday_time(match(), [proposal("reg-home", next_week)], window).source == "default"
+
+
+@pytest.mark.parametrize("status", ["declined", "withdrawn", "countered"])
+def test_settled_offers_no_longer_count(status):
+    window = matchday_window(TUESDAY, 1)
+    wish = TUESDAY + timedelta(days=2)
+
+    resolution = resolve_matchday_time(
+        match(), [proposal("reg-home", wish, status=status)], window)
+
+    assert resolution.source == "default"
+
+
+def test_a_naive_datetime_is_read_as_utc_instead_of_a_guessed_zone():
+    window = matchday_window(TUESDAY.replace(tzinfo=None), 1)
+
+    assert window.start == TUESDAY
+
+
+def test_the_later_agreement_wins_after_a_counter_offer():
+    window = matchday_window(TUESDAY, 1)
+    first = TUESDAY + timedelta(days=1)
+    later = TUESDAY + timedelta(days=4)
+
+    resolution = resolve_matchday_time(match(), [
+        proposal("reg-home", first, status="accepted", updated_at=TUESDAY.isoformat()),
+        proposal("reg-away", later, status="accepted",
+                 updated_at=(TUESDAY + timedelta(hours=5)).isoformat()),
+    ], window)
+
+    assert resolution.scheduled_at == later

--- a/backend/tests/test_tournament_flows.py
+++ b/backend/tests/test_tournament_flows.py
@@ -10,6 +10,7 @@ a tournament host would make them.
 """
 import pathlib
 import sys
+from datetime import datetime
 
 import pytest
 import pytest_asyncio
@@ -382,3 +383,118 @@ async def test_the_format_alone_decides_the_structure(flow, tournament_format, e
     stages = (await flow.get(f"/api/tournaments/{tournament['id']}/stages")).json()
     assert stages, "Es muss eine Phase entstanden sein"
     assert stages[0]["stage_type"] == expected_stage_type
+
+
+# ---------------------------------------------------------------- Spielwochen
+
+LEAGUE_START = "2026-09-08T18:00:00+00:00"
+
+
+async def league_with_matchdays(flow, count=4, **fields):
+    staff, tournament, users, regs = await bracket_of(
+        flow, count, format="league", start_date=LEAGUE_START, **fields)
+    return staff, tournament, users, regs
+
+
+@pytest.mark.asyncio
+async def test_a_league_is_played_in_weeks_not_in_rounds(flow):
+    _staff, tournament, _users, _regs = await league_with_matchdays(flow)
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+
+    assert plan["applies"] is True
+    assert len(plan["matchdays"]) == 6, "vier Teilnehmer spielen Hin- und Rueckrunde"
+    first, second = plan["matchdays"][0], plan["matchdays"][1]
+    assert first["starts_at"] == LEAGUE_START
+    assert first["ends_at"] == second["starts_at"], "die Wochen schliessen luecklos an"
+
+
+@pytest.mark.asyncio
+async def test_without_any_agreement_the_default_time_counts(flow):
+    _staff, tournament, _users, _regs = await league_with_matchdays(flow)
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+
+    entries = plan["matchdays"][0]["matches"]
+    assert entries, "Spieltag 1 hat Partien"
+    for entry in entries:
+        assert entry["schedule_source"] == "default"
+        moment = datetime.fromisoformat(entry["scheduled_at"])
+        assert moment.weekday() == 6 and moment.hour == 20, "Sonntag 20:00"
+
+
+@pytest.mark.asyncio
+async def test_the_default_time_is_a_tournament_setting(flow):
+    _staff, tournament, _users, _regs = await league_with_matchdays(
+        flow, default_match_weekday=4, default_match_time="19:30")
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+
+    assert plan["settings"] == {"days": 7, "weekday": 4, "hour": 19, "minute": 30}
+    moment = datetime.fromisoformat(plan["matchdays"][0]["matches"][0]["scheduled_at"])
+    assert moment.weekday() == 4 and (moment.hour, moment.minute) == (19, 30)
+
+
+@pytest.mark.asyncio
+async def test_an_agreed_time_replaces_the_default(flow):
+    """Was die Gegenseite annimmt, gilt - und der Grund steht dabei."""
+    staff, tournament, users, regs = await league_with_matchdays(flow)
+    match = (await flow.matches(tournament))[0]
+    first, second = [slot["registration_id"] for slot in match["slots"]]
+    proposer = user_for(users, regs, first)
+    opponent = user_for(users, regs, second)
+    agreed = "2026-09-10T19:00:00+00:00"
+
+    flow.act_as(proposer)
+    created = await flow.post(f"/api/matches/{match['id']}/schedule-proposals",
+                              json={"scheduled_at": agreed})
+    assert created.status_code == 200, created.text
+    flow.act_as(opponent)
+    decided = await flow.post(
+        f"/api/matches/{match['id']}/schedule-proposals/{created.json()['id']}/decision",
+        json={"action": "accept"})
+    assert decided.status_code == 200, decided.text
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+    entry = next(e for day in plan["matchdays"] for e in day["matches"] if e["match_id"] == match["id"])
+    assert entry["schedule_source"] == "accepted"
+    assert datetime.fromisoformat(entry["scheduled_at"]) == datetime.fromisoformat(agreed)
+
+
+@pytest.mark.asyncio
+async def test_an_unanswered_home_proposal_decides(flow):
+    """Schlaegt nur die Heimseite vor, gilt ihre Zeit - Slot eins ist Heim."""
+    _staff, tournament, users, regs = await league_with_matchdays(flow)
+    match = (await flow.matches(tournament))[0]
+    home_registration = match["slots"][0]["registration_id"]
+    flow.act_as(user_for(users, regs, home_registration))
+    wish = "2026-09-11T21:00:00+00:00"
+
+    created = await flow.post(f"/api/matches/{match['id']}/schedule-proposals",
+                              json={"scheduled_at": wish})
+    assert created.status_code == 200, created.text
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+    entry = next(e for day in plan["matchdays"] for e in day["matches"] if e["match_id"] == match["id"])
+    assert entry["schedule_source"] == "home"
+    assert entry["home_registration_id"] == home_registration
+
+
+@pytest.mark.asyncio
+async def test_a_knockout_bracket_has_rounds_and_says_so(flow):
+    _staff, tournament, _users, _regs = await bracket_of(flow, 4, start_date=LEAGUE_START)
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+
+    assert plan["applies"] is False
+    assert plan["matchdays"] == []
+
+
+@pytest.mark.asyncio
+async def test_the_schedule_opens_on_the_week_being_played(flow):
+    _staff, tournament, _users, _regs = await league_with_matchdays(flow)
+
+    plan = (await flow.get(f"/api/tournaments/{tournament['id']}/matchdays")).json()
+
+    numbers = [day["number"] for day in plan["matchdays"]]
+    assert plan["current"] in numbers

--- a/frontend/e2e/tournament-matchdays.spec.js
+++ b/frontend/e2e/tournament-matchdays.spec.js
@@ -1,0 +1,142 @@
+const { test, expect } = require("@playwright/test");
+
+// Ein Spieltag ist eine Woche. Bisher standen alle Spieltage untereinander auf
+// einer Seite; jetzt blättert man mit Pfeilen durch, und die Kopfzeile nennt
+// den Zeitraum. Dazu steht an jeder Partie, warum dieser Termin gilt.
+
+const TOURNAMENT = {
+  id: "t-liga",
+  slug: "winterliga",
+  title: "Winterliga 2026",
+  status: "live",
+  format: "league",
+  start_date: "2026-09-08T18:00:00+00:00",
+};
+
+function reg(id, name) {
+  return { id, display_name: name };
+}
+
+function match(id, matchday, home, away) {
+  return {
+    id,
+    match_key: id.toUpperCase(),
+    matchday_number: matchday,
+    round: matchday,
+    section: "LIGA",
+    match_type: "duel",
+    status: "pending",
+    slots: [{ registration_id: home }, { registration_id: away }],
+  };
+}
+
+const MATCHES = [
+  match("m1", 1, "r1", "r2"),
+  match("m2", 1, "r3", "r4"),
+  match("m3", 2, "r1", "r3"),
+  match("m4", 3, "r1", "r4"),
+];
+
+function week(number, startsAt, endsAt, entries) {
+  return { number, starts_at: startsAt, ends_at: endsAt, matches: entries };
+}
+
+const PLAN = {
+  applies: true,
+  current: 2,
+  settings: { days: 7, weekday: 6, hour: 20, minute: 0 },
+  matchdays: [
+    week(1, "2026-09-08T18:00:00+00:00", "2026-09-15T18:00:00+00:00", [
+      { match_id: "m1", scheduled_at: "2026-09-13T20:00:00+00:00", schedule_source: "default", home_registration_id: "r1" },
+      { match_id: "m2", scheduled_at: "2026-09-10T19:00:00+00:00", schedule_source: "accepted", home_registration_id: "r3" },
+    ]),
+    week(2, "2026-09-15T18:00:00+00:00", "2026-09-22T18:00:00+00:00", [
+      { match_id: "m3", scheduled_at: "2026-09-18T21:00:00+00:00", schedule_source: "home", home_registration_id: "r1" },
+    ]),
+    week(3, "2026-09-22T18:00:00+00:00", "2026-09-29T18:00:00+00:00", [
+      { match_id: "m4", scheduled_at: "2026-09-27T20:00:00+00:00", schedule_source: "default", home_registration_id: "r1" },
+    ]),
+  ],
+};
+
+async function mockSchedule(page, { plan = PLAN } = {}) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true, external_media: false, analytics: false, meta: false,
+      tiktok: false, saved_at: Date.now(), expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }));
+  });
+  const json = (body) => ({ contentType: "application/json", body: JSON.stringify(body) });
+
+  await page.route("**/api/settings/public", (r) => r.fulfill(json({ club_name: "THE LION SQUAD" })));
+  await page.route("**/api/sponsors**", (r) => r.fulfill(json([])));
+  await page.route("**/api/auth/me", (r) => r.fulfill(json(null)));
+  await page.route("**/api/tournaments/t-liga/matchdays**", (r) => r.fulfill(json(plan)));
+  await page.route("**/api/tournaments/t-liga/bracket**", (r) => r.fulfill(json({
+    tournament: TOURNAMENT,
+    registrations: [reg("r1", "Alpha"), reg("r2", "Bravo"), reg("r3", "Charlie"), reg("r4", "Delta")],
+    matches_v2: MATCHES,
+    matches: [],
+  })));
+  await page.route("**/api/tournaments/winterliga**", (r) => r.fulfill(json(TOURNAMENT)));
+}
+
+test.describe("Spielplan als Spielwochen", () => {
+  test("ein Spieltag wird als Woche mit Zeitraum gezeigt", async ({ page }) => {
+    await mockSchedule(page);
+    await page.goto("/tournaments/winterliga/matches");
+
+    await expect(page.getByTestId("matchday-pager")).toBeVisible();
+    // Die laufende Woche steht offen, nicht Spieltag 1.
+    await expect(page.getByTestId("matchday-title")).toHaveText("Spieltag 2");
+    await expect(page.getByTestId("matchday-range")).toHaveText("15.09. – 22.09.2026");
+    await expect(page.getByTestId("matchday-matches").getByRole("link")).toHaveCount(1);
+  });
+
+  test("mit den Pfeilen blättert man durch die Wochen", async ({ page }) => {
+    await mockSchedule(page);
+    await page.goto("/tournaments/winterliga/matches");
+    await expect(page.getByTestId("matchday-title")).toHaveText("Spieltag 2");
+
+    await page.getByTestId("matchday-prev").click();
+    await expect(page.getByTestId("matchday-title")).toHaveText("Spieltag 1");
+    await expect(page.getByTestId("matchday-range")).toHaveText("08.09. – 15.09.2026");
+    await expect(page.getByTestId("matchday-matches").getByRole("link")).toHaveCount(2);
+    await expect(page.getByTestId("matchday-prev")).toBeDisabled();
+
+    await page.getByTestId("matchday-next").click();
+    await page.getByTestId("matchday-next").click();
+    await expect(page.getByTestId("matchday-title")).toHaveText("Spieltag 3");
+    await expect(page.getByTestId("matchday-next")).toBeDisabled();
+  });
+
+  test("an jeder Partie steht, warum dieser Termin gilt", async ({ page }) => {
+    await mockSchedule(page);
+    await page.goto("/tournaments/winterliga/matches");
+    await expect(page.getByTestId("matchday-title")).toHaveText("Spieltag 2");
+
+    await expect(page.getByTestId("schedule-source-m3")).toHaveText("Heimrecht");
+
+    await page.getByTestId("matchday-prev").click();
+    await expect(page.getByTestId("schedule-source-m1")).toHaveText("Standardzeit");
+    await expect(page.getByTestId("schedule-source-m2")).toHaveText("vereinbart");
+  });
+
+  test("Formate mit Runden statt Wochen behalten ihre Gruppierung", async ({ page }) => {
+    await mockSchedule(page, { plan: { applies: false, matchdays: [] } });
+    await page.goto("/tournaments/winterliga/matches");
+
+    await expect(page.getByRole("heading", { name: "Spielplan" })).toBeVisible();
+    await expect(page.getByTestId("matchday-pager")).toHaveCount(0);
+  });
+
+  test("die Wochenansicht läuft am Telefon nicht quer", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockSchedule(page);
+    await page.goto("/tournaments/winterliga/matches");
+    await expect(page.getByTestId("matchday-pager")).toBeVisible();
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/pages/admin/AdminTournamentEditPage.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.jsx
@@ -87,6 +87,13 @@ const AUTO_STAGE_TYPES = new Set([
 ]);
 const FFA_STAGE_TYPES = new Set(["simple", "ffa_single_elimination", "ffa_custom_bracket", "ffa_league"]);
 const BRONZE_FORMATS = new Set(["single_elim"]);
+// Nur diese Formate spielen in Wochen; ein K.-o.-Baum hat Runden, keine Woche.
+// Muss zu MATCHDAY_FORMATS in services/matchday_schedule.py passen.
+const MATCHDAY_FORMATS = new Set(["league", "round_robin", "groups"]);
+const WEEKDAY_OPTIONS = [
+  ["0", "Montag"], ["1", "Dienstag"], ["2", "Mittwoch"], ["3", "Donnerstag"],
+  ["4", "Freitag"], ["5", "Samstag"], ["6", "Sonntag"],
+];
 const MATCH_SECTION_ORDER = ["WB", "winner", "MAIN", "main", "LB", "loser", "BRONZE", "bronze", "GF", "grand_final", "FINAL", "final", "round_robin"];
 
 function matchSectionKey(match) {
@@ -1587,6 +1594,9 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
     event_mode: source.event_mode || "online",
     result_entry_mode: source.result_entry_mode || "",
     schedule_mode: source.schedule_mode || "",
+    matchday_days: source.matchday_days ?? 7,
+    default_match_weekday: source.default_match_weekday ?? 6,
+    default_match_time: source.default_match_time || "20:00",
     twitch_channel: source.twitch_channel || "",
     twitch_enabled: !!source.twitch_enabled,
     has_live_stream: !!source.has_live_stream,
@@ -1639,6 +1649,9 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
     event_mode: tournament.event_mode || "online",
     result_entry_mode: tournament.result_entry_mode || "",
     schedule_mode: tournament.schedule_mode || "",
+    matchday_days: tournament.matchday_days ?? 7,
+    default_match_weekday: tournament.default_match_weekday ?? 6,
+    default_match_time: tournament.default_match_time || "20:00",
     twitch_channel: tournament.twitch_channel || "",
     twitch_enabled: !!tournament.twitch_enabled,
     has_live_stream: !!tournament.has_live_stream,
@@ -1696,7 +1709,8 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
     payload.format_label = (payload.format_label || "").trim() || null;
     if (!BRONZE_FORMATS.has(payload.format)) payload.bronze_match = false;
     normalizeDateTimeFields(payload, ["registration_open_from", "registration_open_until", "check_in_from", "check_in_until", "start_date", "end_date"]);
-    ["team_size", "max_participants", "min_participants", "best_of", "match_duration_minutes"].forEach((key) => {
+    ["team_size", "max_participants", "min_participants", "best_of", "match_duration_minutes",
+      "matchday_days", "default_match_weekday"].forEach((key) => {
       if (payload[key] !== "" && payload[key] != null) payload[key] = Number(payload[key]);
     });
     payload.season_weight = Number(payload.season_weight || 0);
@@ -1807,6 +1821,21 @@ function TournamentEditForm({ tournament, stages = [], onSaved, onRebuildFromFor
           <SelectField label="Ergebniserfassung" value={f.result_entry_mode || ""} onChange={(v)=>set("result_entry_mode",v || "")} options={RESULT_ENTRY_MODE_OPTIONS} />
           <SelectField label="Terminplanung" value={f.schedule_mode || ""} onChange={(v)=>set("schedule_mode",v || "")} options={SCHEDULE_MODE_OPTIONS} />
         </div>
+        {MATCHDAY_FORMATS.has(f.format) && (
+          <div className="border border-[#29B6E8]/20 bg-[#29B6E8]/5 rounded-sm p-4 space-y-3" data-testid="tr-edit-matchdays">
+            <div className="text-[11px] font-bold uppercase tracking-widest text-[#29B6E8]">Spielwochen</div>
+            <p className="text-xs text-white/55">
+              Ein Spieltag ist ein Zeitraum, kein Zeitpunkt. Beide Seiten dürfen darin Termine vorschlagen;
+              was die Gegenseite annimmt, gilt. Schlägt nur die Heimseite vor, gilt ihre Zeit. Wählt niemand,
+              greift die Standardzeit unten.
+            </p>
+            <div className="grid md:grid-cols-3 gap-3">
+              <Fld label="Spieltag dauert (Tage)" type="number" min="1" max="31" value={f.matchday_days} onChange={(v)=>set("matchday_days", v)} testId="tr-edit-matchday-days" />
+              <SelectField label="Standardtag" value={String(f.default_match_weekday ?? 6)} onChange={(v)=>set("default_match_weekday", Number(v))} options={WEEKDAY_OPTIONS} />
+              <Fld label="Standarduhrzeit" type="time" value={f.default_match_time} onChange={(v)=>set("default_match_time", v)} testId="tr-edit-matchday-time" />
+            </div>
+          </div>
+        )}
         <RulePresetPicker form={f} onApply={applyRulePreset} />
         <div className="border border-white/10 bg-black/20 rounded-sm p-3 text-xs text-white/55">
           Vor-Ort-Turniere werden standardmäßig durch die Turnierleitung gewertet und geplant. Online-Turniere erlauben standardmäßig Ergebnisberichte beider Parteien und Terminvorschläge.

--- a/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
+++ b/frontend/src/pages/admin/AdminTournamentEditPage.test.jsx
@@ -297,3 +297,28 @@ test("ein Ausfall der Nebendaten blockiert das Turnier nicht", async () => {
   expect(await screen.findByRole("heading", { name: "Winter Cup 2026" })).toBeInTheDocument();
   expect(screen.queryByTestId("admin-tr-load-error")).not.toBeInTheDocument();
 });
+
+// Spielwochen gibt es nur bei Formaten, die in Wochen spielen. Ein
+// K.-o.-Turnier hat Runden - dort waeren die Felder nur Ballast.
+
+test("die Spielwochen-Einstellungen erscheinen nur bei Wochenformaten", async () => {
+  const user = userEvent.setup();
+  renderPageWithFormat("league");
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+  await user.click(screen.getByTestId("admin-tr-tab-edit"));
+
+  expect(await screen.findByTestId("tr-edit-matchdays")).toBeInTheDocument();
+  expect(screen.getByTestId("tr-edit-matchday-days")).toHaveValue(7);
+  expect(screen.getByTestId("tr-edit-matchday-time")).toHaveValue("20:00");
+  expect(screen.getByLabelText("Standardtag")).toHaveValue("6");
+});
+
+test("ein K.-o.-Turnier zeigt keine Spielwochen-Einstellungen", async () => {
+  const user = userEvent.setup();
+  renderPageWithFormat("single_elim");
+  await screen.findByRole("heading", { name: "Winter Cup 2026" });
+  await user.click(screen.getByTestId("admin-tr-tab-edit"));
+
+  await screen.findByLabelText("Turnierstruktur");
+  expect(screen.queryByTestId("tr-edit-matchdays")).not.toBeInTheDocument();
+});

--- a/frontend/src/pages/public/TournamentSchedulePage.jsx
+++ b/frontend/src/pages/public/TournamentSchedulePage.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
-import { CalendarClock } from "lucide-react";
+import { CalendarClock, ChevronLeft, ChevronRight } from "lucide-react";
 import { PublicLayout } from "@/components/tls/PublicLayout";
 import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
 import { PublicLoadingState } from "@/components/tls/PublicLoadingState";
@@ -15,6 +15,24 @@ function formatDateTime(value) {
   if (!value) return "Termin offen";
   return new Date(value).toLocaleString("de-DE", { dateStyle: "medium", timeStyle: "short" });
 }
+
+// Ein Spieltag ist eine Woche. Die Kopfzeile nennt deshalb den Zeitraum, nicht
+// nur die Nummer - "Spieltag 3" allein sagt niemandem, wann gespielt wird.
+function formatWeekRange(startsAt, endsAt) {
+  if (!startsAt || !endsAt) return "";
+  const day = { day: "2-digit", month: "2-digit" };
+  const start = new Date(startsAt).toLocaleDateString("de-DE", day);
+  const end = new Date(endsAt).toLocaleDateString("de-DE", { ...day, year: "numeric" });
+  return `${start} – ${end}`;
+}
+
+// Warum dieser Termin gilt. Ohne das steht da eine Uhrzeit, bei der unklar
+// bleibt, ob sie vereinbart oder nur die Vorgabe ist.
+const SCHEDULE_SOURCE_LABELS = {
+  accepted: "vereinbart",
+  home: "Heimrecht",
+  default: "Standardzeit",
+};
 
 function stationLabel(match) {
   return match?.station_label || match?.station_name || match?.station?.name || match?.station_id || "";
@@ -39,12 +57,22 @@ export default function TournamentSchedulePage() {
   const [searchParams] = useSearchParams();
   const accessToken = searchParams.get("access") || "";
   const [data, setData] = useState(null);
+  const [plan, setPlan] = useState(null);
+  const [activeMatchday, setActiveMatchday] = useState(null);
 
   const load = useCallback(async () => {
     const accessConfig = { params: accessToken ? { access: accessToken } : undefined };
     const { data: tournament } = await api.get(`/tournaments/${slug}`, accessConfig);
     const { data: bracket } = await api.get(`/tournaments/${tournament.id}/bracket`, accessConfig);
     setData(bracket);
+    // Spielwochen gibt es nur bei Liga, Round Robin und Gruppen. Schlägt der
+    // Aufruf fehl, bleibt die bisherige Gruppierung stehen statt einer leeren Seite.
+    try {
+      const { data: matchdayPlan } = await api.get(`/tournaments/${tournament.id}/matchdays`, accessConfig);
+      setPlan(matchdayPlan);
+    } catch {
+      setPlan({ applies: false, matchdays: [] });
+    }
   }, [slug, accessToken]);
 
   useEffect(() => {
@@ -79,6 +107,36 @@ export default function TournamentSchedulePage() {
     return [...byDay.values()].sort((a, b) => Number(a.key.split(":")[0]) - Number(b.key.split(":")[0]));
   }, [data]);
 
+  const weeks = useMemo(() => (plan?.applies ? (plan.matchdays || []) : []), [plan]);
+  const suggestedMatchday = plan?.current ?? null;
+  // Beim Öffnen die Woche zeigen, die gerade gespielt wird - nicht Spieltag 1
+  // einer Liga, die im März angefangen hat. Beim Neuladen alle sieben Sekunden
+  // bleibt die gewählte Woche stehen, damit einem nichts wegspringt.
+  useEffect(() => {
+    if (!weeks.length) return;
+    setActiveMatchday((current) => (
+      current != null && weeks.some((week) => week.number === current)
+        ? current
+        : (suggestedMatchday ?? weeks[0].number)
+    ));
+  }, [suggestedMatchday, weeks]);
+
+  const resolvedByMatch = useMemo(() => {
+    const map = {};
+    for (const week of weeks) {
+      for (const entry of week.matches || []) map[entry.match_id] = entry;
+    }
+    return map;
+  }, [weeks]);
+
+  const weekIndex = weeks.findIndex((week) => week.number === activeMatchday);
+  const currentWeek = weekIndex >= 0 ? weeks[weekIndex] : null;
+  const weekMatches = useMemo(() => {
+    if (!currentWeek) return [];
+    const wanted = new Set((currentWeek.matches || []).map((entry) => entry.match_id));
+    return groups.flatMap((group) => group.matches).filter((match) => wanted.has(match.id));
+  }, [currentWeek, groups]);
+
   const tournament = data?.tournament || {};
   const tournamentUrl = `/tournaments/${tournament.slug || tournament.id}${accessToken ? `?access=${encodeURIComponent(accessToken)}` : ""}`;
   const seoDescription = seoTextPreview(tournament.description, "Spielplan des eSports Turniers mit Runden, Heats, Zeiten und Matchseiten.");
@@ -106,32 +164,98 @@ export default function TournamentSchedulePage() {
         <h1 className="mt-3 font-heading text-4xl md:text-6xl font-black uppercase">Spielplan</h1>
         <p className="mt-3 text-white/60 max-w-2xl">Alle Runden, Heats, Zeiten und öffentlichen Matchseiten für Terminabstimmung, Chat und Ergebnisstatus.</p>
 
-        <div className="mt-10 space-y-8">
-          {groups.map((group) => (
-            <section key={group.key}>
-              <h2 className="font-heading text-2xl font-black uppercase flex items-center gap-2"><CalendarClock className="w-5 h-5 text-[#29B6E8]" /> {group.label}</h2>
-              <div className="mt-4 grid md:grid-cols-2 xl:grid-cols-3 gap-3">
-                {group.matches.map((match) => (
-                  <Link key={match.id} to={`/matches/${match.id}`} className="border border-white/10 hover:border-[#29B6E8]/50 bg-[#121212] rounded-sm p-4 transition">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="text-[10px] uppercase tracking-widest text-white/40">{formatMatchKind(match)} {match.match_key || ""}</div>
-                        <div className="mt-1 font-heading font-bold uppercase line-clamp-2">{match.labels.join(" vs. ")}</div>
-                      </div>
-                      <span className="text-[10px] uppercase tracking-widest text-[#FFD700] font-bold">{formatMatchStatus(match.schedule_status || match.status)}</span>
-                    </div>
-                    <div className="mt-3 text-sm text-white/55">{formatDateTime(match.scheduled_at)}</div>
-                    {stationLabel(match) && (
-                      <div className="mt-1 text-xs font-bold uppercase tracking-wider text-[#29B6E8]">Station {stationLabel(match)}</div>
-                    )}
-                  </Link>
-                ))}
+        {currentWeek ? (
+          <div className="mt-10" data-testid="matchday-pager">
+            <div className="flex items-center justify-between gap-3 border border-white/10 bg-[#121212] rounded-sm px-3 py-3">
+              <button
+                type="button"
+                onClick={() => setActiveMatchday(weeks[weekIndex - 1].number)}
+                disabled={weekIndex <= 0}
+                data-testid="matchday-prev"
+                aria-label="Vorheriger Spieltag"
+                className="p-2 rounded-sm border border-white/10 text-white/70 enabled:hover:border-[#29B6E8]/50 enabled:hover:text-white disabled:opacity-30"
+              >
+                <ChevronLeft className="w-5 h-5" />
+              </button>
+              <div className="text-center min-w-0">
+                <div className="font-heading text-xl md:text-2xl font-black uppercase truncate" data-testid="matchday-title">
+                  Spieltag {currentWeek.number}
+                </div>
+                <div className="mt-0.5 text-xs text-white/55 tabular-nums" data-testid="matchday-range">
+                  {formatWeekRange(currentWeek.starts_at, currentWeek.ends_at)}
+                </div>
+                <div className="mt-0.5 text-[10px] uppercase tracking-widest text-white/30">
+                  {weekIndex + 1} von {weeks.length}
+                </div>
               </div>
-            </section>
-          ))}
-          {groups.length === 0 && <div className="border border-dashed border-white/15 rounded-sm p-12 text-center text-white/45">Noch kein Spielplan generiert.</div>}
-        </div>
+              <button
+                type="button"
+                onClick={() => setActiveMatchday(weeks[weekIndex + 1].number)}
+                disabled={weekIndex >= weeks.length - 1}
+                data-testid="matchday-next"
+                aria-label="Nächster Spieltag"
+                className="p-2 rounded-sm border border-white/10 text-white/70 enabled:hover:border-[#29B6E8]/50 enabled:hover:text-white disabled:opacity-30"
+              >
+                <ChevronRight className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="mt-4 grid md:grid-cols-2 xl:grid-cols-3 gap-3" data-testid="matchday-matches">
+              {weekMatches.map((match) => (
+                <MatchCard key={match.id} match={match} resolved={resolvedByMatch[match.id]} />
+              ))}
+              {weekMatches.length === 0 && (
+                <div className="md:col-span-2 xl:col-span-3 border border-dashed border-white/15 rounded-sm p-8 text-center text-white/45">
+                  Für diesen Spieltag liegen keine Partien vor.
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-10 space-y-8">
+            {groups.map((group) => (
+              <section key={group.key}>
+                <h2 className="font-heading text-2xl font-black uppercase flex items-center gap-2"><CalendarClock className="w-5 h-5 text-[#29B6E8]" /> {group.label}</h2>
+                <div className="mt-4 grid md:grid-cols-2 xl:grid-cols-3 gap-3">
+                  {group.matches.map((match) => (
+                    <MatchCard key={match.id} match={match} resolved={resolvedByMatch[match.id]} />
+                  ))}
+                </div>
+              </section>
+            ))}
+            {groups.length === 0 && <div className="border border-dashed border-white/15 rounded-sm p-12 text-center text-white/45">Noch kein Spielplan generiert.</div>}
+          </div>
+        )}
       </section>
     </PublicLayout>
+  );
+}
+
+function MatchCard({ match, resolved }) {
+  // Der berechnete Termin geht vor: bei Spielwochen steht er auch dann fest,
+  // wenn noch niemand etwas vereinbart hat, weil dann die Standardzeit gilt.
+  const scheduledAt = resolved?.scheduled_at || match.scheduled_at;
+  const sourceLabel = SCHEDULE_SOURCE_LABELS[resolved?.schedule_source];
+  return (
+    <Link to={`/matches/${match.id}`} className="border border-white/10 hover:border-[#29B6E8]/50 bg-[#121212] rounded-sm p-4 transition">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-widest text-white/40">{formatMatchKind(match)} {match.match_key || ""}</div>
+          <div className="mt-1 font-heading font-bold uppercase line-clamp-2">{match.labels.join(" vs. ")}</div>
+        </div>
+        <span className="text-[10px] uppercase tracking-widest text-[#FFD700] font-bold shrink-0">{formatMatchStatus(match.schedule_status || match.status)}</span>
+      </div>
+      <div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-sm text-white/55">{formatDateTime(scheduledAt)}</span>
+        {sourceLabel && (
+          <span className="text-[10px] uppercase tracking-widest text-white/35" data-testid={`schedule-source-${match.id}`}>
+            {sourceLabel}
+          </span>
+        )}
+      </div>
+      {stationLabel(match) && (
+        <div className="mt-1 text-xs font-bold uppercase tracking-wider text-[#29B6E8]">Station {stationLabel(match)}</div>
+      )}
+    </Link>
   );
 }


### PR DESCRIPTION
Setzt Block 10 um, wie du ihn beschrieben hast.

## Was schon da war

Bevor ich gebaut habe, nachgesehen — und es war mehr vorhanden als der Plan behauptete. `match_routes.py` kann bereits **vorschlagen, annehmen, ablehnen und gegenvorschlagen**, samt Frist und Eskalation. Sogar deine Regel *„der eigene Vorschlag muss von der Gegenseite bestätigt werden"* ist dort erzwungen.

Und das **Heimrecht ist im Spielplan schon angelegt**: `_auto_league_schema` schreibt jede Paarung als `[heim, auswärts]` und dreht sie in der Rückrunde um. Deine Regel „somit soll jeder ja einmal heim sein" ist damit strukturell erfüllt — nur benutzte sie bisher niemand.

## Was gefehlt hat — und jetzt da ist

| Deine Regel | Umsetzung |
|---|---|
| Ein Spieltag ist eine **Woche** | Fenster ab Ligastart, Dauer einstellbar (Vorgabe 7 Tage). Startet die Liga am Dienstag, läuft die Woche Dienstag bis Dienstag — sie rastet **nicht** auf Montag ein |
| Was die Gegenseite **annimmt**, gilt | Ein angenommener Termin schlägt alles andere |
| Schlägt nur die **Heimseite** vor, gilt ihre Zeit | Die Heimseite entscheidet auch gegen einen unbeantworteten Auswärtsvorschlag — sonst wäre das Heimrecht wertlos, und die Rückrunde dreht es ohnehin um |
| Wählt **niemand**, greift eine Standardzeit | Einstellbar je Turnier, Vorgabe Sonntag 20:00, muss in der Woche liegen |
| Spieltage mit **Pfeilen** durchblättern, Woche von–bis | Der Spielplan blättert statt zu stapeln |

## Die Ansicht

Statt aller Spieltage untereinander — bei acht Teilnehmern 14 Blöcke — jetzt:

```
  ←     Spieltag 2          →
     15.09. – 22.09.2026
         2 von 6
```

Beim Öffnen steht die **Woche da, die gerade läuft**, nicht Spieltag 1 einer Liga vom März. Das automatische Neuladen alle sieben Sekunden lässt die gewählte Woche stehen.

An jeder Partie steht, **warum** dieser Termin gilt: `vereinbart`, `Heimrecht` oder `Standardzeit`. Eine Uhrzeit ohne diesen Hinweis lässt offen, ob sie abgemacht oder nur die Vorgabe ist.

Einstellen kannst du Spieltagsdauer, Standardtag und Standarduhrzeit im Turnierformular — nur bei Formaten, die in Wochen spielen. Ein K.-o.-Baum hat Runden, keine Wochen; der behält seine bisherige Gruppierung, und wenn der Aufruf ausfällt, ebenso.

## Bewusste Entscheidung: rein lesend

Der Endpunkt **berechnet** die Termine, er schreibt sie nicht in die Partien. Damit ist die Regel sofort überall sichtbar, ohne Datenwanderung und ohne Hintergrundjob, der an laufenden Turnieren schreibt.

Falls du willst, dass der berechnete Termin auch in `scheduled_at` landet — für Erinnerungen, Stationen und die TV-Anzeigen — ist das ein eigener, kleiner Schritt. Sag Bescheid; ich wollte das nicht ungefragt an Bestandsturniere schreiben.

## Nachweise

- **24 Regeltests** auf dem reinen Modul, je einer pro Regel
- **7 Ablauftests** durch die echten Routen: Wochen ohne Lücke, Standardzeit, eigene Standardzeit, angenommener Termin, unbeantworteter Heimvorschlag, K.-o.-Baum ohne Spielwochen, geöffnete Woche
- **5 Playwright-Tests** × 2 Projekte: Woche mit Zeitraum, Blättern samt deaktivierten Randpfeilen, Herkunft je Partie, Rückfall bei Rundenformaten, kein Querlauf bei 390 px
- **2 Komponententests**: die Einstellungen erscheinen nur bei Wochenformaten
- Backend **777 bestanden**, Frontend **131 Vitest**, Playwright **125 bestanden**, ESLint ohne Fehler, Build sauber

Der Fähigkeiten-Prüftest aus Block 0 hat den neuen Endpunkt eingefordert, bevor ich daran gedacht hatte — er ist im Inventar eingetragen.

**Zu den lokalen Läufen:** zwischendurch fielen wieder Tests in Serie, auch auf Seiten, die diese Änderung nicht berührt. Jeder bestand einzeln, der saubere Lauf danach war 125 zu 1, und dieser eine (`403/404/500`, der langsamste im Feld) bestand isoliert 3 von 3. Maschinenlast, kein Codeproblem — geprüft, nicht angenommen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)