### PR TITLE
Block 17: Markenbilder — der QR-Code verlor sein Logo, wenn qr_logo_url fehlte

### DIFF
--- a/UMBAUPLAN.md
+++ b/UMBAUPLAN.md
@@ -1,6 +1,6 @@
 # Umbauplan: Turniere, Übersichtlichkeit und die offenen Wünsche
 
-Stand: 10. September 2026 (Block 16 ergänzt).
+Stand: 10. September 2026 (Blöcke 16 bis 18 ergänzt).
 
 Dieser Plan führt das in [RESTPLAN.md](RESTPLAN.md) als **R5** angekündigte Turnierpaket
 aus und nimmt die später dazugekommenen Themen auf (Spielwochen, PDF, Live-Aktualisierung,
@@ -36,12 +36,14 @@ Ein grüner Block unten heißt **umgesetzt**. Was du selbst prüfen musst, steht
 | 8 | Klassischer Schreibweg stillgelegt | umgesetzt | #177 |
 | 9 | **Übersichtlichkeit** | umgesetzt | #178, #179, #181, #183, #185, #186, #188 |
 | 10 | **Spielwochen und Terminfindung** | umgesetzt | #189 |
-| 11 | PDF-Ausgabe | offen | — |
+| 11 | PDF-Ausgabe | umgesetzt | #193, #194 |
 | 12 | Galerie und Medien: Tempo, Videos überall | offen | — |
 | 13 | Entflechtung und Tempo | offen | — |
 | 14 | LionsAPP in den Store | offen | — |
 | 15 | Abschluss | offen | — |
-| 16 | **Turnier-Leitfaden im Adminbereich** | offen, neu aufgenommen | — |
+| 16 | **Turnier-Leitfaden im Adminbereich** | offen | — |
+| 17 | **Markenbilder hell und dunkel überall richtig** | teilweise | #193 |
+| 18 | **Auszeichnungen: Banner und Trophäen** | offen, neu aufgenommen | — |
 
 ### Warum Block 5 die Migration erledigt hat, ohne zu migrieren
 
@@ -307,6 +309,84 @@ Turnierbaum, sondern bei Battle Royale mit Punktewertung — und wer „F1" such
 Rundenzeiten statt bei Spielpaarungen.
 
 Die Liste wächst weiter; neue Titel sind eine Zeile, kein Umbau.
+
+## Block 17 — Markenbilder hell und dunkel überall richtig
+
+Der Branding-Bereich führt jedes Logo doppelt: eine Fassung für dunklen und eine für
+hellen Hintergrund, dazu Favicons je Modus. Der Wunsch: **überall die richtige nehmen**.
+
+### Bestandsaufnahme
+
+Nachgesehen statt vermutet. Das meiste stimmt bereits:
+
+| Ort | Nimmt | Urteil |
+| --- | --- | --- |
+| Weboberfläche (`Logo.jsx`) | `logo_dark_url` zuerst | **richtig** — die Oberfläche ist dunkel |
+| Favicons (`BrandingHead.jsx`) | je Variante mit `prefers-color-scheme` plus Rückfall | **richtig** |
+| SEO und Teilen-Vorschau | `share_banner_url`, dann Logofassungen | **stimmig** |
+| PDF-Export | nahm `logo_dark_url` zuerst | **war falsch**, behoben mit #193 |
+| QR-Code-Mitte | Rückfallkette nur aus Dunkel-Fassungen | **war falsch**, siehe unten |
+| Mobil-App | liest die Markenbilder gar nicht, bringt eigene mit | **offen** |
+
+### Der Fund im QR-Code
+
+Das Logo in der Mitte eines QR-Codes sitzt auf einem **weißen Kreis**. Die Rückfallkette
+bestand aber ausschließlich aus Bildern für dunklen Hintergrund — `mascot_url`,
+`favicon_dark_url`, `logo_dark_url`. War `qr_logo_url` nicht gesetzt, blieb der Kreis
+**leer**: das Maskottchen des Vereins ist rein weiß, und Weiß auf Weiß zeigt nichts.
+
+Beim Verein fällt das nicht auf, weil `qr_logo_url` dunkel gesetzt ist. Bei einem
+Verein ohne diesen Eintrag wäre jeder gedruckte QR-Code ohne Logo.
+
+Behoben: helle Fassungen zuerst, und ohne solche wird die **Silhouette** gezeichnet —
+dann trägt auch ein weißes Logo.
+
+### Was offen bleibt
+
+- **Die App** liest die Markenbilder aus den Einstellungen nicht. Ändert der Verein sein
+  Logo, ändert sich die App nicht mit. Gehört zu Block 14.
+- **Der Standard-Favicon** ist bei euch weiß. Browser ohne Unterstützung für
+  `prefers-color-scheme` zeigen ihn auf hellen Tableisten nicht. Kleinigkeit, aber
+  vermeidbar: dort gehört eine Fassung hin, die auf beidem trägt.
+
+## Block 18 — Auszeichnungen: Banner und Trophäen
+
+Der Wunsch, ausdrücklich für später: **Gewinnerbanner und Trophäen**, die ein Turnier
+vergibt und die im Profil sichtbar bleiben.
+
+### Wie es gedacht ist
+
+- **Für alle Teilnehmer** ein automatisch erzeugtes Banner mit der eigenen Bilanz aus
+  diesem Turnier: Siege, Niederlagen, Unentschieden, Platzierung.
+- **Für die ersten drei** eine eigene, gestaltete Fassung, die der Betreiber selbst
+  entwerfen kann und dem Turnier zuhängt.
+- **Trophäen**, die vergeben werden und die man ansehen kann.
+- Spieler und Teams **getrennt**: es gibt Team- und Einzelturniere, und ein Team-Banner
+  gehört ins Teamprofil, ein Spielerbanner ins Spielerprofil.
+- Eine verliehene Auszeichnung soll sich **als Profil- oder Teambanner einstellen**
+  lassen.
+- Spielbezug: bei FIFA das Spiel-Symbol, dazu Saison oder Liga.
+
+### Was daran zu klären ist
+
+Das ist kein kleiner Block. Vor dem Bauen zu entscheiden:
+
+- **Wie entsteht die Gestaltung?** Ein Vorlagensystem, in dem der Betreiber Hintergrund,
+  Schrift und Felder wählt, ist etwas anderes als fertige Bilder zum Hochladen. Beides ist
+  möglich; das zweite ist deutlich schneller.
+- **Wo werden die Bilder erzeugt?** Serverseitig zum Zeitpunkt der Vergabe, oder erst beim
+  Ansehen. Für Block 12 gilt ohnehin: Bilder brauchen kleinere Varianten.
+- **Was passiert bei Korrekturen?** Wird ein Ergebnis nachträglich geändert, stimmt eine
+  bereits vergebene Bilanz nicht mehr.
+
+Der Zusammenhang zu Block 12 ist eng: erzeugte Banner sind Medien und brauchen dieselben
+Vorschaubilder und Größen.
+
+## Querschnitt: alles auch in der App
+
+Nicht als eigener Block, sondern als Zusage über alle: was im Browser geht, muss **auch in
+der App** gehen — einschließlich der Einstellungen, etwa denen eines Teams. Bei jedem Block
+gehört die App-Seite dazu, nicht als Nachtrag.
 
 ## Querschnitt: Live-Aktualisierung überall
 

--- a/backend/pdf_service.py
+++ b/backend/pdf_service.py
@@ -1225,6 +1225,29 @@ def pdf_certificate(
     )
 
 
+def qr_badge_sources(branding: dict | None) -> tuple[Path | None, Path | None]:
+    """Welches Bild in die Mitte eines QR-Codes gehört, und wie gezeichnet wird.
+
+    Der Kreis in der Mitte ist weiß. Die Rückfallkette bestand vorher nur aus
+    Bildern für dunklen Hintergrund: war ``qr_logo_url`` nicht gesetzt, blieb
+    der Kreis leer, weil ein rein weißes Maskottchen auf Weiß nichts zeigt.
+
+    Zurück kommt entweder ein Bild, das unverändert gezeichnet wird, oder eine
+    Vorlage, von der nur die Silhouette gezeichnet wird - so trägt auch ein
+    weißes Logo.
+    """
+    branding = branding or {}
+    for key in ("qr_logo_url", "favicon_light_url", "logo_light_url"):
+        path = _brand_asset_path(branding.get(key))
+        if path:
+            return path, None
+    for key in ("mascot_url", "logo_url", "logo_dark_url"):
+        path = _brand_asset_path(branding.get(key))
+        if path:
+            return None, path
+    return None, _brand_asset_path("/assets/brand/tls-mascot.png")
+
+
 def _draw_qr_code(canvas, value: str, x: float, y: float, size: float, branding: dict | None = None) -> None:
     widget = qr.QrCodeWidget(value, barLevel="H", barBorder=4)
     bounds = widget.getBounds()
@@ -1236,14 +1259,7 @@ def _draw_qr_code(canvas, value: str, x: float, y: float, size: float, branding:
     canvas.roundRect(x - 1.2 * mm, y - 1.2 * mm, size + 2.4 * mm, size + 2.4 * mm, 7, fill=1, stroke=0)
     renderPDF.draw(drawing, canvas, x, y)
 
-    logo_path = (
-        _brand_asset_path((branding or {}).get("qr_logo_url"))
-        or _brand_asset_path((branding or {}).get("mascot_url"))
-        or _brand_asset_path((branding or {}).get("favicon_dark_url"))
-        or _brand_asset_path((branding or {}).get("logo_dark_url"))
-        or _brand_asset_path((branding or {}).get("logo_url"))
-        or _brand_asset_path("/assets/brand/tls-mascot.png")
-    )
+    logo_path, silhouette_path = qr_badge_sources(branding)
     badge_size = size * 0.205
     logo_size = badge_size * 0.76
     center_x = x + size / 2
@@ -1258,6 +1274,9 @@ def _draw_qr_code(canvas, value: str, x: float, y: float, size: float, branding:
     canvas.circle(center_x, center_y, badge_r, fill=0, stroke=1)
     if logo_path:
         _draw_logo(canvas, logo_path, logo_x, logo_y, logo_size, logo_size, crop_transparent=True)
+    elif silhouette_path:
+        _draw_watermark_logo(canvas, silhouette_path, center_x, center_y, logo_size,
+                             opacity=1.0, tint=(20, 24, 29))
 
 
 def pdf_qr_sign(

--- a/backend/tests/test_pdf_layout_unit.py
+++ b/backend/tests/test_pdf_layout_unit.py
@@ -289,3 +289,34 @@ def test_a_certificate_no_longer_carries_the_banner_text():
     # Ein gekacheltes Muster verwendet dieselbe Vorlage mehrfach; ein
     # seitenfuellendes Banner waere genau ein grosses Bild.
     assert images, "die Urkunde traegt ein Wasserzeichen"
+
+
+# ---------------------------------------------------------------- QR-Mitte
+
+def test_the_qr_badge_prefers_an_image_made_for_a_light_background():
+    """Der Kreis in der Mitte ist weiss; ein weisses Logo zeigt dort nichts."""
+    from pdf_service import qr_badge_sources
+
+    logo, silhouette = qr_badge_sources({"qr_logo_url": "/assets/brand/tls-favicon-light.png"})
+    assert logo is not None and silhouette is None
+
+    logo, silhouette = qr_badge_sources({"favicon_light_url": "/assets/brand/tls-favicon-light.png"})
+    assert logo is not None and silhouette is None
+
+
+def test_without_a_light_variant_the_qr_badge_falls_back_to_a_silhouette():
+    """Vorher blieb der Kreis leer: die Rueckfaelle waren alle fuer Dunkel gedacht."""
+    from pdf_service import qr_badge_sources
+
+    logo, silhouette = qr_badge_sources({"mascot_url": "/assets/brand/tls-mascot.png"})
+
+    assert logo is None, "das weisse Maskottchen darf nicht unveraendert gezeichnet werden"
+    assert silhouette is not None, "als Silhouette traegt es"
+
+
+def test_the_qr_badge_is_never_empty():
+    from pdf_service import qr_badge_sources
+
+    logo, silhouette = qr_badge_sources({})
+
+    assert (logo or silhouette) is not None


### PR DESCRIPTION
Dein Punkt: „dass alles überall richtig genommen wird". Ich habe **jede Stelle nachgesehen**, die zwischen heller und dunkler Fassung wählt — statt gleich umzubauen.

## Das meiste stimmt bereits

| Ort | Nimmt | Urteil |
|---|---|---|
| Weboberfläche (`Logo.jsx`) | `logo_dark_url` zuerst | **richtig** — die Oberfläche ist dunkel |
| Favicons (`BrandingHead.jsx`) | je Variante mit `prefers-color-scheme`, plus Rückfall | **richtig** |
| SEO und Teilen-Vorschau | `share_banner_url`, dann Logofassungen | **stimmig** |
| PDF-Export | nahm `logo_dark_url` zuerst | war falsch, mit #193 behoben |
| **QR-Code-Mitte** | Rückfallkette nur aus Dunkel-Fassungen | **war falsch** |
| Mobil-App | liest die Markenbilder gar nicht | offen, gehört zu Block 14 |

## Der Fund

Das Logo in der Mitte eines QR-Codes sitzt auf einem **weißen Kreis**. Die Rückfallkette bestand aber nur aus Bildern für dunklen Hintergrund:

```python
qr_logo_url → mascot_url → favicon_dark_url → logo_dark_url → logo_url → tls-mascot.png
```

War `qr_logo_url` nicht gesetzt, blieb der Kreis **leer** — euer Maskottchen ist rein weiß (nachgemessen: 255,255,255), und Weiß auf Weiß zeigt nichts. Ich habe es gerendert und angesehen: ein leerer Kreis mitten im QR-Code.

**Bei euch fällt das nicht auf**, weil `qr_logo_url` dunkel gesetzt ist. Ohne diesen Eintrag wäre aber jeder gedruckte QR-Code ohne Logo — und genau solche Einträge gehen beim Umstellen gern verloren.

Jetzt zuerst die hellen Fassungen (`qr_logo_url`, `favicon_light_url`, `logo_light_url`), und ohne solche wird die **Silhouette** gezeichnet. Dann trägt auch ein rein weißes Logo.

Die Auswahl steckt in `qr_badge_sources()` statt im Zeichencode — damit ist sie prüfbar, und die drei neuen Tests halten fest, dass der Kreis nie leer bleibt.

## Zwei Dinge, die offen bleiben

**Die App liest die Markenbilder nicht.** Ändert ihr euer Logo in den Einstellungen, ändert sich die App nicht mit — sie bringt eigene Bilder mit. Das gehört zu Block 14 und steht so im Plan.

**Euer Standard-Favicon ist weiß.** Browser ohne `prefers-color-scheme` zeigen ihn auf hellen Tableisten nicht. Kleinigkeit, aber vermeidbar — dort gehört eine Fassung hin, die auf beidem trägt. Das kannst du selbst in den Einstellungen ändern; ich wollte dir kein Bild überschreiben.

## Neu im Plan

**Block 17** mit der vollständigen Bestandsaufnahme oben.

**Block 18 — Auszeichnungen**, dein neuer Wunsch: Gewinnerbanner je Platz, ein automatisch erzeugtes Banner mit Bilanz für alle Teilnehmer, gestaltete Fassungen für die ersten drei, Trophäen, Spieler und Teams getrennt, verleihbar als Profil- oder Teambanner, mit Spielbezug wie Saison oder Liga.

Ich habe drei Fragen dazu vermerkt, die vor dem Bauen zu klären sind — vor allem: **entwirfst du die Vorlagen im System, oder lädst du fertige Bilder hoch?** Das erste ist ein Vorlagensystem, das zweite ein Nachmittag. Und: was passiert mit einem vergebenen Banner, wenn ein Ergebnis nachträglich korrigiert wird?

**Querschnitt „alles auch in der App"** ist als Zusage über alle Blöcke aufgenommen, nicht als eigener Block — einschließlich der Einstellungen wie denen eines Teams.

## Nachweise

- **45 Tests** in der PDF-Sammlung, drei davon neu für die QR-Mitte
- Backend gesamt: **823 bestanden**; flake8 sauber; Umlautprüfer über die ganze Datei gescannt
- `python scripts/check-doc-links.py`: 32 Dateien, 0 fehlende Ziele

🤖 Generated with [Claude Code](https://claude.com/claude-code)