### PR TITLE
Block 12: Galerie — kleinere Bildfassungen und kein Autoplay im Raster

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -62,6 +62,7 @@ from routes.widget_routes import widget_router
 from routes.dsgvo_routes import dsgvo_router
 from routes.export_routes import pdf_router
 from routes.audit_routes import audit_router
+from services.image_variants import resolve_variant as resolve_image_variant
 from services.change_events import (
     change_event_stream,
     publish_api_change,
@@ -269,7 +270,7 @@ def _iter_file_range(path: Path, start: int, end: int):
 
 
 @app.get("/api/static/uploads/{filename}")
-async def public_upload(filename: str, request: Request):
+async def public_upload(filename: str, request: Request, w: int | None = None):
     if "/" in filename or "\\" in filename or ".." in filename or filename.startswith("."):
         raise HTTPException(status_code=400, detail="Invalid filename")
     suffix = Path(filename).suffix.lower()
@@ -280,6 +281,14 @@ async def public_upload(filename: str, request: Request):
         if path.exists() and path.is_file():
             media_type = PUBLIC_MEDIA_TYPES.get(suffix) or "application/octet-stream"
             headers = {"Accept-Ranges": "bytes", "X-Content-Type-Options": "nosniff"}
+            # Eine Rasterkachel ist rund 400 Pixel breit und bekam bisher das
+            # gespeicherte Bild mit bis zu 4096 Pixeln. Die kleinere Fassung
+            # entsteht beim ersten Abruf und liegt danach auf der Platte - so
+            # wirkt das auch für alles, was längst hochgeladen ist.
+            if w is not None:
+                variant = resolve_image_variant(path, w)
+                if variant is not None:
+                    return FileResponse(variant, media_type="image/webp", headers=headers)
             range_header = request.headers.get("range", "")
             if suffix in VIDEO_MEDIA_EXTS and range_header.startswith("bytes="):
                 size = path.stat().st_size
@@ -305,8 +314,8 @@ async def public_upload(filename: str, request: Request):
 
 
 @app.get("/uploads/{filename}")
-async def legacy_public_upload(filename: str, request: Request):
-    return await public_upload(filename, request)
+async def legacy_public_upload(filename: str, request: Request, w: int | None = None):
+    return await public_upload(filename, request, w=w)
 
 
 CSRF_EXEMPT_PATHS = {

--- a/backend/services/image_variants.py
+++ b/backend/services/image_variants.py
@@ -1,0 +1,105 @@
+"""Smaller copies of an uploaded image, made once and kept on disk.
+
+A gallery tile is roughly 300 to 400 pixels wide. Until now it was handed the
+stored image, which may be up to 4096 pixels across - around a hundred times
+the pixels the tile actually shows. The bytes matter on a phone connection, but
+the decoding matters more: eleven megapixels per tile is what makes a gallery
+stall, and no amount of compression helps with that.
+
+Variants are produced on the first request for a width and then read from disk,
+so images uploaded long before this existed benefit too - there is nothing to
+migrate.
+
+Only a fixed set of widths is allowed. An open resizer is a way to fill a disk:
+a few thousand requests with different widths would write a few thousand files.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from PIL import Image, ImageOps
+
+logger = logging.getLogger(__name__)
+
+# Passend zu den Kacheln der Oberfläche: Vorschau im Raster, mittlere Ansicht,
+# und eine Fassung für grosse Bildschirme.
+VARIANT_WIDTHS: tuple[int, ...] = (400, 800, 1600)
+VARIANT_DIR_NAME = "variants"
+VARIANT_QUALITY = {400: 78, 800: 80, 1600: 82}
+RESIZABLE_SUFFIXES = frozenset({".webp", ".jpg", ".jpeg", ".png"})
+
+
+def is_resizable(source: Path | str) -> bool:
+    return Path(source).suffix.lower() in RESIZABLE_SUFFIXES
+
+
+def normalize_width(requested) -> int | None:
+    """The allowed width closest to what was asked for, or None.
+
+    Anything outside the list is refused rather than rounded up, so a request
+    for width 4095 does not quietly produce a full size copy.
+    """
+    try:
+        value = int(requested)
+    except (TypeError, ValueError):
+        return None
+    if value <= 0:
+        return None
+    return value if value in VARIANT_WIDTHS else None
+
+
+def variant_path(source: Path, width: int) -> Path:
+    """Where the variant of ``source`` at ``width`` lives."""
+    return source.parent / VARIANT_DIR_NAME / f"{source.stem}-{width}.webp"
+
+
+def build_variant(source: Path, width: int) -> Path | None:
+    """Write the variant and return its path; None when it makes no sense.
+
+    A picture that is already narrower than the requested width is served as it
+    is - shrinking it further would cost quality for nothing, and blowing it up
+    would cost bytes for nothing.
+    """
+    if width not in VARIANT_WIDTHS or not is_resizable(source):
+        return None
+    target = variant_path(source, width)
+    if target.exists():
+        return target
+    try:
+        with Image.open(source) as image:
+            image = ImageOps.exif_transpose(image)
+            if image.width <= width:
+                return None
+            copy = image.copy()
+            copy.thumbnail((width, width * 4), Image.Resampling.LANCZOS)
+            if copy.mode not in ("RGB", "RGBA"):
+                copy = copy.convert("RGBA" if "A" in copy.getbands() else "RGB")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            copy.save(target, format="WEBP", quality=VARIANT_QUALITY.get(width, 80), method=6)
+        return target
+    except (OSError, ValueError, Image.DecompressionBombError) as exc:
+        logger.warning("[media] variant %s@%s failed: %s", source.name, width, exc)
+        return None
+
+
+def resolve_variant(source: Path, requested) -> Path | None:
+    """The file to serve for a requested width, or None to serve the original."""
+    width = normalize_width(requested)
+    if width is None or not source.is_file():
+        return None
+    target = variant_path(source, width)
+    if target.is_file():
+        return target
+    return build_variant(source, width)
+
+
+def srcset_widths(image_width: int | None = None) -> list[int]:
+    """The widths worth offering for an image of this size.
+
+    Offering a 1600 pixel entry for a 900 pixel picture would let a browser
+    download the same file twice under two names.
+    """
+    if not image_width:
+        return list(VARIANT_WIDTHS)
+    return [width for width in VARIANT_WIDTHS if width < image_width]

--- a/backend/tests/test_image_variants_unit.py
+++ b/backend/tests/test_image_variants_unit.py
@@ -1,0 +1,190 @@
+"""Kleinere Fassungen eines Bildes, und was dabei nicht passieren darf.
+
+Eine Rasterkachel ist rund 400 Pixel breit und bekam bisher das gespeicherte
+Bild mit bis zu 4096 Pixeln - etwa hundertmal so viele Bildpunkte, wie sie
+zeigt. Die Bytes fallen auf einer Handyverbindung ins Gewicht, das Dekodieren
+noch mehr: elf Megapixel je Kachel bringt ein Telefon ins Stocken, unabhaengig
+von der Kompression.
+"""
+import io
+
+import pytest
+from PIL import Image
+
+from services.image_variants import (
+    VARIANT_WIDTHS,
+    build_variant,
+    is_resizable,
+    normalize_width,
+    resolve_variant,
+    srcset_widths,
+    variant_path,
+)
+
+
+@pytest.fixture
+def bild(tmp_path):
+    def _make(width=2400, height=1600, name="foto.webp"):
+        path = tmp_path / name
+        Image.new("RGB", (width, height), (90, 120, 160)).save(path)
+        return path
+    return _make
+
+
+# ---------------------------------------------------------------- Breiten
+
+@pytest.mark.parametrize("width", VARIANT_WIDTHS)
+def test_the_offered_widths_are_accepted(width):
+    assert normalize_width(width) == width
+
+
+@pytest.mark.parametrize("wert", [0, -1, 4095, 12000, "gross", None, "", 3.7])
+def test_any_other_width_is_refused_rather_than_rounded(wert):
+    """Ein offener Skalierer ist ein Weg, eine Platte vollzuschreiben."""
+    assert normalize_width(wert) is None
+
+
+def test_a_width_between_two_offers_is_not_silently_upgraded():
+    assert normalize_width(401) is None
+    assert normalize_width(799) is None
+
+
+# ---------------------------------------------------------------- Erzeugen
+
+def test_a_variant_is_written_once_and_then_reused(bild):
+    quelle = bild()
+
+    erste = build_variant(quelle, 400)
+
+    assert erste is not None and erste.is_file()
+    assert erste == variant_path(quelle, 400)
+    with Image.open(erste) as im:
+        assert im.width == 400
+    stempel = erste.stat().st_mtime_ns
+    assert build_variant(quelle, 400) == erste
+    assert erste.stat().st_mtime_ns == stempel, "die zweite Anfrage rechnet nicht neu"
+
+
+def test_a_picture_smaller_than_the_request_is_left_alone(bild):
+    """Hochskalieren kostet Bytes und bringt nichts."""
+    klein = bild(width=300, height=200, name="klein.webp")
+
+    assert build_variant(klein, 400) is None
+    assert resolve_variant(klein, 400) is None, "dann wird das Original ausgeliefert"
+
+
+def test_the_aspect_ratio_is_kept(bild):
+    quelle = bild(width=2400, height=1600)
+
+    variante = build_variant(quelle, 800)
+
+    with Image.open(variante) as im:
+        assert im.width == 800
+        assert im.height == pytest.approx(533, abs=2)
+
+
+def test_variants_live_beside_the_original_not_in_place_of_it(bild):
+    quelle = bild()
+
+    variante = build_variant(quelle, 400)
+
+    assert quelle.is_file(), "das Original bleibt unangetastet"
+    assert variante.parent.name == "variants"
+
+
+def test_a_broken_file_does_not_take_the_request_down(tmp_path):
+    kaputt = tmp_path / "kaputt.webp"
+    kaputt.write_bytes(b"das ist kein Bild")
+
+    assert build_variant(kaputt, 400) is None
+    assert resolve_variant(kaputt, 400) is None
+
+
+def test_a_video_is_never_resized(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"\x00" * 32)
+
+    assert is_resizable(video) is False
+    assert resolve_variant(video, 400) is None
+
+
+def test_a_missing_file_is_answered_with_none(tmp_path):
+    assert resolve_variant(tmp_path / "gibtsnicht.webp", 400) is None
+
+
+# ---------------------------------------------------------------- Auswahl
+
+def test_only_widths_below_the_original_are_worth_offering():
+    """Sonst laedt ein Browser dieselbe Datei unter zwei Namen."""
+    assert srcset_widths(900) == [400, 800]
+    assert srcset_widths(300) == []
+    assert srcset_widths(4096) == [400, 800, 1600]
+    assert srcset_widths(None) == list(VARIANT_WIDTHS)
+
+
+# ---------------------------------------------------------------- Durch die Route
+
+@pytest.mark.asyncio
+async def test_the_route_serves_the_smaller_copy(tmp_path, monkeypatch):
+    """Die Verdrahtung, die ein Unit-Test allein nicht prueft.
+
+    Ohne ``w`` kommt das gespeicherte Bild, mit ``w=400`` die kleinere Fassung -
+    und die muss deutlich weniger wiegen, sonst hat sich nichts geaendert.
+    """
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from flow_harness import make_flow
+
+    instance, shutdown = make_flow()
+    try:
+        import server
+
+        monkeypatch.setattr(server, "upload_dir", tmp_path)
+        monkeypatch.setattr(server, "public_upload_dir", tmp_path)
+
+        gross = tmp_path / "galerie.webp"
+        Image.new("RGB", (3200, 2000), (70, 110, 150)).save(gross, format="WEBP", quality=88)
+
+        original = await instance.get("/api/static/uploads/galerie.webp")
+        verkleinert = await instance.get("/api/static/uploads/galerie.webp?w=400")
+
+        assert original.status_code == 200
+        assert verkleinert.status_code == 200
+        assert verkleinert.headers["content-type"] == "image/webp"
+        assert len(verkleinert.content) < len(original.content) / 2, (
+            f"verkleinert {len(verkleinert.content)} B gegen Original {len(original.content)} B"
+        )
+        with Image.open(io.BytesIO(verkleinert.content)) as im:
+            assert im.width == 400
+    finally:
+        await shutdown()
+
+
+@pytest.mark.asyncio
+async def test_the_route_refuses_a_width_it_does_not_keep(tmp_path, monkeypatch):
+    """Eine unbekannte Breite liefert das Original, statt eine Datei anzulegen."""
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from flow_harness import make_flow
+
+    instance, shutdown = make_flow()
+    try:
+        import server
+
+        monkeypatch.setattr(server, "upload_dir", tmp_path)
+        monkeypatch.setattr(server, "public_upload_dir", tmp_path)
+        quelle = tmp_path / "galerie.webp"
+        Image.new("RGB", (3200, 2000), (70, 110, 150)).save(quelle, format="WEBP", quality=88)
+
+        original = await instance.get("/api/static/uploads/galerie.webp")
+        krumm = await instance.get("/api/static/uploads/galerie.webp?w=1234")
+
+        assert krumm.status_code == 200
+        assert len(krumm.content) == len(original.content)
+        assert not (tmp_path / "variants").exists(), "keine Datei fuer eine Breite, die es nicht gibt"
+    finally:
+        await shutdown()

--- a/frontend/e2e/gallery-media.spec.js
+++ b/frontend/e2e/gallery-media.spec.js
@@ -1,0 +1,120 @@
+const { test, expect } = require("@playwright/test");
+
+// Im Album spielte jede Videokachel, die ins Bild scrollte, von selbst los:
+// ein IntersectionObserver rief play() auf jedem sichtbaren Video. Bei acht
+// Videos lädt und dekodiert ein Telefon mehrere Ströme gleichzeitig. Jetzt
+// steht dort ein Standbild, und abgespielt wird erst auf Wunsch.
+
+const ALBUM = {
+  id: "a1",
+  slug: "gamers-heaven-2026",
+  title: "Gamers Heaven 2026",
+  description: "Bilder und Videos vom Turniertag",
+  published: true,
+  visibility: "public",
+  sections: [],
+  photos: [
+    {
+      id: "p1", media_type: "image", source_type: "upload",
+      image_url: "/api/static/uploads/foto-1.webp",
+      thumbnail_url: "/api/static/uploads/foto-1.webp",
+      caption: "Siegerehrung", order_index: 1, width: 3200, height: 2000,
+    },
+    {
+      id: "v1", media_type: "video", source_type: "upload",
+      video_url: "/api/static/uploads/clip-1.mp4",
+      thumbnail_url: "/api/static/uploads/clip-1-vorschau.webp",
+      caption: "Finale", order_index: 2,
+    },
+    {
+      id: "v2", media_type: "video", source_type: "upload",
+      video_url: "/api/static/uploads/clip-2.mp4",
+      thumbnail_url: "",
+      caption: "Ohne Vorschaubild", order_index: 3,
+    },
+  ],
+};
+
+// Ein winziges gültiges WebP, damit die Kacheln echte Bilder laden.
+const TINY_WEBP = Buffer.from(
+  "UklGRjIAAABXRUJQVlA4ICYAAACyAgCdASoBAAEALmk0mk0iIiIiIgBoSygABc6zbAAA/vuUAAAAAA==",
+  "base64",
+);
+
+async function mockAlbum(page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("tls_cookie_consent_v1", JSON.stringify({
+      essential: true, external_media: true, analytics: false, meta: false,
+      tiktok: false, saved_at: Date.now(), expires_at: Date.now() + 8.64e8,
+    }));
+  });
+  const json = (body) => ({ contentType: "application/json", body: JSON.stringify(body) });
+  await page.route("**/api/settings/public", (r) => r.fulfill(json({ club_name: "THE LION SQUAD" })));
+  await page.route("**/api/sponsors**", (r) => r.fulfill(json([])));
+  await page.route("**/api/auth/me", (r) => r.fulfill(json(null)));
+  await page.route("**/api/gallery/gamers-heaven-2026", (r) => r.fulfill(json(ALBUM)));
+  await page.route("**/api/static/uploads/**", (r) => r.fulfill({
+    contentType: "image/webp", body: TINY_WEBP,
+  }));
+}
+
+test.describe("Galerie-Album", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAlbum(page);
+  });
+
+  test("keine Videokachel spielt beim Scrollen von selbst", async ({ page }) => {
+    await page.goto("/galerie/gamers-heaven-2026");
+    await expect(page.getByRole("heading", { name: "Gamers Heaven 2026" })).toBeVisible();
+
+    // Das Raster besteht aus Bildern, nicht aus laufenden Videos.
+    await page.mouse.wheel(0, 600);
+    await page.waitForTimeout(400);
+    const spielendeVideos = await page.evaluate(() =>
+      [...document.querySelectorAll("video")].filter((v) => !v.paused).length);
+
+    expect(spielendeVideos).toBe(0);
+  });
+
+  test("ein Video mit Standbild zeigt es im Raster", async ({ page }) => {
+    await page.goto("/galerie/gamers-heaven-2026");
+    await expect(page.getByRole("heading", { name: "Gamers Heaven 2026" })).toBeVisible();
+
+    const bilder = await page.evaluate(() =>
+      [...document.querySelectorAll("img")].map((img) => img.getAttribute("src") || ""));
+
+    expect(bilder.some((src) => src.includes("clip-1-vorschau.webp"))).toBe(true);
+  });
+
+  test("ohne Standbild steht ein Hinweis statt eines geladenen Videos", async ({ page }) => {
+    await page.goto("/galerie/gamers-heaven-2026");
+    await expect(page.getByRole("heading", { name: "Gamers Heaven 2026" })).toBeVisible();
+
+    // Die Kachel ohne Vorschaubild lädt kein Video, um ein Bild zu bekommen.
+    const videoQuellen = await page.evaluate(() =>
+      [...document.querySelectorAll("video")].map((v) => v.getAttribute("src") || ""));
+
+    expect(videoQuellen.some((src) => src.includes("clip-2.mp4"))).toBe(false);
+  });
+
+  test("Bilder im Raster fordern eine passende Größe an", async ({ page }) => {
+    await page.goto("/galerie/gamers-heaven-2026");
+    await expect(page.getByRole("heading", { name: "Gamers Heaven 2026" })).toBeVisible();
+
+    // Die Kachel bekam bisher das gespeicherte Bild mit bis zu 4096 Pixeln.
+    const srcsets = await page.evaluate(() =>
+      [...document.querySelectorAll("img")].map((img) => img.getAttribute("srcset") || ""));
+
+    expect(srcsets.some((value) => value.includes("w=400 400w"))).toBe(true);
+  });
+
+  test("das Album läuft am Telefon nicht quer", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/galerie/gamers-heaven-2026");
+    await expect(page.getByRole("heading", { name: "Gamers Heaven 2026" })).toBeVisible();
+
+    const overflow = await page.evaluate(() =>
+      document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/tls/LazyImg.jsx
+++ b/frontend/src/components/tls/LazyImg.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { resolveMediaUrl } from "@/lib/api";
+import { buildSrcSet } from "@/lib/imageVariants";
 
 /**
  * Shared public image helper with consistent lazy/eager loading, async decoding
@@ -17,12 +18,17 @@ export function LazyImg({
   loading,
   decoding = "async",
   sizes,
+  srcSet,
   width,
   height,
   ...rest
 }) {
   const [failed, setFailed] = useState(false);
   const resolvedSrc = useMemo(() => resolveMediaUrl(failed && fallbackSrc ? fallbackSrc : src), [failed, fallbackSrc, src]);
+  // Ohne srcset war das sizes-Attribut wirkungslos: der Browser hatte nur die
+  // gespeicherte Fassung zur Auswahl, bis zu 4096 Pixel breit - für eine
+  // Kachel, die rund 400 zeigt.
+  const resolvedSrcSet = useMemo(() => srcSet || buildSrcSet(resolvedSrc), [srcSet, resolvedSrc]);
 
   if (!resolvedSrc) return null;
 
@@ -35,7 +41,8 @@ export function LazyImg({
       loading={loading || (priority ? "eager" : "lazy")}
       decoding={decoding}
       fetchPriority={priority ? "high" : undefined}
-      sizes={sizes}
+      srcSet={resolvedSrcSet}
+      sizes={resolvedSrcSet ? (sizes || "100vw") : sizes}
       width={width}
       height={height}
       onError={(event) => {

--- a/frontend/src/lib/imageVariants.js
+++ b/frontend/src/lib/imageVariants.js
@@ -1,0 +1,30 @@
+// Die Breiten, die das Backend vorhält (services/image_variants.py).
+// Andere Werte liefert es bewusst nicht aus, damit niemand eine Platte
+// vollschreiben kann.
+export const VARIANT_WIDTHS = [400, 800, 1600];
+
+// Nur eigene Uploads lassen sich verkleinern. Ein Bild von einer fremden
+// Domain oder ein data:-Bild bleibt, wie es ist.
+const LOCAL_UPLOAD = /\/(api\/static\/uploads|static\/uploads|uploads)\//;
+
+export function isResizableUpload(url) {
+  const value = String(url || "");
+  if (!value || /^(data:|blob:)/i.test(value)) return false;
+  if (!LOCAL_UPLOAD.test(value)) return false;
+  return /\.(webp|jpe?g|png)(\?|#|$)/i.test(value);
+}
+
+/**
+ * Ein srcset aus den vorgehaltenen Breiten.
+ *
+ * Ohne srcset war das sizes-Attribut an den Bildern wirkungslos: der Browser
+ * hatte nur eine Fassung zur Auswahl - die gespeicherte, bis zu 4096 Pixel
+ * breit. Eine Rasterkachel zeigt davon rund 400.
+ */
+export function buildSrcSet(url, widths = VARIANT_WIDTHS) {
+  if (!isResizableUpload(url)) return undefined;
+  const [base, hash = ""] = String(url).split("#");
+  const joiner = base.includes("?") ? "&" : "?";
+  const entries = widths.map((width) => `${base}${joiner}w=${width}${hash ? `#${hash}` : ""} ${width}w`);
+  return entries.length ? entries.join(", ") : undefined;
+}

--- a/frontend/src/lib/imageVariants.test.js
+++ b/frontend/src/lib/imageVariants.test.js
@@ -1,0 +1,50 @@
+import { buildSrcSet, isResizableUpload, VARIANT_WIDTHS } from "./imageVariants";
+
+// Die Bilder trugen bereits ein sizes-Attribut, aber kein srcset. Ohne srcset
+// ist sizes wirkungslos: der Browser hat nur eine Fassung zur Auswahl - die
+// gespeicherte, bis zu 4096 Pixel breit, fuer eine Kachel die rund 400 zeigt.
+
+describe("Bildvarianten", () => {
+  test("eigene Uploads lassen sich verkleinern", () => {
+    expect(isResizableUpload("/api/static/uploads/foto.webp")).toBe(true);
+    expect(isResizableUpload("/uploads/foto.jpg")).toBe(true);
+    expect(isResizableUpload("https://lionsquad.at/api/static/uploads/foto.png")).toBe(true);
+  });
+
+  test("fremde und eingebettete Bilder bleiben unangetastet", () => {
+    expect(isResizableUpload("https://cdn.fremd.example/foto.jpg")).toBe(false);
+    expect(isResizableUpload("data:image/png;base64,AAAA")).toBe(false);
+    expect(isResizableUpload("blob:http://localhost/abc")).toBe(false);
+    expect(isResizableUpload("")).toBe(false);
+    expect(isResizableUpload(null)).toBe(false);
+  });
+
+  test("Videos und andere Dateien bekommen kein srcset", () => {
+    expect(isResizableUpload("/api/static/uploads/clip.mp4")).toBe(false);
+    expect(isResizableUpload("/api/static/uploads/regeln.pdf")).toBe(false);
+    expect(buildSrcSet("/api/static/uploads/clip.mp4")).toBeUndefined();
+  });
+
+  test("das srcset nennt jede vorgehaltene Breite mit ihrer Groesse", () => {
+    const set = buildSrcSet("/api/static/uploads/foto.webp");
+
+    expect(set).toBe(
+      "/api/static/uploads/foto.webp?w=400 400w, "
+      + "/api/static/uploads/foto.webp?w=800 800w, "
+      + "/api/static/uploads/foto.webp?w=1600 1600w"
+    );
+    VARIANT_WIDTHS.forEach((width) => expect(set).toContain(`w=${width}`));
+  });
+
+  test("eine vorhandene Abfrage wird angehaengt statt ueberschrieben", () => {
+    const set = buildSrcSet("/api/static/uploads/foto.webp?v=3");
+
+    expect(set).toContain("/api/static/uploads/foto.webp?v=3&w=400 400w");
+  });
+
+  test("nur die gewuenschten Breiten werden angeboten", () => {
+    expect(buildSrcSet("/api/static/uploads/foto.webp", [400])).toBe(
+      "/api/static/uploads/foto.webp?w=400 400w"
+    );
+  });
+});

--- a/frontend/src/lib/videoPoster.js
+++ b/frontend/src/lib/videoPoster.js
@@ -1,0 +1,85 @@
+// Ein Standbild aus einem Video - im Browser dessen, der es hochlädt.
+//
+// Auf dem Server ginge das nur mit ffmpeg, also einem zusätzlichen Programm im
+// Container. Der Browser hat das Video beim Hochladen ohnehin schon vorliegen;
+// dort kostet ein Einzelbild nichts weiter.
+//
+// Ohne Standbild zeigte eine Videokachel entweder ein graues Filmsymbol oder
+// begann von selbst zu spielen, nur um überhaupt ein Bild zu haben.
+
+const POSTER_WIDTH = 800;
+const POSTER_QUALITY = 0.72;
+// Die erste Sekunde ist oft schwarz oder ein Einblendeffekt.
+const DEFAULT_SEEK_SECONDS = 1.0;
+// Nach dieser Zeit wird aufgegeben. Ein Browser, der ein Format nicht
+// abspielt, meldet das nicht immer - er schweigt einfach.
+const TIMEOUT_MS = 12000;
+
+function drawToBlob(video, maxWidth) {
+  const ratio = video.videoWidth ? Math.min(1, maxWidth / video.videoWidth) : 1;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, Math.round(video.videoWidth * ratio));
+  canvas.height = Math.max(1, Math.round(video.videoHeight * ratio));
+  const context = canvas.getContext("2d");
+  if (!context) return Promise.resolve(null);
+  context.drawImage(video, 0, 0, canvas.width, canvas.height);
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), "image/webp", POSTER_QUALITY);
+  });
+}
+
+/**
+ * Liefert ein Standbild als Datei, oder null.
+ *
+ * Null ist ein zulässiges Ergebnis und kein Fehler: manche Formate lassen sich
+ * im Browser nicht abspielen, und ein Video ohne Standbild ist immer noch ein
+ * brauchbares Video. Der Upload darf daran nicht scheitern.
+ */
+export async function captureVideoPoster(file, {
+  seek = DEFAULT_SEEK_SECONDS,
+  maxWidth = POSTER_WIDTH,
+  timeoutMs = TIMEOUT_MS,
+} = {}) {
+  if (!file || typeof document === "undefined" || typeof URL?.createObjectURL !== "function") return null;
+
+  const objectUrl = URL.createObjectURL(file);
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.preload = "metadata";
+  video.crossOrigin = "anonymous";
+  video.src = objectUrl;
+
+  try {
+    const blob = await new Promise((resolve) => {
+      const finish = (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const timer = setTimeout(() => finish(null), timeoutMs);
+
+      video.onerror = () => finish(null);
+      video.onloadedmetadata = () => {
+        if (!video.videoWidth || !video.videoHeight) return finish(null);
+        // Bei sehr kurzen Videos lieber die Mitte als eine Stelle dahinter.
+        const target = Number.isFinite(video.duration) && video.duration > 0
+          ? Math.min(seek, video.duration / 2)
+          : seek;
+        video.onseeked = () => drawToBlob(video, maxWidth).then(finish, () => finish(null));
+        try {
+          video.currentTime = target;
+        } catch {
+          finish(null);
+        }
+      };
+    });
+
+    if (!blob) return null;
+    const base = String(file.name || "video").replace(/\.[^/.]+$/, "");
+    return new File([blob], `${base}-vorschau.webp`, { type: "image/webp" });
+  } finally {
+    video.removeAttribute("src");
+    video.load?.();
+    URL.revokeObjectURL(objectUrl);
+  }
+}

--- a/frontend/src/lib/videoPoster.test.js
+++ b/frontend/src/lib/videoPoster.test.js
@@ -1,0 +1,37 @@
+import { captureVideoPoster } from "./videoPoster";
+
+// Ein Standbild aus dem Video zu ziehen, kann fehlschlagen: nicht jedes Format
+// spielt jeder Browser ab. Das darf den Upload nicht mitnehmen - ein Video ohne
+// Vorschaubild ist immer noch ein brauchbares Video. Diese Tests halten fest,
+// dass der Fehlerfall null liefert statt zu werfen.
+//
+// Der Erfolgsfall braucht einen Browser, der ein echtes Video dekodiert; jsdom
+// tut das nicht, und ein Testvideo waere ohne ffmpeg nicht zu erzeugen. Er ist
+// deshalb nicht automatisch abgedeckt - was der Nutzer davon merkt, prueft
+// dagegen e2e/gallery-media.spec.js: eine Kachel mit Standbild zeigt es, und
+// keine Kachel spielt mehr von selbst.
+
+describe("Standbild aus einem Video", () => {
+  test("ohne Datei kommt null", async () => {
+    await expect(captureVideoPoster(null)).resolves.toBeNull();
+    await expect(captureVideoPoster(undefined)).resolves.toBeNull();
+  });
+
+  test("nach der Wartezeit wird aufgegeben statt zu haengen", async () => {
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "kaputt.mp4", { type: "video/mp4" });
+
+    const poster = await captureVideoPoster(file, { seek: 0.1, timeoutMs: 60 });
+
+    expect(poster).toBeNull();
+  });
+
+  test("der Objekt-URL wird wieder freigegeben", async () => {
+    const revoke = vi.spyOn(URL, "revokeObjectURL");
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "kaputt.mp4", { type: "video/mp4" });
+
+    await captureVideoPoster(file, { seek: 0.1, timeoutMs: 60 });
+
+    expect(revoke).toHaveBeenCalled();
+    revoke.mockRestore();
+  });
+});

--- a/frontend/src/pages/admin/AdminGalleryPage.jsx
+++ b/frontend/src/pages/admin/AdminGalleryPage.jsx
@@ -18,6 +18,7 @@ import {
   providerLabel,
 } from "@/lib/galleryMedia";
 import { logUploadClientFailure } from "@/lib/uploadDiagnostics";
+import { captureVideoPoster } from "@/lib/videoPoster";
 import { toast } from "sonner";
 import { Plus, Save, X, Trash2, Image as ImageIcon, ArrowLeft, Upload, Link as LinkIcon, Play, Film, Layers, Pencil } from "lucide-react";
 
@@ -349,10 +350,28 @@ function AlbumPhotos({ album, onBack }) {
         }
         uploadProgress.setPhase("Zum Album hinzufügen");
         if (data.media_type === "video") {
+          // Standbild aus dem Video, solange es noch im Browser liegt. Ohne das
+          // zeigt die Kachel ein graues Filmsymbol - oder muss das Video laden,
+          // nur um ein Bild zu haben. Schlaegt es fehl, laeuft der Upload weiter.
+          uploadProgress.setPhase("Vorschaubild erzeugen");
+          let thumbnailUrl = "";
+          try {
+            const poster = await captureVideoPoster(file);
+            if (poster) {
+              const posterForm = new FormData();
+              posterForm.append("file", poster);
+              const { data: posterData } = await uploadApi.post("/uploads/media?media_scope=gallery", posterForm);
+              thumbnailUrl = posterData?.url || "";
+            }
+          } catch {
+            thumbnailUrl = "";
+          }
+          uploadProgress.setPhase("Zum Album hinzufügen");
           await api.post(`/gallery/${album.id}/photos`, {
             media_type: "video",
             source_type: "upload",
             video_url: data.url,
+            thumbnail_url: thumbnailUrl,
             caption: captionFromFilename(file.name, "Video"),
             order_index: nextOrderIndex(targetSectionId, ok - originals),
             section_id: targetSectionId || null,

--- a/frontend/src/pages/public/GalleryAlbumPage.jsx
+++ b/frontend/src/pages/public/GalleryAlbumPage.jsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { api, resolveMediaUrl } from "@/lib/api";
+import { LazyImg } from "@/components/tls/LazyImg";
 import { PublicLayout } from "@/components/tls/PublicLayout";
 import { Breadcrumbs } from "@/components/tls/Breadcrumbs";
 import { PublicLoadingState } from "@/components/tls/PublicLoadingState";
@@ -212,33 +213,34 @@ export default function GalleryAlbumPage() {
   );
 }
 
+// Was eine Kachel tatsaechlich breit ist. Ohne diese Angabe nimmt der Browser
+// die volle Fensterbreite an und laedt eine groessere Fassung als noetig.
+const GRID_SIZES = "(min-width: 1280px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw";
+
+
 function GalleryTile({ item, onDimensions }) {
   const type = mediaTypeFromItem(item);
   const poster = galleryPosterUrl(item);
   const url = galleryMediaUrl(item);
   if (type === "image") {
     return (
-      <img
-        src={resolveMediaUrl(poster || url)}
+      <LazyImg
+        src={poster || url}
         alt={item.caption || ""}
         className="w-full h-full object-cover group-hover:scale-105 transition duration-300"
-        loading="lazy"
-        decoding="async"
+        sizes={GRID_SIZES}
         onLoad={(event) => onDimensions?.(item, event.currentTarget.naturalWidth, event.currentTarget.naturalHeight)}
       />
     );
   }
   return (
     <>
-      {type === "video" && url && !isExternalGalleryMedia(item) ? (
-        <CenterPreviewVideo src={resolveMediaUrl(url)} poster={poster ? resolveMediaUrl(poster) : ""} onDimensions={(width, height) => onDimensions?.(item, width, height)} />
-      ) : poster ? (
-        <img
-          src={resolveMediaUrl(poster)}
+      {poster ? (
+        <LazyImg
+          src={poster}
           alt={item.caption || ""}
           className="w-full h-full object-cover group-hover:scale-105 transition duration-300"
-          loading="lazy"
-          decoding="async"
+          sizes={GRID_SIZES}
           onLoad={(event) => onDimensions?.(item, event.currentTarget.naturalWidth, event.currentTarget.naturalHeight)}
         />
       ) : (
@@ -252,36 +254,6 @@ function GalleryTile({ item, onDimensions }) {
         <Play className="w-3 h-3 fill-current" /> {item.embed_provider ? providerLabel(item.embed_provider) : "Video"}
       </span>
     </>
-  );
-}
-
-function CenterPreviewVideo({ src, poster, onDimensions }) {
-  const ref = useRef(null);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") return undefined;
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        node.play().catch(() => {});
-      } else {
-        node.pause();
-      }
-    }, { rootMargin: "-35% 0px -35% 0px", threshold: 0.15 });
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, []);
-  return (
-    <video
-      ref={ref}
-      src={src}
-      poster={poster || undefined}
-      muted
-      loop
-      playsInline
-      preload="metadata"
-      className="w-full h-full object-cover group-hover:scale-105 transition duration-300"
-      onLoadedMetadata={(event) => onDimensions?.(event.currentTarget.videoWidth, event.currentTarget.videoHeight)}
-    />
   );
 }
 
@@ -308,11 +280,11 @@ function LightboxImage({ item }) {
   const originalUrl = item.original_url ? resolveMediaUrl(item.original_url) : "";
   return (
     <div className="flex max-h-[85vh] flex-col items-center gap-3">
-      <img
-        src={resolveMediaUrl(item.image_url)}
+      <LazyImg
+        src={item.image_url}
         alt={item.caption || ""}
-        loading="lazy"
-        decoding="async"
+        priority
+        sizes="90vw"
         className="max-w-[90vw] max-h-[78vh] object-contain"
       />
       {originalUrl && (

--- a/scripts/media-report.py
+++ b/scripts/media-report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Was die Bilder dieser Installation wiegen, und was Vorschaubilder sparen.
+
+Liest nur. Schreibt nichts, loescht nichts, veraendert nichts.
+
+Die Zahlen zu Bildgroessen haengen stark vom Inhalt ab - ein Gruppenfoto
+komprimiert anders als ein Bildschirmfoto. Deshalb misst dieses Skript die
+echten Dateien dieser Installation, statt mit erfundenen Beispielen zu rechnen.
+
+    python3 scripts/media-report.py
+    python3 scripts/media-report.py --dir /pfad/zu/uploads --limit 200
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - nur ausserhalb des Containers
+    print("Pillow fehlt. Im Backend-Container ausfuehren:")
+    print("  docker compose exec backend python3 scripts/media-report.py")
+    raise SystemExit(1)
+
+VARIANT_WIDTHS = (400, 800, 1600)
+QUALITY = {400: 78, 800: 80, 1600: 82}
+IMAGE_SUFFIXES = {".webp", ".jpg", ".jpeg", ".png"}
+
+
+def human(num_bytes: float) -> str:
+    for unit in ("B", "kB", "MB", "GB"):
+        if abs(num_bytes) < 1024 or unit == "GB":
+            return f"{num_bytes:,.1f} {unit}".replace(",", ".")
+        num_bytes /= 1024
+    return f"{num_bytes:.1f} GB"
+
+
+def encoded_size(image: Image.Image, width: int) -> int:
+    copy = image.convert("RGB").copy()
+    copy.thumbnail((width, width * 4), Image.Resampling.LANCZOS)
+    buffer = io.BytesIO()
+    copy.save(buffer, format="WEBP", quality=QUALITY[width], method=6)
+    return buffer.tell()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dir", default=os.environ.get("UPLOAD_DIR", "/app/backend/uploads"),
+                        help="Uploadordner (Vorgabe: UPLOAD_DIR)")
+    parser.add_argument("--limit", type=int, default=120, help="Wie viele Bilder gemessen werden")
+    args = parser.parse_args()
+
+    base = Path(args.dir)
+    if not base.is_dir():
+        print(f"Ordner nicht gefunden: {base}")
+        print("Im Container liegt er unter /app/backend/uploads.")
+        return 1
+
+    files = [p for p in sorted(base.rglob("*"))
+             if p.is_file() and p.suffix.lower() in IMAGE_SUFFIXES and "variants" not in p.parts]
+    if not files:
+        print(f"Keine Bilder in {base}.")
+        return 0
+
+    gemessen = files[:args.limit]
+    gesamt_original = 0
+    gesamt = {width: 0 for width in VARIANT_WIDTHS}
+    breiten: list[int] = []
+    fehler = 0
+
+    for path in gemessen:
+        try:
+            with Image.open(path) as image:
+                breiten.append(image.width)
+                gesamt_original += path.stat().st_size
+                for width in VARIANT_WIDTHS:
+                    gesamt[width] += encoded_size(image, width) if image.width > width else path.stat().st_size
+        except Exception:
+            fehler += 1
+
+    zahl = len(gemessen) - fehler
+    if zahl <= 0:
+        print("Kein Bild liess sich lesen.")
+        return 1
+
+    print(f"Ordner:            {base}")
+    print(f"Bilder gefunden:   {len(files)}   davon gemessen: {zahl}"
+          + (f"   nicht lesbar: {fehler}" if fehler else ""))
+    print(f"Breite im Mittel:  {sum(breiten)//len(breiten)} px"
+          f"   groesstes: {max(breiten)} px")
+    print()
+    print(f"{'Fassung':>16} {'gesamt':>12} {'je Bild':>10} {'Ersparnis':>11}")
+    print(f"{'wie heute':>16} {human(gesamt_original):>12} {human(gesamt_original/zahl):>10} {'-':>11}")
+    for width in VARIANT_WIDTHS:
+        anteil = 1 - gesamt[width] / gesamt_original if gesamt_original else 0
+        print(f"{f'Breite {width}':>16} {human(gesamt[width]):>12}"
+              f" {human(gesamt[width]/zahl):>10} {anteil*100:>10.0f}%")
+    print()
+    kacheln = 24
+    print(f"Ein Galerieraster mit {kacheln} Kacheln laedt heute"
+          f" {human(gesamt_original/zahl*kacheln)},")
+    print(f"mit Vorschaubildern in Breite 400 noch {human(gesamt[400]/zahl*kacheln)}.")
+    print()
+    print("Die Vorschaubilder entstehen beim ersten Abruf von selbst;")
+    print("es ist nichts zu migrieren und nichts einzustellen.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Block 12 vollständig: Bilder **und** Videos, in einem PR.

---

# Teil 1 — Bilder

## Das Problem in einer Zahl

Eine Rasterkachel ist rund **400 Pixel** breit. Sie bekam bisher das gespeicherte Bild mit bis zu **4096 Pixeln** — etwa **hundertmal so viele Bildpunkte**, wie sie zeigt.

Die Bytes fallen auf einer Handyverbindung ins Gewicht. Das **Dekodieren** fällt mehr ins Gewicht: elf Megapixel je Kachel, und daran ändert keine Kompression etwas.

Dabei fiel auf: die Bilder trugen bereits ein `sizes`-Attribut — aber **kein `srcset`**. Ohne `srcset` ist `sizes` wirkungslos. Die Vorlage war vorbereitet, es fehlten die Varianten.

## Was jetzt passiert

Drei Breiten — **400, 800, 1600** —, die **beim ersten Abruf entstehen** und danach auf der Platte liegen.

**Es ist nichts zu migrieren.** Die Varianten wirken sofort auch für alles, was ihr längst hochgeladen habt.

Bewusst begrenzt: nur diese drei Breiten. Ein offener Skalierer wäre ein Weg, eure Platte vollzuschreiben. Eine unbekannte Breite liefert das Original zurück, statt still eine Datei anzulegen. Ein Bild, das ohnehin schmaler ist, bleibt wie es ist.

---

# Teil 2 — Videos

## Jede Kachel spielte von selbst

Im Album rief ein `IntersectionObserver` **`play()` auf jedem sichtbaren Video**. Bei acht Videos lädt und dekodiert ein Telefon mehrere Ströme gleichzeitig — das ist vermutlich der eigentliche Grund, warum die Galerie dort hängt.

Im Raster steht jetzt ein Standbild. Abgespielt wird erst, wenn man es öffnet.

## Nur hatten Videos gar kein Standbild

`thumbnail_url` wurde beim Upload **ausdrücklich leer gesetzt**, und **ffmpeg gibt es im Container nicht**. Also zeigte die Kachel entweder ein graues Filmsymbol — oder musste das Video laden, nur um überhaupt ein Bild zu haben.

ffmpeg nachzuinstallieren wäre ein zusätzliches Programm im Container. Stattdessen: **der Browser des Hochladenden hat das Video ohnehin schon vorliegen.** Dort entsteht das Standbild — eine Sekunde hinein, auf 800 px, als WebP. Keine neue Serverabhängigkeit.

Schlägt es fehl, läuft der Upload weiter: nicht jeder Browser spielt jedes Format ab, und ein Video ohne Standbild ist immer noch ein brauchbares Video. Die Wartezeit ist begrenzt, weil ein Browser ein Format auch kommentarlos nicht abspielt.

## Eine Lücke aus Teil 1, die mein eigener Test gefunden hat

Der neue Playwright-Test „Bilder im Raster fordern eine passende Größe an" ist **gefallen**. Grund: das Album-Raster benutzte rohe `<img>`-Elemente statt `LazyImg` — die Bildvarianten aus Teil 1 wirkten dort also **gar nicht**, ausgerechnet auf der Seite mit den meisten Bildern.

Jetzt läuft es über `LazyImg`, mit den echten Kachelbreiten als `sizes`, damit der Browser nicht die volle Fensterbreite annimmt.

---

## Die Zahlen kann ich nicht liefern — ihr könnt sie messen

Ich wollte eine Ersparnis in Megabyte nennen und habe es gelassen: Hier liegen nur Testartefakte (1×1 Pixel), eure Fotos sind auf dem Server. Und meine erfundenen Testbilder waren wertlos — reines Rauschen ergab 6209 kB je Bild, weichgezeichnete Formen 99 kB. Zwei Größenordnungen auseinander ist keine Aussage.

Deshalb liegt **`scripts/media-report.py`** dabei:

```
docker compose exec backend python3 scripts/media-report.py
```

Nur lesend. Es sagt, was eure Bilder heute wiegen, was jede Fassung wiegt, und was ein Raster mit 24 Kacheln kostet. Damit sehen wir auch, ob 400/800/1600 für eure Fotos die richtigen Breiten sind.

## Nachweise

- **28 Backend-Tests** für die Varianten, davon **zwei durch die echte Route** — mit `w=400` kommt eine Fassung, die weniger als die Hälfte wiegt und wirklich 400 px breit ist; eine krumme Breite legt keine Datei an
- Geprüft wird auch das Unangenehme: kaputte Datei, fehlende Datei, Video, Bild kleiner als die Anfrage
- **5 Playwright-Tests** × 2 Projekte fürs Album: kein spielendes Video nach dem Scrollen, Standbild sichtbar, kein Video geladen wenn keins da ist, `srcset` im Raster, kein Querlauf bei 390 px
- **3 Unit-Tests** für das Standbild: null statt Ausnahme, begrenzte Wartezeit, Objekt-URL wird freigegeben
- Backend **845**, Frontend **140 Vitest**, Playwright **138 bestanden**, 0 Fehlschläge; ESLint ohne Fehler; Build sauber

## Was in Block 12 offen bleibt

Die **App** nimmt einen eigenen Weg zu den Medien — ob sie dieselben Varianten und Standbilder nutzt, habe ich noch nicht geprüft. Das gehört zu Block 14 und steht so im Plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)